### PR TITLE
Add session persistence with SQLite-backed storage

### DIFF
--- a/crates/opencrust-db/src/lib.rs
+++ b/crates/opencrust-db/src/lib.rs
@@ -7,5 +7,5 @@ pub use memory_store::{
     CompactionReport, MemoryEntry, MemoryProvider, MemoryRole, MemoryStore, NewMemoryEntry,
     RecallQuery, SessionContext,
 };
-pub use session_store::SessionStore;
+pub use session_store::{MessageRecord, SessionRecord, SessionStore};
 pub use vector_store::VectorStore;

--- a/crates/opencrust-db/src/session_store.rs
+++ b/crates/opencrust-db/src/session_store.rs
@@ -1,11 +1,36 @@
-use opencrust_common::{Error, Result};
-use rusqlite::Connection;
 use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
+
+use chrono::{DateTime, Utc};
+use opencrust_common::{Error, Result};
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
 use tracing::info;
+use uuid::Uuid;
 
 /// Persistent storage for conversation sessions and message history.
 pub struct SessionStore {
-    conn: Connection,
+    conn: Mutex<Connection>,
+}
+
+/// A persisted session record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionRecord {
+    pub id: String,
+    pub channel_id: Option<String>,
+    pub user_id: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A persisted message within a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageRecord {
+    pub id: String,
+    pub session_id: String,
+    pub role: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
 }
 
 impl SessionStore {
@@ -17,7 +42,9 @@ impl SessionStore {
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
             .map_err(|e| Error::Database(format!("failed to set pragmas: {e}")))?;
 
-        let store = Self { conn };
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
         store.run_migrations()?;
         Ok(store)
     }
@@ -26,42 +53,270 @@ impl SessionStore {
         let conn = Connection::open_in_memory()
             .map_err(|e| Error::Database(format!("failed to open in-memory database: {e}")))?;
 
-        let store = Self { conn };
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .map_err(|e| Error::Database(format!("failed to set pragmas: {e}")))?;
+
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
         store.run_migrations()?;
         Ok(store)
     }
 
-    fn run_migrations(&self) -> Result<()> {
+    fn connection(&self) -> Result<MutexGuard<'_, Connection>> {
         self.conn
-            .execute_batch(
-                "CREATE TABLE IF NOT EXISTS sessions (
-                    id TEXT PRIMARY KEY,
-                    channel_id TEXT NOT NULL,
-                    user_id TEXT NOT NULL,
-                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-                    metadata TEXT DEFAULT '{}'
-                );
+            .lock()
+            .map_err(|_| Error::Database("session store lock poisoned".into()))
+    }
 
-                CREATE TABLE IF NOT EXISTS messages (
-                    id TEXT PRIMARY KEY,
-                    session_id TEXT NOT NULL REFERENCES sessions(id),
-                    direction TEXT NOT NULL,
-                    content TEXT NOT NULL,
-                    timestamp TEXT NOT NULL,
-                    metadata TEXT DEFAULT '{}',
-                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
-                );
+    fn run_migrations(&self) -> Result<()> {
+        let conn = self.connection()?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                channel_id TEXT,
+                user_id TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
 
-                CREATE INDEX IF NOT EXISTS idx_messages_session
-                    ON messages(session_id, timestamp);",
-            )
-            .map_err(|e| Error::Database(format!("migration failed: {e}")))?;
+            CREATE TABLE IF NOT EXISTS messages (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_messages_session
+                ON messages(session_id, created_at);",
+        )
+        .map_err(|e| Error::Database(format!("migration failed: {e}")))?;
 
         Ok(())
     }
 
-    pub fn connection(&self) -> &Connection {
-        &self.conn
+    pub fn create_session(
+        &self,
+        id: &str,
+        user_id: Option<&str>,
+        channel_id: Option<&str>,
+    ) -> Result<()> {
+        let conn = self.connection()?;
+        conn.execute(
+            "INSERT INTO sessions (id, channel_id, user_id) VALUES (?1, ?2, ?3)",
+            params![id, channel_id, user_id],
+        )
+        .map_err(|e| Error::Database(format!("failed to create session: {e}")))?;
+        Ok(())
+    }
+
+    pub fn get_session(&self, id: &str) -> Result<Option<SessionRecord>> {
+        let conn = self.connection()?;
+        let mut stmt = conn
+            .prepare("SELECT id, channel_id, user_id, created_at, updated_at FROM sessions WHERE id = ?1")
+            .map_err(|e| Error::Database(format!("failed to prepare query: {e}")))?;
+
+        let result = stmt
+            .query_row(params![id], |row| {
+                Ok(SessionRecord {
+                    id: row.get(0)?,
+                    channel_id: row.get(1)?,
+                    user_id: row.get(2)?,
+                    created_at: parse_datetime(row.get::<_, String>(3)?),
+                    updated_at: parse_datetime(row.get::<_, String>(4)?),
+                })
+            })
+            .ok();
+
+        Ok(result)
+    }
+
+    pub fn delete_session(&self, id: &str) -> Result<()> {
+        let conn = self.connection()?;
+        conn.execute("DELETE FROM sessions WHERE id = ?1", params![id])
+            .map_err(|e| Error::Database(format!("failed to delete session: {e}")))?;
+        Ok(())
+    }
+
+    pub fn touch_session(&self, id: &str) -> Result<()> {
+        let conn = self.connection()?;
+        conn.execute(
+            "UPDATE sessions SET updated_at = datetime('now') WHERE id = ?1",
+            params![id],
+        )
+        .map_err(|e| Error::Database(format!("failed to update session timestamp: {e}")))?;
+        Ok(())
+    }
+
+    pub fn append_message(&self, session_id: &str, role: &str, content: &str) -> Result<String> {
+        let id = Uuid::new_v4().to_string();
+        let conn = self.connection()?;
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content) VALUES (?1, ?2, ?3, ?4)",
+            params![id, session_id, role, content],
+        )
+        .map_err(|e| Error::Database(format!("failed to append message: {e}")))?;
+
+        // Also bump the session's updated_at
+        conn.execute(
+            "UPDATE sessions SET updated_at = datetime('now') WHERE id = ?1",
+            params![session_id],
+        )
+        .map_err(|e| Error::Database(format!("failed to touch session: {e}")))?;
+
+        Ok(id)
+    }
+
+    pub fn get_messages(&self, session_id: &str, limit: usize) -> Result<Vec<MessageRecord>> {
+        let conn = self.connection()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, session_id, role, content, created_at
+                 FROM messages
+                 WHERE session_id = ?1
+                 ORDER BY created_at ASC
+                 LIMIT ?2",
+            )
+            .map_err(|e| Error::Database(format!("failed to prepare query: {e}")))?;
+
+        let rows = stmt
+            .query_map(params![session_id, limit as i64], |row| {
+                Ok(MessageRecord {
+                    id: row.get(0)?,
+                    session_id: row.get(1)?,
+                    role: row.get(2)?,
+                    content: row.get(3)?,
+                    created_at: parse_datetime(row.get::<_, String>(4)?),
+                })
+            })
+            .map_err(|e| Error::Database(format!("failed to query messages: {e}")))?;
+
+        let mut messages = Vec::new();
+        for row in rows {
+            messages.push(
+                row.map_err(|e| Error::Database(format!("failed to read message row: {e}")))?,
+            );
+        }
+        Ok(messages)
+    }
+
+    pub fn session_count(&self) -> Result<usize> {
+        let conn = self.connection()?;
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+            .map_err(|e| Error::Database(format!("failed to count sessions: {e}")))?;
+        Ok(count as usize)
+    }
+}
+
+fn parse_datetime(s: String) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(&s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(|_| {
+            // SQLite datetime('now') produces "YYYY-MM-DD HH:MM:SS"
+            chrono::NaiveDateTime::parse_from_str(&s, "%Y-%m-%d %H:%M:%S")
+                .map(|naive| naive.and_utc())
+                .unwrap_or_else(|_| Utc::now())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_and_get_session_round_trip() {
+        let store = SessionStore::in_memory().unwrap();
+        store
+            .create_session("sess-1", Some("user-1"), Some("web"))
+            .unwrap();
+
+        let session = store.get_session("sess-1").unwrap().unwrap();
+        assert_eq!(session.id, "sess-1");
+        assert_eq!(session.user_id.as_deref(), Some("user-1"));
+        assert_eq!(session.channel_id.as_deref(), Some("web"));
+    }
+
+    #[test]
+    fn create_session_with_no_user_or_channel() {
+        let store = SessionStore::in_memory().unwrap();
+        store.create_session("sess-2", None, None).unwrap();
+
+        let session = store.get_session("sess-2").unwrap().unwrap();
+        assert_eq!(session.id, "sess-2");
+        assert!(session.user_id.is_none());
+        assert!(session.channel_id.is_none());
+    }
+
+    #[test]
+    fn get_missing_session_returns_none() {
+        let store = SessionStore::in_memory().unwrap();
+        assert!(store.get_session("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn append_and_retrieve_messages() {
+        let store = SessionStore::in_memory().unwrap();
+        store.create_session("sess-3", None, None).unwrap();
+
+        store.append_message("sess-3", "user", "Hello").unwrap();
+        store
+            .append_message("sess-3", "assistant", "Hi there!")
+            .unwrap();
+        store
+            .append_message("sess-3", "user", "How are you?")
+            .unwrap();
+
+        let messages = store.get_messages("sess-3", 100).unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].content, "Hello");
+        assert_eq!(messages[1].role, "assistant");
+        assert_eq!(messages[1].content, "Hi there!");
+        assert_eq!(messages[2].role, "user");
+        assert_eq!(messages[2].content, "How are you?");
+    }
+
+    #[test]
+    fn get_messages_respects_limit() {
+        let store = SessionStore::in_memory().unwrap();
+        store.create_session("sess-4", None, None).unwrap();
+
+        for i in 0..10 {
+            store
+                .append_message("sess-4", "user", &format!("msg {i}"))
+                .unwrap();
+        }
+
+        let messages = store.get_messages("sess-4", 3).unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].content, "msg 0");
+    }
+
+    #[test]
+    fn delete_session_cascades_to_messages() {
+        let store = SessionStore::in_memory().unwrap();
+        store.create_session("sess-5", None, None).unwrap();
+        store.append_message("sess-5", "user", "Hello").unwrap();
+
+        store.delete_session("sess-5").unwrap();
+
+        assert!(store.get_session("sess-5").unwrap().is_none());
+        let messages = store.get_messages("sess-5", 100).unwrap();
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn session_count_tracks_correctly() {
+        let store = SessionStore::in_memory().unwrap();
+        assert_eq!(store.session_count().unwrap(), 0);
+
+        store.create_session("a", None, None).unwrap();
+        store.create_session("b", None, None).unwrap();
+        assert_eq!(store.session_count().unwrap(), 2);
+
+        store.delete_session("a").unwrap();
+        assert_eq!(store.session_count().unwrap(), 1);
     }
 }

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 
 use opencrust_common::Result;
 use opencrust_config::AppConfig;
+use opencrust_db::SessionStore;
 use tokio::net::TcpListener;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::router::build_router;
 use crate::state::AppState;
@@ -21,7 +22,10 @@ impl GatewayServer {
     pub async fn run(self) -> Result<()> {
         let addr = format!("{}:{}", self.config.gateway.host, self.config.gateway.port);
 
-        let state = Arc::new(AppState::new(self.config));
+        // Initialize session persistence
+        let session_store = self.init_session_store();
+
+        let state = Arc::new(AppState::new(self.config, session_store));
         let app = build_router(state);
 
         let listener = TcpListener::bind(&addr).await?;
@@ -32,5 +36,38 @@ impl GatewayServer {
             .map_err(|e| opencrust_common::Error::Gateway(format!("server error: {e}")))?;
 
         Ok(())
+    }
+
+    fn init_session_store(&self) -> Option<Arc<SessionStore>> {
+        let data_dir = self.config.data_dir.clone().unwrap_or_else(|| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            std::path::PathBuf::from(home)
+                .join(".opencrust")
+                .join("data")
+        });
+
+        if let Err(e) = std::fs::create_dir_all(&data_dir) {
+            warn!(
+                "failed to create data directory {}: {}",
+                data_dir.display(),
+                e
+            );
+            return None;
+        }
+
+        let db_path = data_dir.join("sessions.db");
+        match SessionStore::open(&db_path) {
+            Ok(store) => {
+                info!("session store opened at {}", db_path.display());
+                Some(Arc::new(store))
+            }
+            Err(e) => {
+                warn!(
+                    "failed to open session store, running without persistence: {}",
+                    e
+                );
+                None
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Expand `SessionStore` with full CRUD: create, get, delete, append message, get messages, session count
- Use `Mutex<Connection>` pattern (same as `MemoryStore`) for thread-safe SQLite access
- Schema: nullable `channel_id`/`user_id`, role-based messages, cascade deletes
- Initialize `SessionStore` at gateway startup, persisting to `~/.opencrust/data/sessions.db`
- Integrate into `AppState` and WebSocket handler for automatic message persistence
- All persistence is best-effort (log on failure, never break the request)

## Files changed
- `crates/opencrust-db/src/session_store.rs` - Full rewrite: Mutex wrapper, CRUD methods, 7 tests
- `crates/opencrust-db/src/lib.rs` - Export `SessionRecord`, `MessageRecord`
- `crates/opencrust-gateway/src/state.rs` - Add `session_store` to `AppState`, persist on create
- `crates/opencrust-gateway/src/server.rs` - Init SessionStore at startup with data dir resolution
- `crates/opencrust-gateway/src/ws.rs` - Persist user + assistant messages after each turn

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (40 tests, 7 new)
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --all` clean
- [ ] Manual: start gateway, verify `~/.opencrust/data/sessions.db` is created with tables

Depends on #40
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)