### PR TITLE
Add scheduling heartbeat tool and persistent task runner

### DIFF
--- a/crates/opencrust-agents/Cargo.toml
+++ b/crates/opencrust-agents/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { workspace = true, features = ["stream"] }
 futures = { workspace = true }
 bytes = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+chrono = { workspace = true, features = ["serde"] }
 
 rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-io"], optional = true }
 

--- a/crates/opencrust-agents/src/lib.rs
+++ b/crates/opencrust-agents/src/lib.rs
@@ -18,7 +18,10 @@ pub use providers::{
     StreamEvent, ToolDefinition,
 };
 pub use runtime::AgentRuntime;
-pub use tools::{BashTool, FileReadTool, FileWriteTool, Tool, ToolOutput, WebFetchTool};
+pub use tools::{
+    BashTool, FileReadTool, FileWriteTool, ScheduleHeartbeat, Tool, ToolContext, ToolOutput,
+    WebFetchTool,
+};
 
 #[cfg(feature = "mcp")]
 pub use mcp::McpManager;

--- a/crates/opencrust-agents/src/mcp/tool_bridge.rs
+++ b/crates/opencrust-agents/src/mcp/tool_bridge.rs
@@ -8,7 +8,7 @@ use rmcp::model::{CallToolRequestParams, RawContent};
 use rmcp::service::{Peer, RoleClient};
 use serde_json::Value;
 
-use crate::tools::{Tool, ToolOutput};
+use crate::tools::{Tool, ToolContext, ToolOutput};
 
 /// Bridges a single MCP server tool into the opencrust `Tool` trait.
 pub struct McpTool {
@@ -61,7 +61,7 @@ impl Tool for McpTool {
         self.schema.clone()
     }
 
-    async fn execute(&self, input: Value) -> Result<ToolOutput> {
+    async fn execute(&self, _context: &ToolContext, input: Value) -> Result<ToolOutput> {
         let arguments = match input {
             Value::Object(map) => Some(map),
             Value::Null => None,

--- a/crates/opencrust-agents/src/tools/mod.rs
+++ b/crates/opencrust-agents/src/tools/mod.rs
@@ -1,16 +1,25 @@
 pub mod bash_tool;
 pub mod file_read_tool;
 pub mod file_write_tool;
+pub mod schedule;
 pub mod web_fetch_tool;
 
 pub use bash_tool::BashTool;
 pub use file_read_tool::FileReadTool;
 pub use file_write_tool::FileWriteTool;
+pub use schedule::ScheduleHeartbeat;
 pub use web_fetch_tool::WebFetchTool;
 
 use async_trait::async_trait;
 use opencrust_common::Result;
 use serde::{Deserialize, Serialize};
+
+/// Context passed to tools during execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolContext {
+    pub session_id: String,
+    pub user_id: Option<String>,
+}
 
 /// Trait for tools that agents can invoke (bash, browser, file operations, etc.).
 #[async_trait]
@@ -18,7 +27,7 @@ pub trait Tool: Send + Sync {
     fn name(&self) -> &str;
     fn description(&self) -> &str;
     fn input_schema(&self) -> serde_json::Value;
-    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput>;
+    async fn execute(&self, context: &ToolContext, input: serde_json::Value) -> Result<ToolOutput>;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/opencrust-agents/src/tools/schedule.rs
+++ b/crates/opencrust-agents/src/tools/schedule.rs
@@ -1,0 +1,116 @@
+use async_trait::async_trait;
+use opencrust_common::{Error, Result};
+use opencrust_db::SessionStore;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::tools::{Tool, ToolContext, ToolOutput};
+
+/// Tool for scheduling a future "heartbeat" wake-up call for the agent.
+pub struct ScheduleHeartbeat {
+    store: Arc<Mutex<SessionStore>>,
+}
+
+impl ScheduleHeartbeat {
+    pub fn new(store: Arc<Mutex<SessionStore>>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl Tool for ScheduleHeartbeat {
+    fn name(&self) -> &'static str {
+        "schedule_heartbeat"
+    }
+
+    fn description(&self) -> &'static str {
+        "Schedule a wake-up call for yourself in the future. Use this to set reminders or check back on tasks."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "delay_seconds": {
+                    "type": "integer",
+                    "description": "Number of seconds to wait before waking up (e.g. 60 for 1 minute, 3600 for 1 hour)"
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Context/reason for the wake-up call (e.g. 'Check if deployment finished')"
+                }
+            },
+            "required": ["delay_seconds", "reason"]
+        })
+    }
+
+    async fn execute(&self, context: &ToolContext, args: serde_json::Value) -> Result<ToolOutput> {
+        let delay = args["delay_seconds"].as_i64().ok_or_else(|| {
+            Error::Agent("missing or invalid 'delay_seconds' argument".to_string())
+        })?;
+
+        let reason = args["reason"]
+            .as_str()
+            .ok_or_else(|| Error::Agent("missing or invalid 'reason' argument".to_string()))?;
+
+        if delay <= 0 {
+            return Err(Error::Agent("delay_seconds must be positive".to_string()));
+        }
+
+        let user_id = context
+            .user_id
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string());
+
+        let execute_at = chrono::Utc::now() + chrono::Duration::seconds(delay);
+
+        let store = self.store.lock().await;
+        let task_id = store.schedule_task(&context.session_id, &user_id, execute_at, reason)?;
+
+        Ok(ToolOutput::success(format!(
+            "Heartbeat scheduled for {} (in {} seconds). Task ID: {}",
+            execute_at.to_rfc3339(),
+            delay,
+            task_id
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn schedules_task_in_store() {
+        let store = SessionStore::in_memory().expect("in-memory store should open");
+        let store = Arc::new(Mutex::new(store));
+
+        {
+            let guard = store.lock().await;
+            guard
+                .upsert_session("sess-1", "web", "u-1", &serde_json::json!({}))
+                .expect("session upsert should succeed");
+        }
+
+        let tool = ScheduleHeartbeat::new(Arc::clone(&store));
+        let context = ToolContext {
+            session_id: "sess-1".to_string(),
+            user_id: Some("u-1".to_string()),
+        };
+
+        let out = tool
+            .execute(
+                &context,
+                serde_json::json!({
+                    "delay_seconds": 1,
+                    "reason": "ping me later"
+                }),
+            )
+            .await
+            .expect("tool execution should succeed");
+
+        assert!(!out.is_error);
+        assert!(out.content.contains("Task ID:"));
+    }
+}

--- a/crates/opencrust-agents/src/tools/web_fetch_tool.rs
+++ b/crates/opencrust-agents/src/tools/web_fetch_tool.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use opencrust_common::{Error, Result};
 use std::time::Duration;
 
-use super::{Tool, ToolOutput};
+use super::{Tool, ToolContext, ToolOutput};
 
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const MAX_RESPONSE_BYTES: usize = 1024 * 1024; // 1MB
@@ -56,7 +56,11 @@ impl Tool for WebFetchTool {
         })
     }
 
-    async fn execute(&self, input: serde_json::Value) -> Result<ToolOutput> {
+    async fn execute(
+        &self,
+        _context: &ToolContext,
+        input: serde_json::Value,
+    ) -> Result<ToolOutput> {
         let url = input
             .get("url")
             .and_then(|v| v.as_str())
@@ -111,7 +115,11 @@ mod tests {
     fn returns_error_on_missing_url() {
         let tool = WebFetchTool::new(None);
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let result = rt.block_on(tool.execute(serde_json::json!({})));
+        let ctx = ToolContext {
+            session_id: "test".into(),
+            user_id: None,
+        };
+        let result = rt.block_on(tool.execute(&ctx, serde_json::json!({})));
         assert!(result.is_err());
     }
 }

--- a/crates/opencrust-db/src/lib.rs
+++ b/crates/opencrust-db/src/lib.rs
@@ -7,5 +7,5 @@ pub use memory_store::{
     CompactionReport, MemoryEntry, MemoryProvider, MemoryRole, MemoryStore, NewMemoryEntry,
     RecallQuery, SessionContext,
 };
-pub use session_store::SessionStore;
+pub use session_store::{ScheduledTask, SessionStore};
 pub use vector_store::VectorStore;


### PR DESCRIPTION
 added ToolContext to tool execution and wire it through runtime + MCP bridge
 added schedule_heartbeat tool for delayed follow-up tasks
 extended SessionStore with scheduled_tasks table and due-task polling/completion APIs
 registered ScheduleHeartbeat in gateway when session store is initialized
 added scheduler loop in gateway to execute due tasks and persist responses
 Validation
 cargo test -p opencrust-agents -p opencrust-db -p opencrust-gateway -- --nocapture
 cargo clippy -p opencrust-agents -p opencrust-db -p opencrust-gateway --all-targets -- -D warnings

 Notes: responses from scheduled tasks are persisted even when no channel adapter is available; channel delivery is best-effort.