### PR TITLE
feat(webchat): sandy theme with dark mode toggle and smooth transitions

### DIFF
--- a/crates/opencrust-gateway/src/webchat.html
+++ b/crates/opencrust-gateway/src/webchat.html
@@ -5,24 +5,66 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>OpenCrust Chat</title>
   <style>
-    @import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap");
+    @import url("https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap");
 
     :root {
-      --bg: #f7f4ee;
-      --bg-accent: #efe8d8;
-      --ink: #1c232b;
-      --ink-soft: #5a6472;
-      --panel: #fffdfa;
-      --panel-edge: #d7d2c6;
-      --elev: 0 12px 40px rgba(18, 25, 35, 0.1);
-      --brand: #e06b2d;
-      --brand-2: #f3ae3d;
-      --online: #0d9a6f;
-      --offline: #d03f3f;
-      --sys: #eff3f6;
-      --user: #2a4c6f;
-      --assistant: #ffffff;
-      --error: #ffe7e5;
+      --bg: #f3ecdf;
+      --bg-accent: #e8decc;
+      --ink: #2f2416;
+      --ink-soft: #6c5a42;
+      --panel: #fffaf1;
+      --panel-2: #f7ebd8;
+      --panel-edge: #d8c3a5;
+      --elev: 0 14px 30px rgba(91, 68, 38, 0.18);
+      --brand: #7f5a31;
+      --brand-2: #ad7d47;
+      --online: #2d7e4d;
+      --offline: #8f7a5f;
+      --sys: #ece0ce;
+      --assistant: #fffdf8;
+      --error: #f8e2d5;
+      --error-edge: #c28b6e;
+      --sand-1: #ecdec8;
+      --sand-2: #f7efe2;
+      --accent-line: rgba(127, 90, 49, 0.24);
+      --topbar: rgba(255, 247, 233, 0.88);
+      --glow-a: rgba(255, 255, 255, 0.76);
+      --glow-b: rgba(208, 166, 105, 0.35);
+      --user-grad-a: #6a4d2f;
+      --user-grad-b: #4a341e;
+      --warn-edge: #cfaa62;
+      --warn-bg: #f8efd8;
+      --warn-text: #6b5300;
+    }
+
+    [data-theme="dark"] {
+      --bg: #191510;
+      --bg-accent: #110f0d;
+      --ink: #f1e4d0;
+      --ink-soft: #c1ab8d;
+      --panel: #241d16;
+      --panel-2: #1a1510;
+      --panel-edge: #4f3d2b;
+      --elev: 0 16px 34px rgba(0, 0, 0, 0.42);
+      --brand: #d7a467;
+      --brand-2: #ad7841;
+      --online: #84d69c;
+      --offline: #a68f72;
+      --sys: #302519;
+      --assistant: #2b2219;
+      --error: #452a1f;
+      --error-edge: #9d6649;
+      --sand-1: #2e241b;
+      --sand-2: #201912;
+      --accent-line: rgba(215, 164, 103, 0.32);
+      --topbar: rgba(37, 31, 24, 0.9);
+      --glow-a: rgba(255, 205, 140, 0.09);
+      --glow-b: rgba(0, 0, 0, 0.2);
+      --user-grad-a: #7b5631;
+      --user-grad-b: #5b3f25;
+      --warn-edge: #8b6c36;
+      --warn-bg: #322514;
+      --warn-text: #e2c68b;
     }
 
     * { box-sizing: border-box; }
@@ -31,11 +73,19 @@
       margin: 0;
       min-height: 100vh;
       color: var(--ink);
-      font-family: "Space Grotesk", "Segoe UI", sans-serif;
+      font-family: "Archivo", "Segoe UI", sans-serif;
       background:
-        radial-gradient(1200px 700px at 0% -10%, #fde9d1 0%, transparent 60%),
-        radial-gradient(1000px 700px at 100% -20%, #dae9f3 0%, transparent 58%),
+        radial-gradient(1000px 620px at 0% -15%, var(--glow-a) 0%, transparent 58%),
+        radial-gradient(1000px 620px at 100% -15%, var(--glow-b) 0%, transparent 58%),
         linear-gradient(180deg, var(--bg), var(--bg-accent));
+      opacity: 0;
+      transform: translateY(6px);
+      transition: opacity 320ms ease, transform 320ms ease, background 360ms ease, color 240ms ease;
+    }
+
+    body.ready {
+      opacity: 1;
+      transform: translateY(0);
     }
 
     .shell {
@@ -50,6 +100,25 @@
       align-items: center;
       gap: 12px;
       margin-bottom: 16px;
+      padding: 10px 12px;
+      border: 1px solid var(--panel-edge);
+      border-radius: 14px;
+      background: var(--topbar);
+      box-shadow: 0 8px 20px rgba(35, 22, 10, 0.12);
+    }
+
+    .topbar-actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .theme-toggle {
+      padding: 6px 10px;
+      font-size: 0.77rem;
+      border-radius: 999px;
+      border-color: var(--panel-edge);
+      background: var(--panel);
     }
 
     .brand {
@@ -61,26 +130,32 @@
     .badge {
       width: 30px;
       height: 30px;
-      border-radius: 9px;
-      background: linear-gradient(145deg, var(--brand), var(--brand-2));
-      box-shadow: 0 7px 20px rgba(224, 107, 45, 0.38);
+      border-radius: 8px;
+      border: 2px solid var(--panel-edge);
+      background:
+        radial-gradient(circle at 30% 30%, #4d4d4d 0%, transparent 45%),
+        linear-gradient(145deg, var(--brand), var(--brand-2));
+      box-shadow: 0 8px 18px rgba(0, 0, 0, 0.28);
     }
 
     .title {
       margin: 0;
       font-size: 1.35rem;
-      letter-spacing: 0.2px;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
     }
 
     .subtitle {
       margin: 0;
       color: var(--ink-soft);
-      font-size: 0.84rem;
+      font-size: 0.78rem;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
     }
 
     .workspace {
       display: grid;
-      grid-template-columns: 280px 1fr;
+      grid-template-columns: 300px minmax(0, 1fr);
       gap: 14px;
       align-items: start;
     }
@@ -88,16 +163,26 @@
     .panel {
       border: 1px solid var(--panel-edge);
       border-radius: 16px;
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 252, 246, 0.92));
+      background: linear-gradient(180deg, var(--panel), var(--panel-2));
       box-shadow: var(--elev);
       overflow: hidden;
       animation: rise 360ms ease both;
+      position: relative;
+    }
+
+    .panel::before {
+      content: "";
+      position: absolute;
+      inset: 0 0 auto;
+      height: 3px;
+      background: linear-gradient(90deg, transparent, var(--accent-line), transparent);
+      pointer-events: none;
     }
 
     .panel-head {
       padding: 14px 16px;
       border-bottom: 1px solid var(--panel-edge);
-      background: rgba(255, 255, 255, 0.72);
+      background: var(--sand-1);
     }
 
     .panel-head h2 {
@@ -142,7 +227,7 @@
     }
 
     .status-row code {
-      color: #1f4e6f;
+      color: var(--brand);
       font-family: "IBM Plex Mono", Consolas, monospace;
       font-size: 0.78rem;
       text-align: right;
@@ -176,7 +261,7 @@
       border: 1px solid var(--panel-edge);
       border-radius: 8px;
       font-size: 0.78rem;
-      background: #fff;
+      background: var(--panel);
     }
 
     .no-channels {
@@ -201,7 +286,7 @@
       border: 1px solid var(--panel-edge);
       border-radius: 10px;
       color: var(--ink);
-      background: #ffffff;
+      background: var(--panel);
       padding: 8px 10px;
       font-family: "IBM Plex Mono", Consolas, monospace;
       font-size: 0.82rem;
@@ -210,8 +295,8 @@
 
     .gateway-key-section input:focus {
       outline: none;
-      border-color: #cf7641;
-      box-shadow: 0 0 0 3px rgba(224, 107, 45, 0.16);
+      border-color: var(--brand);
+      box-shadow: 0 0 0 3px rgba(127, 90, 49, 0.2);
     }
 
     .gateway-key-section .hint {
@@ -224,9 +309,9 @@
       border: 1px solid var(--panel-edge);
       border-radius: 10px;
       color: var(--ink);
-      background: #ffffff;
+      background: var(--panel);
       padding: 8px 10px;
-      font-family: "Space Grotesk", "Segoe UI", sans-serif;
+      font-family: "Archivo", "Segoe UI", sans-serif;
       font-size: 0.84rem;
       cursor: pointer;
       transition: border-color 120ms ease, box-shadow 120ms ease;
@@ -235,8 +320,8 @@
 
     .provider-select:focus {
       outline: none;
-      border-color: #cf7641;
-      box-shadow: 0 0 0 3px rgba(224, 107, 45, 0.16);
+      border-color: var(--brand);
+      box-shadow: 0 0 0 3px rgba(127, 90, 49, 0.2);
     }
 
     .provider-status {
@@ -250,7 +335,7 @@
       border: 1px solid var(--panel-edge);
       border-radius: 10px;
       color: var(--ink);
-      background: #ffffff;
+      background: var(--panel);
       padding: 8px 10px;
       font-family: "IBM Plex Mono", Consolas, monospace;
       font-size: 0.82rem;
@@ -260,19 +345,19 @@
 
     .provider-key-input:focus {
       outline: none;
-      border-color: #cf7641;
-      box-shadow: 0 0 0 3px rgba(224, 107, 45, 0.16);
+      border-color: var(--brand);
+      box-shadow: 0 0 0 3px rgba(127, 90, 49, 0.2);
     }
 
     .provider-activate-btn {
       width: 100%;
-      border: none;
-      color: #2f220e;
-      background: linear-gradient(145deg, var(--brand), var(--brand-2));
-      box-shadow: 0 6px 14px rgba(224, 107, 45, 0.22);
+      border: 1px solid var(--brand);
+      color: #fff8ee;
+      background: linear-gradient(145deg, var(--brand-2), var(--brand));
+      box-shadow: 0 6px 14px rgba(57, 34, 13, 0.3);
       border-radius: 10px;
       padding: 8px 12px;
-      font-family: "Space Grotesk", "Segoe UI", sans-serif;
+      font-family: "Archivo", "Segoe UI", sans-serif;
       font-size: 0.84rem;
       font-weight: 600;
       cursor: pointer;
@@ -283,7 +368,7 @@
       border-radius: 999px;
       padding: 6px 10px;
       font-size: 0.8rem;
-      background: #fff;
+      background: var(--panel);
       min-width: 118px;
       text-align: center;
     }
@@ -298,7 +383,7 @@
       gap: 10px;
       padding: 14px 16px;
       border-bottom: 1px solid var(--panel-edge);
-      background: rgba(255, 255, 255, 0.7);
+      background: var(--sand-1);
       flex-wrap: wrap;
     }
 
@@ -318,8 +403,7 @@
       display: flex;
       flex-direction: column;
       gap: 11px;
-      background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.34), rgba(246, 241, 233, 0.5));
+      background: var(--sand-2);
     }
 
     .msg {
@@ -330,7 +414,7 @@
       white-space: pre-wrap;
       word-wrap: break-word;
       line-height: 1.42;
-      box-shadow: 0 6px 14px rgba(20, 30, 40, 0.06);
+      box-shadow: 0 6px 14px rgba(59, 38, 17, 0.12);
       animation: msg-in 220ms ease both;
     }
 
@@ -345,9 +429,9 @@
 
     .user {
       align-self: flex-end;
-      color: #eef5fb;
-      border-color: #204362;
-      background: linear-gradient(145deg, #2a4c6f, #1e3b59);
+      color: #fff7e9;
+      border-color: var(--brand);
+      background: linear-gradient(145deg, var(--user-grad-a), var(--user-grad-b));
     }
 
     .assistant {
@@ -358,8 +442,8 @@
     .error {
       align-self: flex-start;
       background: var(--error);
-      border-color: #e89a91;
-      color: #8b2b2b;
+      border-color: var(--error-edge);
+      color: var(--ink);
     }
 
     .controls {
@@ -367,7 +451,7 @@
       padding: 14px;
       display: grid;
       gap: 10px;
-      background: rgba(255, 255, 255, 0.72);
+      background: var(--sand-1);
     }
 
     .actions {
@@ -377,12 +461,12 @@
     }
 
     button {
-      border: 1px solid #cfc6b5;
+      border: 1px solid var(--panel-edge);
       border-radius: 10px;
-      background: #fff;
+      background: var(--panel);
       color: var(--ink);
       padding: 8px 12px;
-      font-family: "Space Grotesk", "Segoe UI", sans-serif;
+      font-family: "Archivo", "Segoe UI", sans-serif;
       font-size: 0.84rem;
       font-weight: 600;
       cursor: pointer;
@@ -391,15 +475,15 @@
 
     button:hover {
       transform: translateY(-1px);
-      border-color: #c9bca5;
-      box-shadow: 0 7px 14px rgba(31, 42, 55, 0.1);
+      border-color: var(--brand-2);
+      box-shadow: 0 7px 14px rgba(0, 0, 0, 0.12);
     }
 
     button.primary {
-      border: none;
-      color: #2f220e;
-      background: linear-gradient(145deg, var(--brand), var(--brand-2));
-      box-shadow: 0 10px 18px rgba(224, 107, 45, 0.28);
+      border-color: var(--brand);
+      color: #fff8ee;
+      background: linear-gradient(145deg, var(--brand-2), var(--brand));
+      box-shadow: 0 10px 18px rgba(57, 34, 13, 0.35);
     }
 
     .composer {
@@ -417,7 +501,7 @@
       border: 1px solid var(--panel-edge);
       border-radius: 10px;
       color: var(--ink);
-      background: #ffffff;
+      background: var(--panel);
       padding: 10px 11px;
       font-family: "IBM Plex Mono", Consolas, monospace;
       font-size: 0.9rem;
@@ -427,8 +511,8 @@
 
     textarea:focus {
       outline: none;
-      border-color: #cf7641;
-      box-shadow: 0 0 0 3px rgba(224, 107, 45, 0.16);
+      border-color: var(--brand);
+      box-shadow: 0 0 0 3px rgba(127, 90, 49, 0.2);
     }
 
     .divider {
@@ -444,11 +528,11 @@
       gap: 10px;
       padding: 10px 16px;
       margin-bottom: 12px;
-      border: 1px solid #d4a017;
+      border: 1px solid var(--warn-edge);
       border-radius: 12px;
-      background: linear-gradient(145deg, #fef9ec, #fdf3d7);
+      background: linear-gradient(145deg, var(--warn-bg), var(--panel-2));
       font-size: 0.84rem;
-      color: #6b5300;
+      color: var(--warn-text);
       animation: rise 360ms ease both;
     }
 
@@ -465,7 +549,7 @@
     .update-banner-close {
       background: none;
       border: none;
-      color: #6b5300;
+      color: var(--warn-text);
       cursor: pointer;
       font-size: 1.1rem;
       padding: 0 4px;
@@ -478,6 +562,24 @@
       opacity: 1;
       transform: none;
       box-shadow: none;
+    }
+
+    .topbar,
+    .panel,
+    .panel-head,
+    .chat-top,
+    .chat,
+    .controls,
+    .msg,
+    button,
+    .pill,
+    .gateway-key-section input,
+    .provider-select,
+    .provider-key-input,
+    textarea,
+    .channel-tag,
+    .update-banner {
+      transition: background 280ms ease, border-color 280ms ease, color 220ms ease, box-shadow 280ms ease;
     }
 
     @keyframes rise {
@@ -497,6 +599,38 @@
       .composer { grid-template-columns: 1fr; }
       .composer button { width: 100%; }
     }
+
+    @media (prefers-reduced-motion: reduce) {
+      body {
+        opacity: 1;
+        transform: none;
+        transition: none;
+      }
+
+      .panel,
+      .msg,
+      .update-banner {
+        animation: none;
+      }
+
+      .topbar,
+      .panel,
+      .panel-head,
+      .chat-top,
+      .chat,
+      .controls,
+      .msg,
+      button,
+      .pill,
+      .gateway-key-section input,
+      .provider-select,
+      .provider-key-input,
+      textarea,
+      .channel-tag,
+      .update-banner {
+        transition: none;
+      }
+    }
   </style>
 </head>
 <body>
@@ -509,7 +643,10 @@
           <p class="subtitle">Your personal AI assistant</p>
         </div>
       </div>
-      <div class="pill" id="conn-pill"><span class="offline">Disconnected</span></div>
+      <div class="topbar-actions">
+        <button id="theme-toggle" class="theme-toggle" type="button">Dark Mode</button>
+        <div class="pill" id="conn-pill"><span class="offline">Disconnected</span></div>
+      </div>
     </header>
 
     <div id="update-banner" class="update-banner" style="display:none">
@@ -608,6 +745,7 @@
     const refreshBtn = document.getElementById("refresh");
     const clearBtn = document.getElementById("clear");
     const connPill = document.getElementById("conn-pill");
+    const themeToggleBtn = document.getElementById("theme-toggle");
     const sessionEl = document.getElementById("session");
     const apiStatusEl = document.getElementById("api-status");
     const sessionCountEl = document.getElementById("session-count");
@@ -627,6 +765,7 @@
     const storageKey = "opencrust.session_id";
     const keyStorage = "opencrust.gateway_key";
     const providerStorage = "opencrust.provider";
+    const themeStorageKey = "opencrust.ui.theme";
     let sessionId = localStorage.getItem(storageKey) || "";
     let gatewayKey = localStorage.getItem(keyStorage) || "";
     let selectedProvider = localStorage.getItem(providerStorage) || "";
@@ -637,6 +776,27 @@
 
     // Pre-fill saved key
     keyGatewayEl.value = gatewayKey;
+
+    function setTheme(theme, persist = true) {
+      const selected = theme === "dark" ? "dark" : "light";
+      document.documentElement.setAttribute("data-theme", selected);
+      if (themeToggleBtn) {
+        themeToggleBtn.textContent = selected === "dark" ? "Light Mode" : "Dark Mode";
+      }
+      if (persist) {
+        localStorage.setItem(themeStorageKey, selected);
+      }
+    }
+
+    function initTheme() {
+      const stored = localStorage.getItem(themeStorageKey);
+      if (stored === "light" || stored === "dark") {
+        setTheme(stored, false);
+        return;
+      }
+      const prefersDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+      setTheme(prefersDark ? "dark" : "light");
+    }
 
     function wsUrl() {
       const proto = location.protocol === "https:" ? "wss:" : "ws:";
@@ -934,8 +1094,19 @@
       reconnectFresh();
     });
 
+    if (themeToggleBtn) {
+      themeToggleBtn.addEventListener("click", () => {
+        const current = document.documentElement.getAttribute("data-theme") || "light";
+        setTheme(current === "dark" ? "light" : "dark");
+      });
+    }
+
     // Boot: check if auth is required, then connect
     async function boot() {
+      initTheme();
+      requestAnimationFrame(() => {
+        document.body.classList.add("ready");
+      });
       setConnectionState(false);
       setSession(sessionId);
       refreshStatus();


### PR DESCRIPTION
applied a cleaner sandy visual hierarchy across the existing webchat UI
added a persistent Light/Dark mode toggle in the header
added smooth page-load fade-in and theme transition animations
kept existing provider/auth/status/chat behavior unchanged
Testing done
cargo check -p opencrust-gateway