### PR TITLE
Add agent orchestration: conversation loop with tool execution

### DIFF
--- a/crates/opencrust-agents/src/lib.rs
+++ b/crates/opencrust-agents/src/lib.rs
@@ -4,5 +4,9 @@ pub mod runtime;
 pub mod tools;
 
 pub use embeddings::{CohereEmbeddingProvider, EmbeddingProvider};
-pub use providers::{LlmProvider, LlmRequest, LlmResponse};
+pub use providers::{
+    ChatMessage, ChatRole, ContentBlock, LlmProvider, LlmRequest, LlmResponse, MessagePart,
+    ToolDefinition,
+};
 pub use runtime::AgentRuntime;
+pub use tools::{Tool, ToolOutput};

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -1,12 +1,18 @@
 use std::sync::Arc;
 
 use futures::future::join_all;
-use opencrust_common::Result;
+use opencrust_common::{Error, Result};
 use opencrust_db::{MemoryEntry, MemoryProvider, MemoryRole, NewMemoryEntry, RecallQuery};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::embeddings::EmbeddingProvider;
-use crate::providers::LlmProvider;
+use crate::providers::{
+    ChatMessage, ChatRole, ContentBlock, LlmProvider, LlmRequest, MessagePart, ToolDefinition,
+};
+use crate::tools::{Tool, ToolOutput};
+
+/// Maximum number of tool-use round-trips before the loop is forcibly stopped.
+const MAX_TOOL_ITERATIONS: usize = 10;
 
 /// Manages agent sessions, tool execution, and LLM provider routing.
 pub struct AgentRuntime {
@@ -14,6 +20,7 @@ pub struct AgentRuntime {
     default_provider: Option<String>,
     memory: Option<Arc<dyn MemoryProvider>>,
     embeddings: Option<Arc<dyn EmbeddingProvider>>,
+    tools: Vec<Box<dyn Tool>>,
 }
 
 impl AgentRuntime {
@@ -23,6 +30,7 @@ impl AgentRuntime {
             default_provider: None,
             memory: None,
             embeddings: None,
+            tools: Vec::new(),
         }
     }
 
@@ -159,6 +167,135 @@ impl AgentRuntime {
             .await
     }
 
+    pub fn register_tool(&mut self, tool: Box<dyn Tool>) {
+        info!("registered tool: {}", tool.name());
+        self.tools.push(tool);
+    }
+
+    fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        self.tools
+            .iter()
+            .map(|t| ToolDefinition {
+                name: t.name().to_string(),
+                description: t.description().to_string(),
+                input_schema: t.input_schema(),
+            })
+            .collect()
+    }
+
+    fn find_tool(&self, name: &str) -> Option<&dyn Tool> {
+        self.tools
+            .iter()
+            .find(|t| t.name() == name)
+            .map(|t| t.as_ref())
+    }
+
+    /// Run the full conversation loop: recall context, call LLM, execute tools, return response.
+    pub async fn process_message(
+        &self,
+        session_id: &str,
+        user_text: &str,
+        conversation_history: &[ChatMessage],
+    ) -> Result<String> {
+        let provider = self
+            .default_provider()
+            .ok_or_else(|| Error::Agent("no LLM provider configured".into()))?;
+
+        // Recall relevant memory if available
+        let system = match self
+            .recall_context(user_text, Some(session_id), None, 5)
+            .await
+        {
+            Ok(entries) if !entries.is_empty() => {
+                let context: Vec<String> = entries.iter().map(|e| e.content.clone()).collect();
+                Some(format!(
+                    "Relevant context from memory:\n- {}",
+                    context.join("\n- ")
+                ))
+            }
+            Err(e) => {
+                warn!("memory recall failed, continuing without context: {}", e);
+                None
+            }
+            _ => None,
+        };
+
+        let tool_defs = self.tool_definitions();
+
+        let mut messages: Vec<ChatMessage> = conversation_history.to_vec();
+        messages.push(ChatMessage {
+            role: ChatRole::User,
+            content: MessagePart::Text(user_text.to_string()),
+        });
+
+        for _iteration in 0..MAX_TOOL_ITERATIONS {
+            let request = LlmRequest {
+                model: String::new(),
+                messages: messages.clone(),
+                system: system.clone(),
+                max_tokens: Some(4096),
+                temperature: None,
+                tools: tool_defs.clone(),
+            };
+
+            let response = provider.complete(&request).await?;
+
+            let has_tool_use = response
+                .content
+                .iter()
+                .any(|block| matches!(block, ContentBlock::ToolUse { .. }));
+
+            if !has_tool_use {
+                let final_text = extract_text(&response.content);
+
+                // Store turn in memory (best-effort)
+                if let Err(e) = self
+                    .remember_turn(session_id, None, None, user_text, &final_text)
+                    .await
+                {
+                    warn!("failed to store turn in memory: {}", e);
+                }
+
+                return Ok(final_text);
+            }
+
+            // Append the assistant's response (including tool_use blocks) to history
+            messages.push(ChatMessage {
+                role: ChatRole::Assistant,
+                content: MessagePart::Parts(response.content.clone()),
+            });
+
+            // Execute each tool and collect results
+            let mut tool_results = Vec::new();
+            for block in &response.content {
+                if let ContentBlock::ToolUse { id, name, input } = block {
+                    let output = match self.find_tool(name) {
+                        Some(tool) => tool
+                            .execute(input.clone())
+                            .await
+                            .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
+                        None => ToolOutput::error(format!("unknown tool: {}", name)),
+                    };
+                    tool_results.push(ContentBlock::ToolResult {
+                        tool_use_id: id.clone(),
+                        content: output.content,
+                    });
+                }
+            }
+
+            // Append tool results as a user message
+            messages.push(ChatMessage {
+                role: ChatRole::User,
+                content: MessagePart::Parts(tool_results),
+            });
+        }
+
+        Err(Error::Agent(format!(
+            "tool loop exceeded maximum of {} iterations",
+            MAX_TOOL_ITERATIONS
+        )))
+    }
+
     pub async fn health_check_all(&self) -> Result<Vec<(String, bool)>> {
         let checks = self.providers.iter().map(|provider| async {
             let provider_id = provider.provider_id().to_string();
@@ -222,4 +359,15 @@ impl Default for AgentRuntime {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn extract_text(content: &[ContentBlock]) -> String {
+    content
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/crates/opencrust-gateway/src/state.rs
+++ b/crates/opencrust-gateway/src/state.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use opencrust_agents::AgentRuntime;
+use opencrust_agents::{AgentRuntime, ChatMessage};
 use opencrust_channels::ChannelRegistry;
 use opencrust_config::AppConfig;
 use uuid::Uuid;
@@ -19,6 +19,7 @@ pub struct SessionState {
     pub id: String,
     pub user_id: Option<String>,
     pub channel_id: Option<String>,
+    pub history: Vec<ChatMessage>,
 }
 
 impl AppState {
@@ -39,6 +40,7 @@ impl AppState {
                 id: id.clone(),
                 user_id: None,
                 channel_id: None,
+                history: Vec::new(),
             },
         );
         id


### PR DESCRIPTION
## Summary
- Replace WebSocket echo logic with full agent routing through LLM providers
- Add `process_message()` to `AgentRuntime` with agentic tool loop (max 10 iterations)
- Integrate memory recall as optional system context for conversations
- Track per-session conversation history in `SessionState` for multi-turn support
- Graceful JSON error when no LLM provider is configured (nothing crashes)

## Files changed
- `crates/opencrust-agents/src/runtime.rs` - Tool registry, conversation loop, text extraction
- `crates/opencrust-agents/src/lib.rs` - Expanded re-exports for gateway use
- `crates/opencrust-gateway/src/state.rs` - Added conversation history to sessions
- `crates/opencrust-gateway/src/ws.rs` - Agent routing replaces echo, JSON message parsing

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (34 tests)
- [x] `cargo clippy --workspace` clean with `-Dwarnings`
- [x] `cargo fmt --all` clean
- [ ] Manual: connect via WebSocket, confirm JSON error response (no provider configured yet)
- [ ] Integration: verify end-to-end once an LLM provider is implemented (#1 or #2)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)