### PR TITLE
feat(plugins): complete WASM sandbox limits and hot-reload registry

### DIFF
--- a/crates/opencrust-plugins/src/lib.rs
+++ b/crates/opencrust-plugins/src/lib.rs
@@ -3,7 +3,7 @@ pub mod manifest;
 pub mod runtime;
 pub mod traits;
 
-pub use loader::PluginLoader;
+pub use loader::{PluginLoader, PluginRegistry};
 pub use manifest::PluginManifest;
 pub use runtime::WasmRuntime;
 pub use traits::{Capability, Plugin, PluginInput, PluginOutput};

--- a/crates/opencrust-plugins/src/manifest.rs
+++ b/crates/opencrust-plugins/src/manifest.rs
@@ -23,10 +23,19 @@ pub struct PluginMetadata {
 /// Capability-based permissions.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Permissions {
+    /// Allowlisted network domains.
     #[serde(default)]
     pub network: Vec<String>,
+    /// Enable filesystem access at all.
     #[serde(default)]
-    pub filesystem: bool, // For now, just a boolean based on example.
+    pub filesystem: bool,
+    /// Read-only preopened host directories exposed to the plugin.
+    #[serde(default)]
+    pub filesystem_read_paths: Vec<String>,
+    /// Read-write preopened host directories exposed to the plugin.
+    #[serde(default)]
+    pub filesystem_write_paths: Vec<String>,
+    /// Environment variables that can be passed through from PluginInput.
     #[serde(default)]
     pub env_vars: Vec<String>,
 }
@@ -34,10 +43,15 @@ pub struct Permissions {
 /// Resource limits.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Limits {
+    /// Maximum execution time in seconds.
     #[serde(default = "default_timeout")]
     pub timeout_secs: u64,
+    /// Maximum linear memory usage in MiB.
     #[serde(default = "default_memory")]
     pub max_memory_mb: u64,
+    /// Maximum bytes captured per output stream (stdout/stderr).
+    #[serde(default = "default_output_bytes")]
+    pub max_output_bytes: usize,
 }
 
 impl Default for Limits {
@@ -45,6 +59,7 @@ impl Default for Limits {
         Self {
             timeout_secs: default_timeout(),
             max_memory_mb: default_memory(),
+            max_output_bytes: default_output_bytes(),
         }
     }
 }
@@ -55,6 +70,10 @@ fn default_timeout() -> u64 {
 
 fn default_memory() -> u64 {
     64
+}
+
+fn default_output_bytes() -> usize {
+    1024 * 1024
 }
 
 impl PluginManifest {
@@ -80,18 +99,31 @@ description = "A test plugin"
 
 [permissions]
 filesystem = true
+filesystem_read_paths = ["./fixtures/read"]
+filesystem_write_paths = ["./fixtures/write"]
 network = ["example.com"]
 env_vars = ["TEST_VAR"]
 
 [limits]
 timeout_secs = 10
 max_memory_mb = 128
+max_output_bytes = 2048
 "#;
         let manifest: PluginManifest = toml::from_str(toml).unwrap();
         assert_eq!(manifest.plugin.name, "test-plugin");
         assert!(manifest.permissions.filesystem);
+        assert_eq!(
+            manifest.permissions.filesystem_read_paths,
+            vec!["./fixtures/read"]
+        );
+        assert_eq!(
+            manifest.permissions.filesystem_write_paths,
+            vec!["./fixtures/write"]
+        );
         assert_eq!(manifest.permissions.network, vec!["example.com"]);
         assert_eq!(manifest.limits.timeout_secs, 10);
+        assert_eq!(manifest.limits.max_memory_mb, 128);
+        assert_eq!(manifest.limits.max_output_bytes, 2048);
     }
 
     #[test]
@@ -105,6 +137,10 @@ description = "minimal"
         let manifest: PluginManifest = toml::from_str(toml).unwrap();
         assert!(!manifest.permissions.filesystem);
         assert!(manifest.permissions.network.is_empty());
-        assert_eq!(manifest.limits.timeout_secs, 30); // Default
+        assert!(manifest.permissions.filesystem_read_paths.is_empty());
+        assert!(manifest.permissions.filesystem_write_paths.is_empty());
+        assert_eq!(manifest.limits.timeout_secs, 30);
+        assert_eq!(manifest.limits.max_memory_mb, 64);
+        assert_eq!(manifest.limits.max_output_bytes, 1024 * 1024);
     }
 }

--- a/crates/opencrust-plugins/src/runtime.rs
+++ b/crates/opencrust-plugins/src/runtime.rs
@@ -2,20 +2,25 @@ use crate::manifest::PluginManifest;
 use crate::traits::{Capability, Plugin, PluginInput, PluginOutput};
 use async_trait::async_trait;
 use opencrust_common::{Error, Result};
-use std::path::PathBuf;
-use wasmtime::{Config, Engine, Linker, Module, Store};
-use wasmtime_wasi::WasiCtxBuilder;
+use std::collections::{BTreeMap, HashSet};
+use std::net::{IpAddr, ToSocketAddrs};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use wasmtime::{Config, Engine, Linker, Module, Store, StoreLimits, StoreLimitsBuilder};
 use wasmtime_wasi::preview1::{self, WasiP1Ctx};
+use wasmtime_wasi::{DirPerms, FilePerms, SocketAddrUse, WasiCtxBuilder};
 
 pub struct WasmRuntime {
     manifest: PluginManifest,
     engine: Engine,
     module: Module,
+    plugin_root: PathBuf,
     ticker_handle: tokio::task::JoinHandle<()>,
 }
 
 struct WasmState {
     ctx: WasiP1Ctx,
+    limits: StoreLimits,
 }
 
 impl Drop for WasmRuntime {
@@ -38,6 +43,10 @@ impl WasmRuntime {
         })?;
         let module = Module::new(&engine, &wasm_bytes)
             .map_err(|e| Error::Plugin(format!("module error: {e}")))?;
+        let plugin_root = wasm_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
 
         let ticker_engine = engine.clone();
         let ticker_handle = tokio::spawn(async move {
@@ -52,8 +61,91 @@ impl WasmRuntime {
             manifest,
             engine,
             module,
+            plugin_root,
             ticker_handle,
         })
+    }
+
+    fn configure_filesystem(&self, builder: &mut WasiCtxBuilder) -> Result<()> {
+        let read_paths = &self.manifest.permissions.filesystem_read_paths;
+        let write_paths = &self.manifest.permissions.filesystem_write_paths;
+
+        if !self.manifest.permissions.filesystem {
+            if !read_paths.is_empty() || !write_paths.is_empty() {
+                return Err(Error::Plugin(
+                    "filesystem paths were provided but filesystem=false in plugin permissions"
+                        .to_string(),
+                ));
+            }
+            return Ok(());
+        }
+
+        // Filesystem enabled: always scope access to explicit preopened dirs.
+        // If none are configured, default to plugin root as read-only.
+        let effective_read_paths = if read_paths.is_empty() && write_paths.is_empty() {
+            vec![self.plugin_root.display().to_string()]
+        } else {
+            read_paths.clone()
+        };
+
+        let mut mounts: BTreeMap<PathBuf, bool> = BTreeMap::new();
+        for raw in effective_read_paths {
+            let host_path = normalize_scoped_path(&self.plugin_root, &raw, false)?;
+            mounts.entry(host_path).or_insert(false);
+        }
+        for raw in write_paths {
+            let host_path = normalize_scoped_path(&self.plugin_root, raw, true)?;
+            mounts.insert(host_path, true);
+        }
+
+        for (idx, (host_path, writable)) in mounts.into_iter().enumerate() {
+            let guest_path = format!("mnt{idx}");
+            let dir_perms = if writable {
+                DirPerms::READ | DirPerms::MUTATE
+            } else {
+                DirPerms::READ
+            };
+            let file_perms = if writable {
+                FilePerms::READ | FilePerms::WRITE
+            } else {
+                FilePerms::READ
+            };
+
+            builder
+                .preopened_dir(&host_path, &guest_path, dir_perms, file_perms)
+                .map_err(|e| {
+                    Error::Plugin(format!(
+                        "failed to preopen filesystem path {}: {e}",
+                        host_path.display()
+                    ))
+                })?;
+        }
+
+        Ok(())
+    }
+
+    fn configure_network(&self, builder: &mut WasiCtxBuilder) -> Result<()> {
+        if self.manifest.permissions.network.is_empty() {
+            return Ok(());
+        }
+
+        let allowed_ips = Arc::new(resolve_allowlisted_ips(&self.manifest.permissions.network)?);
+        builder.allow_ip_name_lookup(true);
+        builder.allow_tcp(true);
+        builder.allow_udp(true);
+        builder.socket_addr_check(move |addr, reason| {
+            let allowed_ips = Arc::clone(&allowed_ips);
+            Box::pin(async move {
+                match reason {
+                    SocketAddrUse::TcpConnect
+                    | SocketAddrUse::UdpConnect
+                    | SocketAddrUse::UdpOutgoingDatagram => allowed_ips.contains(&addr.ip()),
+                    SocketAddrUse::TcpBind | SocketAddrUse::UdpBind => false,
+                }
+            })
+        });
+
+        Ok(())
     }
 }
 
@@ -69,7 +161,12 @@ impl Plugin for WasmRuntime {
 
     fn capabilities(&self) -> Vec<Capability> {
         let mut caps = Vec::new();
-        caps.push(Capability::Filesystem(self.manifest.permissions.filesystem));
+        if self.manifest.permissions.filesystem {
+            caps.push(Capability::Filesystem {
+                read_paths: self.manifest.permissions.filesystem_read_paths.clone(),
+                write_paths: self.manifest.permissions.filesystem_write_paths.clone(),
+            });
+        }
         if !self.manifest.permissions.network.is_empty() {
             caps.push(Capability::Network(
                 self.manifest.permissions.network.clone(),
@@ -90,6 +187,8 @@ impl Plugin for WasmRuntime {
 
         let mut builder = WasiCtxBuilder::new();
         builder.args(&input.args);
+        self.configure_filesystem(&mut builder)?;
+        self.configure_network(&mut builder)?;
 
         for (k, v) in &input.env {
             if self.manifest.permissions.env_vars.contains(k) {
@@ -97,9 +196,10 @@ impl Plugin for WasmRuntime {
             }
         }
 
-        // Output capture via pipes
-        let stdout = wasmtime_wasi::pipe::MemoryOutputPipe::new(4096);
-        let stderr = wasmtime_wasi::pipe::MemoryOutputPipe::new(4096);
+        // Output capture via bounded pipes.
+        let max_output_bytes = self.manifest.limits.max_output_bytes.max(1);
+        let stdout = wasmtime_wasi::pipe::MemoryOutputPipe::new(max_output_bytes);
+        let stderr = wasmtime_wasi::pipe::MemoryOutputPipe::new(max_output_bytes);
         builder.stdout(stdout.clone());
         builder.stderr(stderr.clone());
 
@@ -110,14 +210,24 @@ impl Plugin for WasmRuntime {
         }
 
         let ctx = builder.build_p1();
+        let max_memory_bytes = self
+            .manifest
+            .limits
+            .max_memory_mb
+            .saturating_mul(1024 * 1024)
+            .min(usize::MAX as u64) as usize;
+        let limits = StoreLimitsBuilder::new()
+            .memory_size(max_memory_bytes)
+            .build();
 
-        let state = WasmState { ctx };
+        let state = WasmState { ctx, limits };
         let mut store = Store::new(&self.engine, state);
+        store.limiter(|s| &mut s.limits);
 
         // Timeout
         // We set the deadline to the current engine epoch + timeout_secs.
         // The background ticker increments the epoch every second.
-        let timeout_secs = self.manifest.limits.timeout_secs;
+        let timeout_secs = self.manifest.limits.timeout_secs.max(1);
         store.set_epoch_deadline(timeout_secs);
 
         let instance = linker
@@ -137,10 +247,16 @@ impl Plugin for WasmRuntime {
         let status = match res {
             Ok(_) => 0,
             Err(e) => {
+                let root = e.root_cause().to_string();
                 if let Some(exit) = e.downcast_ref::<wasmtime_wasi::I32Exit>() {
                     exit.0
-                } else if e.root_cause().to_string().contains("interrupted") {
+                } else if root.contains("interrupted") {
                     return Err(Error::Plugin("execution timed out".into()));
+                } else if root.contains("write beyond capacity of MemoryOutputPipe") {
+                    return Err(Error::Plugin(format!(
+                        "plugin output exceeded limit ({} bytes per stream)",
+                        max_output_bytes
+                    )));
                 } else {
                     return Err(Error::Plugin(format!("execution error: {e}")));
                 }
@@ -152,5 +268,103 @@ impl Plugin for WasmRuntime {
             stderr: stderr_data,
             status,
         })
+    }
+}
+
+fn normalize_scoped_path(
+    plugin_root: &Path,
+    raw: &str,
+    create_if_missing: bool,
+) -> Result<PathBuf> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(Error::Plugin(
+            "filesystem path entries cannot be empty".to_string(),
+        ));
+    }
+
+    let mut path = PathBuf::from(raw);
+    if path.is_relative() {
+        path = plugin_root.join(path);
+    }
+    if create_if_missing {
+        std::fs::create_dir_all(&path).map_err(|e| {
+            Error::Plugin(format!(
+                "failed to create writable filesystem path {}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+    if !path.exists() {
+        return Err(Error::Plugin(format!(
+            "filesystem path does not exist: {}",
+            path.display()
+        )));
+    }
+    path.canonicalize().map_err(|e| {
+        Error::Plugin(format!(
+            "failed to canonicalize path {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+fn resolve_allowlisted_ips(domains: &[String]) -> Result<HashSet<IpAddr>> {
+    let mut ips = HashSet::new();
+    for domain in domains {
+        let domain = domain.trim();
+        if domain.is_empty() {
+            continue;
+        }
+
+        let query = format!("{domain}:0");
+        let resolved = query.to_socket_addrs().map_err(|e| {
+            Error::Plugin(format!(
+                "failed to resolve allowlisted domain '{domain}': {e}"
+            ))
+        })?;
+
+        let mut resolved_any = false;
+        for addr in resolved {
+            ips.insert(addr.ip());
+            resolved_any = true;
+        }
+        if !resolved_any {
+            return Err(Error::Plugin(format!(
+                "allowlisted domain '{domain}' resolved to no addresses"
+            )));
+        }
+    }
+
+    if ips.is_empty() {
+        return Err(Error::Plugin(
+            "network permission enabled but no allowlisted domains were resolved".to_string(),
+        ));
+    }
+
+    Ok(ips)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_scoped_path, resolve_allowlisted_ips};
+    use std::path::Path;
+
+    #[test]
+    fn resolve_allowlisted_ips_handles_localhost() {
+        let ips = resolve_allowlisted_ips(&["localhost".to_string()]).unwrap();
+        assert!(!ips.is_empty());
+    }
+
+    #[test]
+    fn normalize_scoped_path_creates_writable_path() {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("opencrust-plugin-test-{nanos}"));
+        std::fs::create_dir_all(&root).unwrap();
+        let scoped = normalize_scoped_path(Path::new(&root), "rw-data", true).unwrap();
+        assert!(scoped.exists());
     }
 }

--- a/crates/opencrust-plugins/src/traits.rs
+++ b/crates/opencrust-plugins/src/traits.rs
@@ -6,8 +6,11 @@ use std::collections::HashMap;
 /// Represents the capabilities required by a plugin.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Capability {
-    /// Filesystem access. If true, allows read/write (scoped).
-    Filesystem(bool),
+    /// Filesystem access scoped to explicit host paths.
+    Filesystem {
+        read_paths: Vec<String>,
+        write_paths: Vec<String>,
+    },
     /// Network access. List of allowed domains.
     Network(Vec<String>),
     /// Environment variables. List of allowed variable names.


### PR DESCRIPTION
## Summary
- implement stronger WASM sandbox enforcement in opencrust-plugins
- add manifest fields for filesystem path scopes and output-size limits
- enforce filesystem, network, env-var, timeout, memory, and output limits at runtime
- add PluginRegistry with directory watch + hot-reload support
- add CLI command opencrust plugin watch

## Details
- Permissions now supports ilesystem_read_paths and ilesystem_write_paths
- Limits now supports max_output_bytes (default 1 MiB)
- runtime now configures:
  - preopened directories with read-only/read-write perms
  - socket allowlist checks from allowed domains
  - StoreLimitsBuilder memory cap from max_memory_mb
  - timeout via epoch deadline
  - bounded stdout/stderr pipes with explicit overflow error
- capability reporting updated to include scoped filesystem paths

## Validation
- cargo check -p opencrust-plugins -p opencrust
- cargo test -p opencrust-plugins
- cargo clippy -p opencrust-plugins -p opencrust --all-targets -- -D warnings
- opencrust plugin --help now includes watch

## Notes
- plugin runtime execution wiring into agent tools remains follow-up work outside this patch.