### PR TITLE
Added chatgpt oauth authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@
 # LLM API Keys
 ANTHROPIC_API_KEY=your_anthropic_key_here
 OPENAI_API_KEY=your_openai_key_here
+CODEX_ACCESS_TOKEN=your_codex_access_token_here
+CODEX_REFRESH_TOKEN=your_codex_refresh_token_here
+CODEX_ACCOUNT_ID=your_codex_account_id_here
+CODEX_ID_TOKEN=your_codex_id_token_here
 SANSA_API_KEY=your_sansa_key_here
 BRAVE_API_KEY=your_brave_search_key_here
 COHERE_API_KEY=your_cohere_key_here

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2622,6 +2622,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
+ "base64",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -2746,6 +2747,7 @@ dependencies = [
  "opencrust-security",
  "opencrust-skills",
  "reqwest 0.12.28",
+ "ring",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,7 +2750,6 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "serde_yaml",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,6 +2750,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
+ "serde_yaml",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tower",

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ OpenCrust is built for the security requirements of always-on AI agents that acc
 
 - **Anthropic Claude** - streaming (SSE), tool use
 - **OpenAI** - GPT-4o, Azure, any OpenAI-compatible endpoint via `base_url`
+- **Codex OAuth** - ChatGPT-backed Codex Responses API via OAuth
 - **Ollama** - local models with streaming
 
 **OpenAI-compatible providers:**
@@ -296,7 +297,7 @@ crates/
 | iMessage (macOS, group chats) | Working |
 | LINE (webhooks, reply/push fallback) | Working |
 | WeChat (Official Account webhooks, media dispatch) | Working |
-| LLM providers (15: Anthropic, OpenAI, Ollama + 12 OpenAI-compatible) | Working |
+| LLM providers (15: Anthropic, OpenAI, Codex, Ollama + 11 OpenAI-compatible) | Working |
 | Agent tools (bash, file_read, file_write, web_fetch, web_search, doc_search, schedule_heartbeat, cancel_heartbeat, list_heartbeats, mcp_resources) | Working |
 | MCP client (stdio, HTTP, tool bridging, resources, instructions) | Working |
 | A2A protocol (Agent-to-Agent) | Working |

--- a/assets/webchat/main.js
+++ b/assets/webchat/main.js
@@ -20,7 +20,9 @@ const providerModelOptions = document.getElementById("provider-model-options");
 const providerModelStatus = document.getElementById("provider-model-status");
 const providerKeySection = document.getElementById("provider-key-section");
 const providerApiKey = document.getElementById("provider-api-key");
+const providerOauthRedirect = document.getElementById("provider-oauth-redirect");
 const providerActivateBtn = document.getElementById("provider-activate");
+const providerOauthCompleteBtn = document.getElementById("provider-oauth-complete");
 const authSection = document.getElementById("auth-section");
 const keyGatewayEl = document.getElementById("key-gateway");
 const authConnectBtn = document.getElementById("auth-connect");
@@ -670,6 +672,9 @@ function updateProviderUI() {
   if (!p) {
     providerStatus.textContent = "";
     providerKeySection.style.display = "none";
+    providerActivateBtn.textContent = "Save & Activate";
+    providerOauthCompleteBtn.style.display = "none";
+    providerOauthRedirect.style.display = "none";
     updateModelUI(null);
     return;
   }
@@ -677,9 +682,17 @@ function updateProviderUI() {
     const tag = p.is_default ? "active, default" : "active";
     providerStatus.innerHTML = `<span class="status-dot dot-ok"></span>${tag}`;
     providerKeySection.style.display = "none";
+    providerActivateBtn.textContent = "Save & Activate";
+    providerApiKey.style.display = "";
+    providerOauthRedirect.style.display = "none";
+    providerOauthCompleteBtn.style.display = "none";
   } else {
     providerStatus.innerHTML = `<span class="status-dot dot-off"></span>not configured`;
-    providerKeySection.style.display = p.needs_api_key ? "" : "none";
+    providerKeySection.style.display = p.id === "codex" || p.needs_api_key ? "" : "none";
+    providerApiKey.style.display = p.id === "codex" ? "none" : "";
+    providerOauthRedirect.style.display = p.id === "codex" ? "" : "none";
+    providerOauthCompleteBtn.style.display = p.id === "codex" ? "" : "none";
+    providerActivateBtn.textContent = p.id === "codex" ? "Connect with Codex" : "Save & Activate";
   }
   selectedProvider = id;
   localStorage.setItem(providerStorage, id);
@@ -701,6 +714,20 @@ providerSelect.addEventListener("change", () => {
 
 providerActivateBtn.addEventListener("click", async () => {
   const id = providerSelect.value;
+  if (id === "codex") {
+    providerActivateBtn.textContent = "Connecting...";
+    providerActivateBtn.disabled = true;
+    try {
+      const popup = window.open("/api/providers/codex/oauth/start", "opencrust-codex-oauth", "popup,width=560,height=760");
+      if (!popup) {
+        appendMessage("error", "Popup blocked while opening Codex OAuth.");
+      }
+    } finally {
+      providerActivateBtn.textContent = "Connect with Codex";
+      providerActivateBtn.disabled = false;
+    }
+    return;
+  }
   const key = providerApiKey.value.trim();
   if (!key) return;
   const model = providerModelInput.value.trim();
@@ -740,10 +767,52 @@ providerActivateBtn.addEventListener("click", async () => {
   }
 });
 
+providerOauthCompleteBtn.addEventListener("click", async () => {
+  if (providerSelect.value !== "codex") return;
+  const redirectUrl = providerOauthRedirect.value.trim();
+  if (!redirectUrl) {
+    appendMessage("error", "Paste the Codex redirect URL first.");
+    return;
+  }
+
+  providerOauthCompleteBtn.textContent = "Completing...";
+  providerOauthCompleteBtn.disabled = true;
+  try {
+    const response = await fetch("/api/providers/codex/oauth/complete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ redirect_url: redirectUrl }),
+    });
+    const result = await response.json();
+    if (response.ok) {
+      providerOauthRedirect.value = "";
+      appendMessage("sys", result.message || "Codex connected.");
+      await loadProviders();
+    } else {
+      appendMessage("error", result.message || "Failed to complete Codex login.");
+    }
+  } catch (error) {
+    appendMessage("error", `Failed to complete Codex login: ${error}`);
+  } finally {
+    providerOauthCompleteBtn.textContent = "Complete Codex Login";
+    providerOauthCompleteBtn.disabled = false;
+  }
+});
+
 providerModelInput.addEventListener("input", () => {
   const providerId = providerSelect.value;
   if (!providerId) return;
   setSavedModelForProvider(providerId, providerModelInput.value.trim());
+});
+
+window.addEventListener("message", async event => {
+  if (!event.data || event.data.type !== "opencrust.codex.oauth") return;
+  if (event.data.success) {
+    appendMessage("sys", event.data.message || "Codex connected.");
+    await loadProviders();
+  } else {
+    appendMessage("error", event.data.message || "Codex connection failed.");
+  }
 });
 
 function scheduleReconnect() {

--- a/crates/opencrust-agents/Cargo.toml
+++ b/crates/opencrust-agents/Cargo.toml
@@ -20,6 +20,7 @@ bytes = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 chrono = { workspace = true, features = ["serde"] }
 dashmap = { workspace = true }
+base64 = { workspace = true }
 dirs = "6"
 chrono-tz = "0.10"
 cron = "0.15"

--- a/crates/opencrust-agents/src/codex.rs
+++ b/crates/opencrust-agents/src/codex.rs
@@ -296,81 +296,6 @@ impl CodexProvider {
         })
     }
 
-    fn parse_output_item(item: &Value) -> Vec<ContentBlock> {
-        match item.get("type").and_then(Value::as_str) {
-            Some("message") => {
-                item.get("content")
-                    .and_then(Value::as_array)
-                    .map(|content| {
-                        content
-                            .iter()
-                            .filter_map(|part| match part.get("type").and_then(Value::as_str) {
-                                Some("output_text") => part
-                                    .get("text")
-                                    .and_then(Value::as_str)
-                                    .map(|text| ContentBlock::Text {
-                                        text: text.to_string(),
-                                    }),
-                                _ => None,
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default()
-            }
-            Some("function_call") => {
-                let call_id = item
-                    .get("call_id")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string();
-                let name = item
-                    .get("name")
-                    .and_then(Value::as_str)
-                    .unwrap_or_default()
-                    .to_string();
-                let input = item
-                    .get("arguments")
-                    .and_then(Value::as_str)
-                    .and_then(|raw| serde_json::from_str(raw).ok())
-                    .unwrap_or_else(|| serde_json::json!({}));
-                if call_id.is_empty() || name.is_empty() {
-                    Vec::new()
-                } else {
-                    vec![ContentBlock::ToolUse {
-                        id: call_id,
-                        name,
-                        input,
-                    }]
-                }
-            }
-            _ => Vec::new(),
-        }
-    }
-
-    fn parse_non_streaming_response(body: &Value) -> LlmResponse {
-        let output = body
-            .get("output")
-            .and_then(Value::as_array)
-            .into_iter()
-            .flatten()
-            .flat_map(Self::parse_output_item)
-            .collect::<Vec<_>>();
-
-        LlmResponse {
-            content: output,
-            model: body
-                .get("model")
-                .and_then(Value::as_str)
-                .unwrap_or(DEFAULT_MODEL)
-                .to_string(),
-            usage: Self::parse_usage(body),
-            stop_reason: body
-                .get("status")
-                .and_then(Value::as_str)
-                .map(|s| s.to_string()),
-        }
-    }
-
     fn response_from_stream_events(
         &self,
         request: &LlmRequest,
@@ -457,20 +382,21 @@ impl LlmProvider for CodexProvider {
 
     #[instrument(skip(self, request), fields(model))]
     async fn complete(&self, request: &LlmRequest) -> Result<LlmResponse> {
-        let response = self.send_responses_request(request, false).await?;
+        let response = self.send_responses_request(request, true).await?;
         let status = response.status();
-        let body = response
-            .json::<Value>()
-            .await
-            .map_err(|e| Error::Agent(format!("failed to parse codex response body: {e}")))?;
-
         if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
             return Err(Error::Agent(format!(
                 "codex request failed ({status}): {body}"
             )));
         }
 
-        Ok(Self::parse_non_streaming_response(&body))
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::Agent(format!("failed to read codex SSE body: {e}")))?;
+        let events = parse_sse_events(bytes.as_ref())?;
+        Ok(self.response_from_stream_events(request, &events))
     }
 
     async fn stream_complete(

--- a/crates/opencrust-agents/src/codex.rs
+++ b/crates/opencrust-agents/src/codex.rs
@@ -1,0 +1,761 @@
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use futures::Stream;
+use futures::stream;
+use opencrust_common::{Error, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::{instrument, warn};
+
+use crate::providers::{
+    ChatMessage, ChatRole, ContentBlock, LlmProvider, LlmRequest, LlmResponse, MessagePart,
+    StreamEvent, Usage,
+};
+
+const DEFAULT_MODEL: &str = "gpt-5.3-codex";
+const DEFAULT_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+const MODELS_CLIENT_VERSION: &str = "0.1.0";
+const OAUTH_ISSUER: &str = "https://auth.openai.com";
+const OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+#[derive(Debug, Clone)]
+pub struct CodexAuthConfig {
+    pub access_token: Option<String>,
+    pub refresh_token: Option<String>,
+    pub account_id: Option<String>,
+    pub id_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CodexOAuthClaims {
+    pub email: Option<String>,
+    pub account_id: Option<String>,
+    pub user_id: Option<String>,
+    pub plan_type: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CodexAuthState {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    account_id: Option<String>,
+    id_token: Option<String>,
+}
+
+pub struct CodexProvider {
+    client: reqwest::Client,
+    model: String,
+    base_url: String,
+    auth: Arc<RwLock<CodexAuthState>>,
+}
+
+impl CodexProvider {
+    pub fn new(auth: CodexAuthConfig, model: Option<String>, base_url: Option<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            model: model.unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+            base_url: base_url.unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+            auth: Arc::new(RwLock::new(CodexAuthState {
+                access_token: auth.access_token.filter(|v| !v.trim().is_empty()),
+                refresh_token: auth.refresh_token.filter(|v| !v.trim().is_empty()),
+                account_id: auth.account_id.filter(|v| !v.trim().is_empty()),
+                id_token: auth.id_token.filter(|v| !v.trim().is_empty()),
+            })),
+        }
+    }
+
+    fn responses_endpoint(&self) -> String {
+        format!("{}/responses", self.base_url.trim_end_matches('/'))
+    }
+
+    fn models_endpoint(&self) -> String {
+        format!("{}/models", self.base_url.trim_end_matches('/'))
+    }
+
+    fn read_auth(&self) -> CodexAuthState {
+        self.auth.read().unwrap().clone()
+    }
+
+    async fn ensure_access_token(&self) -> Result<CodexAuthState> {
+        let auth = self.read_auth();
+        if auth.access_token.is_some() {
+            return Ok(auth);
+        }
+        self.refresh_access_token().await
+    }
+
+    async fn refresh_access_token(&self) -> Result<CodexAuthState> {
+        let refresh_token = self
+            .read_auth()
+            .refresh_token
+            .ok_or_else(|| Error::Agent("codex oauth refresh token missing".to_string()))?;
+
+        let response = self
+            .client
+            .post(format!("{OAUTH_ISSUER}/oauth/token"))
+            .header("content-type", "application/json")
+            .json(&serde_json::json!({
+                "client_id": OAUTH_CLIENT_ID,
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+            }))
+            .send()
+            .await
+            .map_err(|e| Error::Agent(format!("codex token refresh failed: {e}")))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(Error::Agent(format!(
+                "codex token refresh failed ({status}): {body}"
+            )));
+        }
+
+        let refresh = response.json::<RefreshResponse>().await.map_err(|e| {
+            Error::Agent(format!("failed to parse codex token refresh response: {e}"))
+        })?;
+
+        let claims = refresh
+            .id_token
+            .as_deref()
+            .and_then(|token| parse_codex_id_token_claims(token).ok());
+
+        let mut guard = self.auth.write().unwrap();
+        guard.access_token = refresh.access_token.or_else(|| guard.access_token.clone());
+        if let Some(next_refresh) = refresh.refresh_token {
+            guard.refresh_token = Some(next_refresh);
+        }
+        if let Some(id_token) = refresh.id_token {
+            guard.id_token = Some(id_token);
+        }
+        if guard.account_id.is_none() {
+            guard.account_id = claims.and_then(|c| c.account_id);
+        }
+        Ok(guard.clone())
+    }
+
+    async fn send_responses_request(
+        &self,
+        request: &LlmRequest,
+        stream: bool,
+    ) -> Result<reqwest::Response> {
+        let mut auth = self.ensure_access_token().await?;
+        let body = self.build_request(request, stream);
+
+        for attempt in 0..2 {
+            let mut builder = self
+                .client
+                .post(self.responses_endpoint())
+                .header("content-type", "application/json")
+                .bearer_auth(
+                    auth.access_token
+                        .as_deref()
+                        .ok_or_else(|| Error::Agent("codex access token missing".to_string()))?,
+                )
+                .json(&body);
+
+            if let Some(account_id) = auth.account_id.as_deref() {
+                builder = builder.header("chatgpt-account-id", account_id);
+            }
+            if stream {
+                builder = builder.header("accept", "text/event-stream");
+            }
+
+            let response = builder
+                .send()
+                .await
+                .map_err(|e| Error::Agent(format!("codex request failed: {e}")))?;
+
+            if response.status() != reqwest::StatusCode::UNAUTHORIZED || attempt == 1 {
+                return Ok(response);
+            }
+
+            auth = self.refresh_access_token().await?;
+        }
+
+        Err(Error::Agent(
+            "codex request failed after refresh retry".to_string(),
+        ))
+    }
+
+    fn build_request(&self, request: &LlmRequest, stream: bool) -> Value {
+        let model = if request.model.trim().is_empty() {
+            self.model.clone()
+        } else {
+            request.model.trim().to_string()
+        };
+
+        let mut input = Vec::new();
+        for msg in &request.messages {
+            self.push_message_items(&mut input, msg);
+        }
+
+        let tools = request
+            .tools
+            .iter()
+            .map(|tool| {
+                serde_json::json!({
+                    "type": "function",
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.input_schema,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        serde_json::json!({
+            "model": model,
+            "instructions": request.system.clone().unwrap_or_default(),
+            "input": input,
+            "tools": tools,
+            "tool_choice": "auto",
+            "parallel_tool_calls": true,
+            "reasoning": serde_json::Value::Null,
+            "store": false,
+            "stream": stream,
+            "include": Vec::<String>::new(),
+        })
+    }
+
+    fn push_message_items(&self, input: &mut Vec<Value>, msg: &ChatMessage) {
+        match (&msg.role, &msg.content) {
+            (ChatRole::System, _) => {}
+            (ChatRole::User, MessagePart::Text(text)) => {
+                input.push(message_item("user", vec![input_text(text)]));
+            }
+            (ChatRole::User, MessagePart::Parts(parts)) => {
+                let mut content = Vec::new();
+                let mut has_tool_results = false;
+                for part in parts {
+                    match part {
+                        ContentBlock::Text { text } => content.push(input_text(text)),
+                        ContentBlock::Image { url } => content.push(input_image(url)),
+                        ContentBlock::ToolResult {
+                            tool_use_id,
+                            content,
+                        } => {
+                            has_tool_results = true;
+                            input.push(serde_json::json!({
+                                "type": "function_call_output",
+                                "call_id": tool_use_id,
+                                "output": content,
+                            }));
+                        }
+                        _ => {}
+                    }
+                }
+                if !content.is_empty() {
+                    input.push(message_item("user", content));
+                } else if !has_tool_results {
+                    input.push(message_item("user", Vec::new()));
+                }
+            }
+            (ChatRole::Assistant, MessagePart::Text(text)) => {
+                input.push(message_output_item("assistant", vec![output_text(text)]));
+            }
+            (ChatRole::Assistant, MessagePart::Parts(parts)) => {
+                let mut content = Vec::new();
+                for part in parts {
+                    match part {
+                        ContentBlock::Text { text } => content.push(output_text(text)),
+                        ContentBlock::ToolUse {
+                            id,
+                            name,
+                            input: args,
+                        } => {
+                            input.push(serde_json::json!({
+                                "type": "function_call",
+                                "call_id": id,
+                                "name": name,
+                                "arguments": serde_json::to_string(args).unwrap_or_else(|_| "{}".to_string()),
+                            }));
+                        }
+                        _ => {}
+                    }
+                }
+                if !content.is_empty() {
+                    input.push(message_output_item("assistant", content));
+                }
+            }
+            (ChatRole::Tool, MessagePart::Text(text)) => {
+                input.push(message_item("tool", vec![input_text(text)]));
+            }
+            (ChatRole::Tool, MessagePart::Parts(_)) => {}
+        }
+    }
+
+    fn parse_usage(response: &Value) -> Option<Usage> {
+        let usage = response.get("usage")?;
+        let input_tokens = usage.get("input_tokens")?.as_u64()? as u32;
+        let output_tokens = usage.get("output_tokens")?.as_u64()? as u32;
+        Some(Usage {
+            input_tokens,
+            output_tokens,
+        })
+    }
+
+    fn parse_output_item(item: &Value) -> Vec<ContentBlock> {
+        match item.get("type").and_then(Value::as_str) {
+            Some("message") => {
+                item.get("content")
+                    .and_then(Value::as_array)
+                    .map(|content| {
+                        content
+                            .iter()
+                            .filter_map(|part| match part.get("type").and_then(Value::as_str) {
+                                Some("output_text") => part
+                                    .get("text")
+                                    .and_then(Value::as_str)
+                                    .map(|text| ContentBlock::Text {
+                                        text: text.to_string(),
+                                    }),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            }
+            Some("function_call") => {
+                let call_id = item
+                    .get("call_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let name = item
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let input = item
+                    .get("arguments")
+                    .and_then(Value::as_str)
+                    .and_then(|raw| serde_json::from_str(raw).ok())
+                    .unwrap_or_else(|| serde_json::json!({}));
+                if call_id.is_empty() || name.is_empty() {
+                    Vec::new()
+                } else {
+                    vec![ContentBlock::ToolUse {
+                        id: call_id,
+                        name,
+                        input,
+                    }]
+                }
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn parse_non_streaming_response(body: &Value) -> LlmResponse {
+        let output = body
+            .get("output")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .flat_map(Self::parse_output_item)
+            .collect::<Vec<_>>();
+
+        LlmResponse {
+            content: output,
+            model: body
+                .get("model")
+                .and_then(Value::as_str)
+                .unwrap_or(DEFAULT_MODEL)
+                .to_string(),
+            usage: Self::parse_usage(body),
+            stop_reason: body
+                .get("status")
+                .and_then(Value::as_str)
+                .map(|s| s.to_string()),
+        }
+    }
+
+    fn response_from_stream_events(
+        &self,
+        request: &LlmRequest,
+        events: &[StreamEvent],
+    ) -> LlmResponse {
+        let model = if request.model.trim().is_empty() {
+            self.model.clone()
+        } else {
+            request.model.trim().to_string()
+        };
+
+        let mut content = Vec::new();
+        let mut text = String::new();
+        let mut usage = None;
+        let mut stop_reason = None;
+        let mut pending_tool: Option<(String, String, String)> = None;
+
+        for event in events {
+            match event {
+                StreamEvent::TextDelta(delta) => {
+                    text.push_str(delta);
+                }
+                StreamEvent::ToolUseStart { id, name, .. } => {
+                    if !text.is_empty() {
+                        content.push(ContentBlock::Text {
+                            text: std::mem::take(&mut text),
+                        });
+                    }
+                    pending_tool = Some((id.clone(), name.clone(), String::new()));
+                }
+                StreamEvent::InputJsonDelta(delta) => {
+                    if let Some((_, _, arguments)) = pending_tool.as_mut() {
+                        arguments.push_str(delta);
+                    }
+                }
+                StreamEvent::ContentBlockStop { .. } => {
+                    if let Some((id, name, arguments)) = pending_tool.take() {
+                        let input = serde_json::from_str(&arguments)
+                            .unwrap_or_else(|_| serde_json::json!({}));
+                        content.push(ContentBlock::ToolUse { id, name, input });
+                    }
+                }
+                StreamEvent::MessageDelta {
+                    stop_reason: next_stop_reason,
+                    usage: next_usage,
+                } => {
+                    if next_stop_reason.is_some() {
+                        stop_reason = next_stop_reason.clone();
+                    }
+                    if next_usage.is_some() {
+                        usage = next_usage.clone();
+                    }
+                }
+                StreamEvent::MessageStop => {}
+            }
+        }
+
+        if !text.is_empty() {
+            content.push(ContentBlock::Text { text });
+        }
+        if let Some((id, name, arguments)) = pending_tool.take() {
+            let input = serde_json::from_str(&arguments).unwrap_or_else(|_| serde_json::json!({}));
+            content.push(ContentBlock::ToolUse { id, name, input });
+        }
+
+        LlmResponse {
+            content,
+            model,
+            usage,
+            stop_reason,
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for CodexProvider {
+    fn provider_id(&self) -> &str {
+        "codex"
+    }
+
+    fn configured_model(&self) -> Option<&str> {
+        Some(&self.model)
+    }
+
+    #[instrument(skip(self, request), fields(model))]
+    async fn complete(&self, request: &LlmRequest) -> Result<LlmResponse> {
+        let response = self.send_responses_request(request, false).await?;
+        let status = response.status();
+        let body = response
+            .json::<Value>()
+            .await
+            .map_err(|e| Error::Agent(format!("failed to parse codex response body: {e}")))?;
+
+        if !status.is_success() {
+            return Err(Error::Agent(format!(
+                "codex request failed ({status}): {body}"
+            )));
+        }
+
+        Ok(Self::parse_non_streaming_response(&body))
+    }
+
+    async fn stream_complete(
+        &self,
+        request: &LlmRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamEvent>> + Send>>> {
+        let response = self.send_responses_request(request, true).await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(Error::Agent(format!(
+                "codex streaming request failed ({status}): {body}"
+            )));
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| Error::Agent(format!("failed to read codex SSE body: {e}")))?;
+        let events = parse_sse_events(bytes.as_ref())?;
+        Ok(Box::pin(stream::iter(events.into_iter().map(Ok))))
+    }
+
+    async fn available_models(&self) -> Result<Vec<String>> {
+        let auth = self.ensure_access_token().await?;
+        let token = auth
+            .access_token
+            .ok_or_else(|| Error::Agent("codex access token missing".to_string()))?;
+        let mut request = self
+            .client
+            .get(format!(
+                "{}?client_version={MODELS_CLIENT_VERSION}",
+                self.models_endpoint()
+            ))
+            .bearer_auth(token);
+        if let Some(account_id) = auth.account_id {
+            request = request.header("chatgpt-account-id", account_id);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|e| Error::Agent(format!("failed to load codex models: {e}")))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(Error::Agent(format!(
+                "failed to load codex models ({status}): {body}"
+            )));
+        }
+
+        let body = response
+            .json::<Value>()
+            .await
+            .map_err(|e| Error::Agent(format!("failed to parse codex models response: {e}")))?;
+
+        Ok(body
+            .get("models")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|model| model.get("slug").and_then(Value::as_str))
+            .map(|slug| slug.to_string())
+            .collect())
+    }
+
+    async fn health_check(&self) -> Result<bool> {
+        Ok(self.ensure_access_token().await.is_ok())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RefreshResponse {
+    id_token: Option<String>,
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+}
+
+fn message_item(role: &str, content: Vec<Value>) -> Value {
+    serde_json::json!({
+        "type": "message",
+        "role": role,
+        "content": content,
+    })
+}
+
+fn message_output_item(role: &str, content: Vec<Value>) -> Value {
+    serde_json::json!({
+        "type": "message",
+        "role": role,
+        "content": content,
+    })
+}
+
+fn input_text(text: &str) -> Value {
+    serde_json::json!({
+        "type": "input_text",
+        "text": text,
+    })
+}
+
+fn output_text(text: &str) -> Value {
+    serde_json::json!({
+        "type": "output_text",
+        "text": text,
+    })
+}
+
+fn input_image(url: &str) -> Value {
+    serde_json::json!({
+        "type": "input_image",
+        "image_url": url,
+    })
+}
+
+pub fn parse_codex_id_token_claims(token: &str) -> std::result::Result<CodexOAuthClaims, String> {
+    use base64::Engine;
+
+    let mut parts = token.split('.');
+    let (_header, payload, _sig) = match (parts.next(), parts.next(), parts.next()) {
+        (Some(h), Some(p), Some(s)) if !h.is_empty() && !p.is_empty() && !s.is_empty() => (h, p, s),
+        _ => return Err("invalid id token format".to_string()),
+    };
+
+    let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|e| format!("failed to decode id token payload: {e}"))?;
+    let payload: Value = serde_json::from_slice(&payload_bytes)
+        .map_err(|e| format!("failed to parse id token payload: {e}"))?;
+
+    let auth = payload
+        .get("https://api.openai.com/auth")
+        .and_then(Value::as_object);
+    let profile = payload
+        .get("https://api.openai.com/profile")
+        .and_then(Value::as_object);
+
+    Ok(CodexOAuthClaims {
+        email: payload
+            .get("email")
+            .and_then(Value::as_str)
+            .map(|s| s.to_string())
+            .or_else(|| {
+                profile
+                    .and_then(|profile| profile.get("email"))
+                    .and_then(Value::as_str)
+                    .map(|s| s.to_string())
+            }),
+        account_id: auth
+            .and_then(|auth| auth.get("chatgpt_account_id"))
+            .and_then(Value::as_str)
+            .map(|s| s.to_string()),
+        user_id: auth
+            .and_then(|auth| auth.get("chatgpt_user_id").or_else(|| auth.get("user_id")))
+            .and_then(Value::as_str)
+            .map(|s| s.to_string()),
+        plan_type: auth
+            .and_then(|auth| auth.get("chatgpt_plan_type"))
+            .and_then(Value::as_str)
+            .map(|s| s.to_string()),
+    })
+}
+
+fn parse_sse_events(bytes: &[u8]) -> Result<Vec<StreamEvent>> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|e| Error::Agent(format!("invalid UTF-8 in codex SSE body: {e}")))?;
+    let mut out = Vec::new();
+    let mut saw_text_delta = false;
+
+    for chunk in text.split("\n\n") {
+        let chunk = chunk.trim();
+        if chunk.is_empty() {
+            continue;
+        }
+
+        let mut event_name = None::<String>;
+        let mut data_lines = Vec::new();
+        for line in chunk.lines() {
+            if let Some(rest) = line.strip_prefix("event:") {
+                event_name = Some(rest.trim().to_string());
+            } else if let Some(rest) = line.strip_prefix("data:") {
+                data_lines.push(rest.trim_start().to_string());
+            }
+        }
+
+        let Some(kind) = event_name else {
+            continue;
+        };
+
+        let payload = if data_lines.is_empty() {
+            None
+        } else {
+            let joined = data_lines.join("\n");
+            Some(
+                serde_json::from_str::<Value>(&joined)
+                    .map_err(|e| Error::Agent(format!("failed to parse codex SSE payload: {e}")))?,
+            )
+        };
+
+        match kind.as_str() {
+            "response.output_text.delta" => {
+                if let Some(delta) = payload
+                    .as_ref()
+                    .and_then(|v| v.get("delta"))
+                    .and_then(Value::as_str)
+                {
+                    saw_text_delta = true;
+                    out.push(StreamEvent::TextDelta(delta.to_string()));
+                }
+            }
+            "response.output_item.done" => {
+                let Some(item) = payload.as_ref().and_then(|v| v.get("item")) else {
+                    continue;
+                };
+                match item.get("type").and_then(Value::as_str) {
+                    Some("function_call") => {
+                        let id = item
+                            .get("call_id")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string();
+                        let name = item
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default()
+                            .to_string();
+                        let arguments = item
+                            .get("arguments")
+                            .and_then(Value::as_str)
+                            .unwrap_or("{}")
+                            .to_string();
+                        if !id.is_empty() && !name.is_empty() {
+                            out.push(StreamEvent::ToolUseStart { index: 0, id, name });
+                            out.push(StreamEvent::InputJsonDelta(arguments));
+                            out.push(StreamEvent::ContentBlockStop { index: 0 });
+                        }
+                    }
+                    Some("message") if !saw_text_delta => {
+                        if let Some(content) = item.get("content").and_then(Value::as_array) {
+                            let text = content
+                                .iter()
+                                .filter(|part| {
+                                    part.get("type").and_then(Value::as_str) == Some("output_text")
+                                })
+                                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                                .collect::<String>();
+                            if !text.is_empty() {
+                                out.push(StreamEvent::TextDelta(text));
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            "response.failed" => {
+                let details = payload
+                    .as_ref()
+                    .and_then(|v| v.get("response"))
+                    .and_then(|v| v.get("error"))
+                    .and_then(|v| v.get("message"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("codex response failed");
+                return Err(Error::Agent(details.to_string()));
+            }
+            "response.completed" => {
+                let usage = payload
+                    .as_ref()
+                    .and_then(|v| v.get("response"))
+                    .and_then(CodexProvider::parse_usage);
+                out.push(StreamEvent::MessageDelta {
+                    stop_reason: Some("end_turn".to_string()),
+                    usage,
+                });
+                out.push(StreamEvent::MessageStop);
+            }
+            _ => {}
+        }
+    }
+
+    if !out
+        .iter()
+        .any(|event| matches!(event, StreamEvent::MessageStop))
+    {
+        warn!("codex SSE stream ended without response.completed");
+        out.push(StreamEvent::MessageStop);
+    }
+
+    Ok(out)
+}

--- a/crates/opencrust-agents/src/codex.rs
+++ b/crates/opencrust-agents/src/codex.rs
@@ -253,7 +253,7 @@ impl CodexProvider {
                 }
             }
             (ChatRole::Assistant, MessagePart::Text(text)) => {
-                input.push(message_output_item("assistant", vec![output_text(text)]));
+                input.push(message_item("assistant", vec![output_text(text)]));
             }
             (ChatRole::Assistant, MessagePart::Parts(parts)) => {
                 let mut content = Vec::new();
@@ -276,7 +276,7 @@ impl CodexProvider {
                     }
                 }
                 if !content.is_empty() {
-                    input.push(message_output_item("assistant", content));
+                    input.push(message_item("assistant", content));
                 }
             }
             (ChatRole::Tool, MessagePart::Text(text)) => {
@@ -475,14 +475,6 @@ struct RefreshResponse {
 }
 
 fn message_item(role: &str, content: Vec<Value>) -> Value {
-    serde_json::json!({
-        "type": "message",
-        "role": role,
-        "content": content,
-    })
-}
-
-fn message_output_item(role: &str, content: Vec<Value>) -> Value {
     serde_json::json!({
         "type": "message",
         "role": role,

--- a/crates/opencrust-agents/src/codex.rs
+++ b/crates/opencrust-agents/src/codex.rs
@@ -48,6 +48,7 @@ pub struct CodexProvider {
     client: reqwest::Client,
     model: String,
     base_url: String,
+    oauth_issuer: String,
     auth: Arc<RwLock<CodexAuthState>>,
 }
 
@@ -57,6 +58,7 @@ impl CodexProvider {
             client: reqwest::Client::new(),
             model: model.unwrap_or_else(|| DEFAULT_MODEL.to_string()),
             base_url: base_url.unwrap_or_else(|| DEFAULT_BASE_URL.to_string()),
+            oauth_issuer: OAUTH_ISSUER.to_string(),
             auth: Arc::new(RwLock::new(CodexAuthState {
                 access_token: auth.access_token.filter(|v| !v.trim().is_empty()),
                 refresh_token: auth.refresh_token.filter(|v| !v.trim().is_empty()),
@@ -94,7 +96,10 @@ impl CodexProvider {
 
         let response = self
             .client
-            .post(format!("{OAUTH_ISSUER}/oauth/token"))
+            .post(format!(
+                "{}/oauth/token",
+                self.oauth_issuer.trim_end_matches('/')
+            ))
             .header("content-type", "application/json")
             .json(&serde_json::json!({
                 "client_id": OAUTH_CLIENT_ID,
@@ -676,4 +681,202 @@ fn parse_sse_events(bytes: &[u8]) -> Result<Vec<StreamEvent>> {
     }
 
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Json, Router, http::StatusCode, routing::post};
+    use base64::Engine;
+    use std::net::SocketAddr;
+    use tokio::net::TcpListener;
+
+    fn test_provider(auth: CodexAuthConfig) -> CodexProvider {
+        CodexProvider {
+            client: reqwest::Client::new(),
+            model: DEFAULT_MODEL.to_string(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+            oauth_issuer: OAUTH_ISSUER.to_string(),
+            auth: Arc::new(RwLock::new(CodexAuthState {
+                access_token: auth.access_token,
+                refresh_token: auth.refresh_token,
+                account_id: auth.account_id,
+                id_token: auth.id_token,
+            })),
+        }
+    }
+
+    fn id_token_with_account(account_id: &str) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(r#"{"alg":"none"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(
+            r#"{{"https://api.openai.com/auth":{{"chatgpt_account_id":"{account_id}","chatgpt_user_id":"user-123","chatgpt_plan_type":"plus"}}}}"#
+        ));
+        format!("{header}.{payload}.signature")
+    }
+
+    async fn spawn_test_server(app: Router) -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let addr = listener.local_addr().expect("test listener addr");
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("run test server");
+        });
+        addr
+    }
+
+    #[test]
+    fn parse_sse_events_parses_text_tool_and_usage() {
+        let body = concat!(
+            "event: response.output_text.delta\n",
+            "data: {\"delta\":\"Hello\"}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"item\":{\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"lookup\",\"arguments\":\"{\\\"city\\\":\\\"Paris\\\"}\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"response\":{\"usage\":{\"input_tokens\":12,\"output_tokens\":34}}}\n\n"
+        );
+
+        let events = parse_sse_events(body.as_bytes()).expect("parse SSE events");
+
+        assert_eq!(events.len(), 6);
+        assert!(matches!(&events[0], StreamEvent::TextDelta(text) if text == "Hello"));
+        assert!(matches!(
+            &events[1],
+            StreamEvent::ToolUseStart { index: 0, id, name }
+            if id == "call-1" && name == "lookup"
+        ));
+        assert!(matches!(
+            &events[2],
+            StreamEvent::InputJsonDelta(arguments) if arguments == "{\"city\":\"Paris\"}"
+        ));
+        assert!(matches!(
+            &events[3],
+            StreamEvent::ContentBlockStop { index: 0 }
+        ));
+        assert!(matches!(
+            &events[4],
+            StreamEvent::MessageDelta {
+                stop_reason: Some(reason),
+                usage: Some(Usage {
+                    input_tokens: 12,
+                    output_tokens: 34,
+                }),
+            } if reason == "end_turn"
+        ));
+        assert!(matches!(&events[5], StreamEvent::MessageStop));
+    }
+
+    #[test]
+    fn parse_sse_events_uses_message_text_when_no_delta_arrives() {
+        let body = concat!(
+            "event: response.output_item.done\n",
+            "data: {\"item\":{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"Hello \"},{\"type\":\"output_text\",\"text\":\"world\"}]}}\n\n",
+            "event: response.completed\n",
+            "data: {\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n"
+        );
+
+        let events = parse_sse_events(body.as_bytes()).expect("parse SSE events");
+
+        assert!(matches!(
+            &events[0],
+            StreamEvent::TextDelta(text) if text == "Hello world"
+        ));
+        assert!(matches!(events.last(), Some(StreamEvent::MessageStop)));
+    }
+
+    #[test]
+    fn parse_sse_events_returns_error_for_failed_response() {
+        let body = concat!(
+            "event: response.failed\n",
+            "data: {\"response\":{\"error\":{\"message\":\"model exploded\"}}}\n\n"
+        );
+
+        let err = parse_sse_events(body.as_bytes()).expect_err("failed response should error");
+
+        assert!(err.to_string().contains("model exploded"));
+    }
+
+    #[test]
+    fn parse_sse_events_adds_message_stop_when_completed_missing() {
+        let body = concat!(
+            "event: response.output_text.delta\n",
+            "data: {\"delta\":\"partial\"}\n\n"
+        );
+
+        let events = parse_sse_events(body.as_bytes()).expect("parse SSE events");
+
+        assert_eq!(events.len(), 2);
+        assert!(matches!(&events[0], StreamEvent::TextDelta(text) if text == "partial"));
+        assert!(matches!(&events[1], StreamEvent::MessageStop));
+    }
+
+    #[tokio::test]
+    async fn refresh_access_token_updates_tokens_and_account_id() {
+        let next_id_token = id_token_with_account("acct-456");
+        let app = Router::new().route(
+            "/oauth/token",
+            post({
+                let next_id_token = next_id_token.clone();
+                move || async move {
+                    Json(serde_json::json!({
+                        "access_token": "next-access",
+                        "refresh_token": "next-refresh",
+                        "id_token": next_id_token,
+                    }))
+                }
+            }),
+        );
+        let addr = spawn_test_server(app).await;
+        let provider = CodexProvider {
+            oauth_issuer: format!("http://{addr}"),
+            ..test_provider(CodexAuthConfig {
+                access_token: Some("old-access".to_string()),
+                refresh_token: Some("old-refresh".to_string()),
+                account_id: None,
+                id_token: None,
+            })
+        };
+
+        let auth = provider
+            .refresh_access_token()
+            .await
+            .expect("refresh should succeed");
+
+        assert_eq!(auth.access_token.as_deref(), Some("next-access"));
+        assert_eq!(auth.refresh_token.as_deref(), Some("next-refresh"));
+        assert_eq!(auth.account_id.as_deref(), Some("acct-456"));
+        assert_eq!(auth.id_token.as_deref(), Some(next_id_token.as_str()));
+
+        let stored = provider.read_auth();
+        assert_eq!(stored.access_token, auth.access_token);
+        assert_eq!(stored.refresh_token, auth.refresh_token);
+        assert_eq!(stored.account_id, auth.account_id);
+        assert_eq!(stored.id_token, auth.id_token);
+    }
+
+    #[tokio::test]
+    async fn refresh_access_token_surfaces_http_error_body() {
+        let app = Router::new().route(
+            "/oauth/token",
+            post(|| async move { (StatusCode::UNAUTHORIZED, "invalid_grant") }),
+        );
+        let addr = spawn_test_server(app).await;
+        let provider = CodexProvider {
+            oauth_issuer: format!("http://{addr}"),
+            ..test_provider(CodexAuthConfig {
+                access_token: None,
+                refresh_token: Some("stale-refresh".to_string()),
+                account_id: None,
+                id_token: None,
+            })
+        };
+
+        let err = provider
+            .refresh_access_token()
+            .await
+            .expect_err("refresh should fail");
+
+        assert!(err.to_string().contains("401 Unauthorized"));
+        assert!(err.to_string().contains("invalid_grant"));
+    }
 }

--- a/crates/opencrust-agents/src/codex.rs
+++ b/crates/opencrust-agents/src/codex.rs
@@ -68,6 +68,19 @@ impl CodexProvider {
         }
     }
 
+    #[cfg(test)]
+    fn new_for_test(
+        auth: CodexAuthConfig,
+        base_url: Option<String>,
+        oauth_issuer: Option<String>,
+    ) -> Self {
+        let mut provider = Self::new(auth, None, base_url);
+        if let Some(oauth_issuer) = oauth_issuer {
+            provider.oauth_issuer = oauth_issuer;
+        }
+        provider
+    }
+
     fn responses_endpoint(&self) -> String {
         format!("{}/responses", self.base_url.trim_end_matches('/'))
     }
@@ -772,21 +785,6 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
 
-    fn test_provider(auth: CodexAuthConfig) -> CodexProvider {
-        CodexProvider {
-            client: reqwest::Client::new(),
-            model: DEFAULT_MODEL.to_string(),
-            base_url: DEFAULT_BASE_URL.to_string(),
-            oauth_issuer: OAUTH_ISSUER.to_string(),
-            auth: Arc::new(RwLock::new(CodexAuthState {
-                access_token: auth.access_token,
-                refresh_token: auth.refresh_token,
-                account_id: auth.account_id,
-                id_token: auth.id_token,
-            })),
-        }
-    }
-
     fn id_token_with_account(account_id: &str) -> String {
         let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(r#"{"alg":"none"}"#);
         let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(format!(
@@ -908,15 +906,16 @@ mod tests {
             }),
         );
         let addr = spawn_test_server(app).await;
-        let provider = CodexProvider {
-            oauth_issuer: format!("http://{addr}"),
-            ..test_provider(CodexAuthConfig {
+        let provider = CodexProvider::new_for_test(
+            CodexAuthConfig {
                 access_token: Some("old-access".to_string()),
                 refresh_token: Some("old-refresh".to_string()),
                 account_id: None,
                 id_token: None,
-            })
-        };
+            },
+            None,
+            Some(format!("http://{addr}")),
+        );
 
         let auth = provider
             .refresh_access_token()
@@ -942,15 +941,16 @@ mod tests {
             post(|| async move { (StatusCode::UNAUTHORIZED, "invalid_grant") }),
         );
         let addr = spawn_test_server(app).await;
-        let provider = CodexProvider {
-            oauth_issuer: format!("http://{addr}"),
-            ..test_provider(CodexAuthConfig {
+        let provider = CodexProvider::new_for_test(
+            CodexAuthConfig {
                 access_token: None,
                 refresh_token: Some("stale-refresh".to_string()),
                 account_id: None,
                 id_token: None,
-            })
-        };
+            },
+            None,
+            Some(format!("http://{addr}")),
+        );
 
         let err = provider
             .refresh_access_token()
@@ -991,15 +991,16 @@ mod tests {
             }),
         );
         let addr = spawn_test_server(app).await;
-        let provider = CodexProvider {
-            base_url: format!("http://{addr}"),
-            ..test_provider(CodexAuthConfig {
+        let provider = CodexProvider::new_for_test(
+            CodexAuthConfig {
                 access_token: Some("access-token".to_string()),
                 refresh_token: None,
                 account_id: None,
                 id_token: None,
-            })
-        };
+            },
+            Some(format!("http://{addr}")),
+            None,
+        );
         let request = LlmRequest {
             model: String::new(),
             messages: vec![ChatMessage {

--- a/crates/opencrust-agents/src/codex.rs
+++ b/crates/opencrust-agents/src/codex.rs
@@ -1,9 +1,9 @@
 use std::pin::Pin;
 use std::sync::{Arc, RwLock};
+use std::{collections::VecDeque, str};
 
 use async_trait::async_trait;
-use futures::Stream;
-use futures::stream;
+use futures::{Stream, StreamExt};
 use opencrust_common::{Error, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -417,12 +417,83 @@ impl LlmProvider for CodexProvider {
             )));
         }
 
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| Error::Agent(format!("failed to read codex SSE body: {e}")))?;
-        let events = parse_sse_events(bytes.as_ref())?;
-        Ok(Box::pin(stream::iter(events.into_iter().map(Ok))))
+        let byte_stream: Pin<
+            Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>,
+        > = Box::pin(response.bytes_stream());
+
+        let event_stream = futures::stream::unfold(
+            (
+                byte_stream,
+                String::new(),
+                false,
+                false,
+                VecDeque::<Result<StreamEvent>>::new(),
+            ),
+            |(mut stream, mut buffer, mut saw_text_delta, mut saw_message_stop, mut pending)| async move {
+                loop {
+                    if let Some(next) = pending.pop_front() {
+                        return Some((
+                            next,
+                            (stream, buffer, saw_text_delta, saw_message_stop, pending),
+                        ));
+                    }
+
+                    if let Some(pos) = buffer.find("\n\n") {
+                        let chunk = buffer[..pos].to_string();
+                        buffer = buffer[pos + 2..].to_string();
+
+                        match parse_sse_chunk(&chunk, &mut saw_text_delta) {
+                            Ok(events) => {
+                                for event in events {
+                                    if matches!(event, StreamEvent::MessageStop) {
+                                        saw_message_stop = true;
+                                    }
+                                    pending.push_back(Ok(event));
+                                }
+                                continue;
+                            }
+                            Err(err) => {
+                                return Some((
+                                    Err(err),
+                                    (stream, buffer, saw_text_delta, true, pending),
+                                ));
+                            }
+                        }
+                    }
+
+                    match stream.next().await {
+                        Some(Ok(bytes)) => match str::from_utf8(&bytes) {
+                            Ok(text) => buffer.push_str(text),
+                            Err(e) => {
+                                return Some((
+                                    Err(Error::Agent(format!(
+                                        "invalid UTF-8 in codex SSE body: {e}"
+                                    ))),
+                                    (stream, buffer, saw_text_delta, true, pending),
+                                ));
+                            }
+                        },
+                        Some(Err(e)) => {
+                            return Some((
+                                Err(Error::Agent(format!("failed to read codex SSE body: {e}"))),
+                                (stream, buffer, saw_text_delta, true, pending),
+                            ));
+                        }
+                        None if !saw_message_stop => {
+                            warn!("codex SSE stream ended without response.completed");
+                            saw_message_stop = true;
+                            return Some((
+                                Ok(StreamEvent::MessageStop),
+                                (stream, buffer, saw_text_delta, saw_message_stop, pending),
+                            ));
+                        }
+                        None => return None,
+                    }
+                }
+            },
+        );
+
+        Ok(Box::pin(event_stream))
     }
 
     async fn available_models(&self) -> Result<Vec<String>> {
@@ -557,7 +628,7 @@ pub fn parse_codex_id_token_claims(token: &str) -> std::result::Result<CodexOAut
 }
 
 fn parse_sse_events(bytes: &[u8]) -> Result<Vec<StreamEvent>> {
-    let text = std::str::from_utf8(bytes)
+    let text = str::from_utf8(bytes)
         .map_err(|e| Error::Agent(format!("invalid UTF-8 in codex SSE body: {e}")))?;
     let mut out = Vec::new();
     let mut saw_text_delta = false;
@@ -567,109 +638,7 @@ fn parse_sse_events(bytes: &[u8]) -> Result<Vec<StreamEvent>> {
         if chunk.is_empty() {
             continue;
         }
-
-        let mut event_name = None::<String>;
-        let mut data_lines = Vec::new();
-        for line in chunk.lines() {
-            if let Some(rest) = line.strip_prefix("event:") {
-                event_name = Some(rest.trim().to_string());
-            } else if let Some(rest) = line.strip_prefix("data:") {
-                data_lines.push(rest.trim_start().to_string());
-            }
-        }
-
-        let Some(kind) = event_name else {
-            continue;
-        };
-
-        let payload = if data_lines.is_empty() {
-            None
-        } else {
-            let joined = data_lines.join("\n");
-            Some(
-                serde_json::from_str::<Value>(&joined)
-                    .map_err(|e| Error::Agent(format!("failed to parse codex SSE payload: {e}")))?,
-            )
-        };
-
-        match kind.as_str() {
-            "response.output_text.delta" => {
-                if let Some(delta) = payload
-                    .as_ref()
-                    .and_then(|v| v.get("delta"))
-                    .and_then(Value::as_str)
-                {
-                    saw_text_delta = true;
-                    out.push(StreamEvent::TextDelta(delta.to_string()));
-                }
-            }
-            "response.output_item.done" => {
-                let Some(item) = payload.as_ref().and_then(|v| v.get("item")) else {
-                    continue;
-                };
-                match item.get("type").and_then(Value::as_str) {
-                    Some("function_call") => {
-                        let id = item
-                            .get("call_id")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default()
-                            .to_string();
-                        let name = item
-                            .get("name")
-                            .and_then(Value::as_str)
-                            .unwrap_or_default()
-                            .to_string();
-                        let arguments = item
-                            .get("arguments")
-                            .and_then(Value::as_str)
-                            .unwrap_or("{}")
-                            .to_string();
-                        if !id.is_empty() && !name.is_empty() {
-                            out.push(StreamEvent::ToolUseStart { index: 0, id, name });
-                            out.push(StreamEvent::InputJsonDelta(arguments));
-                            out.push(StreamEvent::ContentBlockStop { index: 0 });
-                        }
-                    }
-                    Some("message") if !saw_text_delta => {
-                        if let Some(content) = item.get("content").and_then(Value::as_array) {
-                            let text = content
-                                .iter()
-                                .filter(|part| {
-                                    part.get("type").and_then(Value::as_str) == Some("output_text")
-                                })
-                                .filter_map(|part| part.get("text").and_then(Value::as_str))
-                                .collect::<String>();
-                            if !text.is_empty() {
-                                out.push(StreamEvent::TextDelta(text));
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            "response.failed" => {
-                let details = payload
-                    .as_ref()
-                    .and_then(|v| v.get("response"))
-                    .and_then(|v| v.get("error"))
-                    .and_then(|v| v.get("message"))
-                    .and_then(Value::as_str)
-                    .unwrap_or("codex response failed");
-                return Err(Error::Agent(details.to_string()));
-            }
-            "response.completed" => {
-                let usage = payload
-                    .as_ref()
-                    .and_then(|v| v.get("response"))
-                    .and_then(CodexProvider::parse_usage);
-                out.push(StreamEvent::MessageDelta {
-                    stop_reason: Some("end_turn".to_string()),
-                    usage,
-                });
-                out.push(StreamEvent::MessageStop);
-            }
-            _ => {}
-        }
+        out.extend(parse_sse_chunk(chunk, &mut saw_text_delta)?);
     }
 
     if !out
@@ -683,13 +652,125 @@ fn parse_sse_events(bytes: &[u8]) -> Result<Vec<StreamEvent>> {
     Ok(out)
 }
 
+fn parse_sse_chunk(chunk: &str, saw_text_delta: &mut bool) -> Result<Vec<StreamEvent>> {
+    let mut event_name = None::<String>;
+    let mut data_lines = Vec::new();
+    for line in chunk.lines() {
+        if let Some(rest) = line.strip_prefix("event:") {
+            event_name = Some(rest.trim().to_string());
+        } else if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.trim_start().to_string());
+        }
+    }
+
+    let Some(kind) = event_name else {
+        return Ok(Vec::new());
+    };
+
+    let payload = if data_lines.is_empty() {
+        None
+    } else {
+        let joined = data_lines.join("\n");
+        Some(
+            serde_json::from_str::<Value>(&joined)
+                .map_err(|e| Error::Agent(format!("failed to parse codex SSE payload: {e}")))?,
+        )
+    };
+
+    let mut out = Vec::new();
+    match kind.as_str() {
+        "response.output_text.delta" => {
+            if let Some(delta) = payload
+                .as_ref()
+                .and_then(|v| v.get("delta"))
+                .and_then(Value::as_str)
+            {
+                *saw_text_delta = true;
+                out.push(StreamEvent::TextDelta(delta.to_string()));
+            }
+        }
+        "response.output_item.done" => {
+            let Some(item) = payload.as_ref().and_then(|v| v.get("item")) else {
+                return Ok(out);
+            };
+            match item.get("type").and_then(Value::as_str) {
+                Some("function_call") => {
+                    let id = item
+                        .get("call_id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let name = item
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string();
+                    let arguments = item
+                        .get("arguments")
+                        .and_then(Value::as_str)
+                        .unwrap_or("{}")
+                        .to_string();
+                    if !id.is_empty() && !name.is_empty() {
+                        out.push(StreamEvent::ToolUseStart { index: 0, id, name });
+                        out.push(StreamEvent::InputJsonDelta(arguments));
+                        out.push(StreamEvent::ContentBlockStop { index: 0 });
+                    }
+                }
+                Some("message") if !*saw_text_delta => {
+                    if let Some(content) = item.get("content").and_then(Value::as_array) {
+                        let text = content
+                            .iter()
+                            .filter(|part| {
+                                part.get("type").and_then(Value::as_str) == Some("output_text")
+                            })
+                            .filter_map(|part| part.get("text").and_then(Value::as_str))
+                            .collect::<String>();
+                        if !text.is_empty() {
+                            out.push(StreamEvent::TextDelta(text));
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        "response.failed" => {
+            let details = payload
+                .as_ref()
+                .and_then(|v| v.get("response"))
+                .and_then(|v| v.get("error"))
+                .and_then(|v| v.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("codex response failed");
+            return Err(Error::Agent(details.to_string()));
+        }
+        "response.completed" => {
+            let usage = payload
+                .as_ref()
+                .and_then(|v| v.get("response"))
+                .and_then(CodexProvider::parse_usage);
+            out.push(StreamEvent::MessageDelta {
+                stop_reason: Some("end_turn".to_string()),
+                usage,
+            });
+            out.push(StreamEvent::MessageStop);
+        }
+        _ => {}
+    }
+
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::{Json, Router, http::StatusCode, routing::post};
+    use axum::{Json, Router, body::Body, http::StatusCode, response::Response, routing::post};
     use base64::Engine;
+    use bytes::Bytes;
     use std::net::SocketAddr;
+    use std::{convert::Infallible, time::Duration};
     use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+    use tokio_stream::wrappers::ReceiverStream;
 
     fn test_provider(auth: CodexAuthConfig) -> CodexProvider {
         CodexProvider {
@@ -878,5 +959,92 @@ mod tests {
 
         assert!(err.to_string().contains("401 Unauthorized"));
         assert!(err.to_string().contains("invalid_grant"));
+    }
+
+    #[tokio::test]
+    async fn stream_complete_yields_events_before_body_finishes() {
+        let app = Router::new().route(
+            "/responses",
+            post(|| async move {
+                let (tx, rx) = mpsc::channel::<std::result::Result<Bytes, Infallible>>(4);
+                tokio::spawn(async move {
+                    tx.send(Ok(Bytes::from(concat!(
+                        "event: response.output_text.delta\n",
+                        "data: {\"delta\":\"Hello\"}\n\n"
+                    ))))
+                    .await
+                    .expect("send first SSE chunk");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    tx.send(Ok(Bytes::from(concat!(
+                        "event: response.completed\n",
+                        "data: {\"response\":{\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n"
+                    ))))
+                    .await
+                    .expect("send completed SSE chunk");
+                });
+
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header("content-type", "text/event-stream")
+                    .body(Body::from_stream(ReceiverStream::new(rx)))
+                    .expect("build SSE response")
+            }),
+        );
+        let addr = spawn_test_server(app).await;
+        let provider = CodexProvider {
+            base_url: format!("http://{addr}"),
+            ..test_provider(CodexAuthConfig {
+                access_token: Some("access-token".to_string()),
+                refresh_token: None,
+                account_id: None,
+                id_token: None,
+            })
+        };
+        let request = LlmRequest {
+            model: String::new(),
+            messages: vec![ChatMessage {
+                role: ChatRole::User,
+                content: MessagePart::Text("ping".to_string()),
+            }],
+            system: None,
+            max_tokens: Some(4),
+            temperature: None,
+            tools: Vec::new(),
+        };
+
+        let mut stream = provider
+            .stream_complete(&request)
+            .await
+            .expect("stream should start");
+
+        let first = tokio::time::timeout(Duration::from_millis(50), stream.next())
+            .await
+            .expect("first event should arrive before completion chunk")
+            .expect("stream should yield first event")
+            .expect("first event should be ok");
+        assert!(matches!(first, StreamEvent::TextDelta(text) if text == "Hello"));
+
+        let second = tokio::time::timeout(Duration::from_millis(250), stream.next())
+            .await
+            .expect("completion metadata should arrive")
+            .expect("stream should yield second event")
+            .expect("second event should be ok");
+        assert!(matches!(
+            second,
+            StreamEvent::MessageDelta {
+                stop_reason: Some(reason),
+                usage: Some(Usage {
+                    input_tokens: 1,
+                    output_tokens: 2,
+                }),
+            } if reason == "end_turn"
+        ));
+
+        let third = tokio::time::timeout(Duration::from_millis(50), stream.next())
+            .await
+            .expect("message stop should follow immediately")
+            .expect("stream should yield message stop")
+            .expect("message stop should be ok");
+        assert!(matches!(third, StreamEvent::MessageStop));
     }
 }

--- a/crates/opencrust-agents/src/lib.rs
+++ b/crates/opencrust-agents/src/lib.rs
@@ -3,6 +3,7 @@ pub mod mcp;
 
 pub mod a2a;
 pub mod anthropic;
+pub mod codex;
 pub mod embeddings;
 pub mod ollama;
 pub mod openai;
@@ -11,6 +12,7 @@ pub mod runtime;
 pub mod tools;
 
 pub use anthropic::AnthropicProvider;
+pub use codex::{CodexAuthConfig, CodexOAuthClaims, CodexProvider, parse_codex_id_token_claims};
 pub use embeddings::{CohereEmbeddingProvider, EmbeddingProvider, OllamaEmbeddingProvider};
 pub use ollama::OllamaProvider;
 pub use openai::OpenAiProvider;

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -226,10 +226,18 @@ impl AgentRuntime {
         {
             let mut default = self.default_provider.write().unwrap();
             if default.is_none() {
-                *default = Some(id);
+                *default = Some(id.clone());
             }
         }
-        self.providers.write().unwrap().push(provider);
+        let mut providers = self.providers.write().unwrap();
+        if let Some(slot) = providers
+            .iter_mut()
+            .find(|existing| existing.provider_id() == id)
+        {
+            *slot = provider;
+            return;
+        }
+        providers.push(provider);
     }
 
     pub fn get_provider(&self, id: &str) -> Option<Arc<dyn LlmProvider>> {

--- a/crates/opencrust-config/src/loader.rs
+++ b/crates/opencrust-config/src/loader.rs
@@ -76,6 +76,26 @@ impl ConfigLoader {
         }
     }
 
+    pub fn save(&self, config: &AppConfig) -> Result<PathBuf> {
+        self.ensure_dirs()?;
+
+        let yaml_path = self.config_dir.join("config.yml");
+        let toml_path = self.config_dir.join("config.toml");
+
+        let (path, encoded) = if yaml_path.exists() || !toml_path.exists() {
+            let yaml = serde_yaml::to_string(config)
+                .map_err(|e| Error::Config(format!("failed to serialize YAML config: {e}")))?;
+            (yaml_path, yaml)
+        } else {
+            let toml = toml::to_string_pretty(config)
+                .map_err(|e| Error::Config(format!("failed to serialize TOML config: {e}")))?;
+            (toml_path, toml)
+        };
+
+        std::fs::write(&path, encoded)?;
+        Ok(path)
+    }
+
     /// Load MCP server configs from `~/.opencrust/mcp.json` (Claude Desktop compatible format).
     /// Returns an empty map if the file does not exist.
     pub fn load_mcp_json(&self) -> HashMap<String, McpServerConfig> {
@@ -295,6 +315,47 @@ mod tests {
         assert!(dir.join("plugins").exists());
         assert!(dir.join("skills").exists());
         assert!(dir.join("data").exists());
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn save_writes_yaml_by_default() {
+        let dir = temp_dir("save-yaml-default");
+        let loader = ConfigLoader::with_dir(&dir);
+
+        let mut config = crate::model::AppConfig::default();
+        config.gateway.port = 4003;
+
+        let path = loader.save(&config).expect("save should succeed");
+        assert_eq!(path, dir.join("config.yml"));
+
+        let reloaded = loader.load().expect("load should succeed");
+        assert_eq!(reloaded.gateway.port, 4003);
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn save_preserves_toml_format_when_yaml_missing() {
+        let dir = temp_dir("save-toml");
+        fs::create_dir_all(&dir).expect("failed to create temp dir");
+        fs::write(
+            dir.join("config.toml"),
+            "[gateway]\nhost = \"127.0.0.2\"\nport = 4002\n",
+        )
+        .expect("failed to write toml config");
+
+        let loader = ConfigLoader::with_dir(&dir);
+        let mut config = loader.load().expect("load should succeed");
+        config.gateway.port = 4010;
+
+        let path = loader.save(&config).expect("save should succeed");
+        assert_eq!(path, dir.join("config.toml"));
+        assert!(!dir.join("config.yml").exists());
+
+        let reloaded = loader.load().expect("load should succeed");
+        assert_eq!(reloaded.gateway.port, 4010);
 
         let _ = fs::remove_dir_all(dir);
     }

--- a/crates/opencrust-gateway/Cargo.toml
+++ b/crates/opencrust-gateway/Cargo.toml
@@ -20,6 +20,7 @@ dotenvy = { workspace = true }
 reqwest = { workspace = true, features = ["multipart"] }
 base64 = { workspace = true }
 axum = { workspace = true, features = ["multipart"] }
+ring = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 serde = { workspace = true }

--- a/crates/opencrust-gateway/Cargo.toml
+++ b/crates/opencrust-gateway/Cargo.toml
@@ -25,6 +25,7 @@ tower = { workspace = true }
 tower-http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 dashmap = { workspace = true }

--- a/crates/opencrust-gateway/Cargo.toml
+++ b/crates/opencrust-gateway/Cargo.toml
@@ -25,7 +25,6 @@ tower = { workspace = true }
 tower-http = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 dashmap = { workspace = true }

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use opencrust_agents::tools::Tool;
@@ -47,14 +47,17 @@ pub(crate) fn read_auth_json_secret(key: &str) -> Option<String> {
 }
 
 pub(crate) fn persist_auth_json_secret(key: &str, value: &str) -> bool {
-    let path = default_auth_json_path();
+    persist_auth_json_secret_at(&default_auth_json_path(), key, value)
+}
+
+fn persist_auth_json_secret_at(path: &Path, key: &str, value: &str) -> bool {
     if let Some(parent) = path.parent()
         && std::fs::create_dir_all(parent).is_err()
     {
         return false;
     }
 
-    let mut json = std::fs::read_to_string(&path)
+    let mut json = std::fs::read_to_string(path)
         .ok()
         .and_then(|raw| {
             serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&raw).ok()
@@ -75,7 +78,24 @@ pub(crate) fn persist_auth_json_secret(key: &str, value: &str) -> bool {
         Err(_) => return false,
     };
 
-    std::fs::write(path, format!("{encoded}\n")).is_ok()
+    if std::fs::write(path, format!("{encoded}\n")).is_err() {
+        return false;
+    }
+
+    restrict_auth_json_permissions(path)
+}
+
+#[cfg(unix)]
+fn restrict_auth_json_permissions(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).is_ok()
+}
+
+#[cfg(not(unix))]
+fn restrict_auth_json_permissions(_path: &Path) -> bool {
+    // Platform-specific ACL hardening is not available via the Rust stdlib on non-Unix targets.
+    true
 }
 
 pub(crate) fn upsert_codex_config_entry() -> std::result::Result<(), String> {
@@ -3994,6 +4014,54 @@ mod tests {
             updated.llm.get("main").map(|cfg| cfg.provider.as_str()),
             Some("openai")
         );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn persist_auth_json_secret_writes_file() {
+        let dir = temp_dir("auth-json");
+        fs::create_dir_all(&dir).expect("failed to create temp dir");
+        let path = dir.join("auth.json");
+
+        assert!(persist_auth_json_secret_at(
+            &path,
+            "CODEX_ACCESS_TOKEN",
+            "secret-token"
+        ));
+
+        let raw = fs::read_to_string(&path).expect("auth.json should exist");
+        let json: serde_json::Value = serde_json::from_str(&raw).expect("auth.json should parse");
+        assert_eq!(
+            json.get("CODEX_ACCESS_TOKEN")
+                .and_then(serde_json::Value::as_str),
+            Some("secret-token")
+        );
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persist_auth_json_secret_restricts_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = temp_dir("auth-json-perms");
+        fs::create_dir_all(&dir).expect("failed to create temp dir");
+        let path = dir.join("auth.json");
+
+        assert!(persist_auth_json_secret_at(
+            &path,
+            "CODEX_REFRESH_TOKEN",
+            "secret-token"
+        ));
+
+        let mode = fs::metadata(&path)
+            .expect("auth.json metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
 
         let _ = fs::remove_dir_all(dir);
     }

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -86,9 +86,6 @@ pub(crate) fn upsert_codex_config_entry() -> std::result::Result<(), String> {
 
 fn upsert_codex_config_entry_at(config_dir: &std::path::Path) -> std::result::Result<(), String> {
     let loader = opencrust_config::ConfigLoader::with_dir(config_dir);
-    loader
-        .ensure_dirs()
-        .map_err(|e| format!("failed to prepare config directory: {e}"))?;
 
     let mut config = loader
         .load()
@@ -105,11 +102,9 @@ fn upsert_codex_config_entry_at(config_dir: &std::path::Path) -> std::result::Re
     codex.api_key = None;
     config.llm.insert("codex".to_string(), codex);
 
-    let config_path = config_dir.join("config.yml");
-    let yaml =
-        serde_yaml::to_string(&config).map_err(|e| format!("failed to serialize config: {e}"))?;
-    std::fs::write(&config_path, yaml)
-        .map_err(|e| format!("failed to write {}: {e}", config_path.display()))?;
+    loader
+        .save(&config)
+        .map_err(|e| format!("failed to write config: {e}"))?;
 
     Ok(())
 }
@@ -3984,8 +3979,9 @@ mod tests {
                 extra: HashMap::new(),
             },
         );
-        let yaml = serde_yaml::to_string(&config).expect("serialize config");
-        fs::write(dir.join("config.yml"), yaml).expect("write config");
+        opencrust_config::ConfigLoader::with_dir(&dir)
+            .save(&config)
+            .expect("write config");
 
         upsert_codex_config_entry_at(&dir).expect("upsert codex config");
 

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -32,6 +32,52 @@ pub(crate) fn default_vault_path() -> Option<PathBuf> {
     )
 }
 
+pub(crate) fn default_auth_json_path() -> PathBuf {
+    opencrust_config::ConfigLoader::default_config_dir().join("auth.json")
+}
+
+pub(crate) fn read_auth_json_secret(key: &str) -> Option<String> {
+    let path = default_auth_json_path();
+    let raw = std::fs::read_to_string(path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    json.get(key)
+        .and_then(serde_json::Value::as_str)
+        .map(ToString::to_string)
+        .filter(|value| !value.is_empty())
+}
+
+pub(crate) fn persist_auth_json_secret(key: &str, value: &str) -> bool {
+    let path = default_auth_json_path();
+    if let Some(parent) = path.parent()
+        && std::fs::create_dir_all(parent).is_err()
+    {
+        return false;
+    }
+
+    let mut json = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| {
+            serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&raw).ok()
+        })
+        .unwrap_or_default();
+
+    if value.is_empty() {
+        json.remove(key);
+    } else {
+        json.insert(
+            key.to_string(),
+            serde_json::Value::String(value.to_string()),
+        );
+    }
+
+    let encoded = match serde_json::to_string_pretty(&json) {
+        Ok(encoded) => encoded,
+        Err(_) => return false,
+    };
+
+    std::fs::write(path, format!("{encoded}\n")).is_ok()
+}
+
 fn default_allowlist_path() -> PathBuf {
     opencrust_config::ConfigLoader::default_config_dir().join("allowlist.json")
 }
@@ -69,6 +115,9 @@ fn resolve_secret(
         && let Some(val) = opencrust_security::try_vault_get(&vault_path, vault_credential_key)
     {
         return Some(val);
+    }
+    if let Some(value) = read_auth_json_secret(vault_credential_key) {
+        return Some(value);
     }
     if let Some(value) = config_value
         && !value.is_empty()

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -4,9 +4,10 @@ use std::sync::{Arc, Mutex};
 
 use opencrust_agents::tools::Tool;
 use opencrust_agents::{
-    AgentRuntime, AnthropicProvider, BashTool, ChatMessage, CohereEmbeddingProvider, DocSearchTool,
-    FileReadTool, FileWriteTool, GoogleSearchTool, McpManager, OllamaEmbeddingProvider,
-    OllamaProvider, OpenAiProvider, WebFetchTool, WebSearchTool,
+    AgentRuntime, AnthropicProvider, BashTool, ChatMessage, CodexAuthConfig, CodexProvider,
+    CohereEmbeddingProvider, DocSearchTool, FileReadTool, FileWriteTool, GoogleSearchTool,
+    McpManager, OllamaEmbeddingProvider, OllamaProvider, OpenAiProvider, WebFetchTool,
+    WebSearchTool,
 };
 use opencrust_channels::{
     ChannelResponse, MediaAttachment, SlackChannel, SlackGroupFilter, SlackOnMessageFn,
@@ -57,6 +58,24 @@ pub(crate) fn resolve_api_key(
 
     // 3. Environment variable
     std::env::var(env_var).ok()
+}
+
+fn resolve_secret(
+    config_value: Option<&str>,
+    vault_credential_key: &str,
+    env_var: &str,
+) -> Option<String> {
+    if let Some(vault_path) = default_vault_path()
+        && let Some(val) = opencrust_security::try_vault_get(&vault_path, vault_credential_key)
+    {
+        return Some(val);
+    }
+    if let Some(value) = config_value
+        && !value.is_empty()
+    {
+        return Some(value.to_string());
+    }
+    std::env::var(env_var).ok().filter(|v| !v.is_empty())
 }
 
 /// Build a fully-configured `AgentRuntime` from the application config.
@@ -113,6 +132,54 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
                     OllamaProvider::new(llm_config.model.clone(), llm_config.base_url.clone());
                 runtime.register_provider(Arc::new(provider));
                 info!("configured ollama provider: {name}");
+            }
+            "codex" => {
+                let access_token = resolve_secret(
+                    llm_config
+                        .extra
+                        .get("access_token")
+                        .and_then(|v| v.as_str())
+                        .or(llm_config.api_key.as_deref()),
+                    "CODEX_ACCESS_TOKEN",
+                    "CODEX_ACCESS_TOKEN",
+                );
+                let refresh_token = resolve_secret(
+                    llm_config
+                        .extra
+                        .get("refresh_token")
+                        .and_then(|v| v.as_str()),
+                    "CODEX_REFRESH_TOKEN",
+                    "CODEX_REFRESH_TOKEN",
+                );
+                let account_id = resolve_secret(
+                    llm_config.extra.get("account_id").and_then(|v| v.as_str()),
+                    "CODEX_ACCOUNT_ID",
+                    "CODEX_ACCOUNT_ID",
+                );
+                let id_token = resolve_secret(
+                    llm_config.extra.get("id_token").and_then(|v| v.as_str()),
+                    "CODEX_ID_TOKEN",
+                    "CODEX_ID_TOKEN",
+                );
+
+                if access_token.is_some() || refresh_token.is_some() {
+                    let provider = CodexProvider::new(
+                        CodexAuthConfig {
+                            access_token,
+                            refresh_token,
+                            account_id,
+                            id_token,
+                        },
+                        llm_config.model.clone(),
+                        llm_config.base_url.clone(),
+                    );
+                    runtime.register_provider(Arc::new(provider));
+                    info!("configured codex provider: {name}");
+                } else {
+                    warn!(
+                        "skipping codex provider {name}: no oauth credentials (set CODEX_ACCESS_TOKEN / CODEX_REFRESH_TOKEN or store them in the vault)"
+                    );
+                }
             }
             "sansa" => {
                 let api_key = resolve_api_key(

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -16,7 +16,7 @@ use opencrust_channels::{
 };
 #[cfg(target_os = "macos")]
 use opencrust_channels::{IMessageChannel, IMessageGroupFilter, IMessageOnMessageFn};
-use opencrust_config::AppConfig;
+use opencrust_config::{AppConfig, LlmProviderConfig};
 use opencrust_db::MemoryStore;
 use opencrust_security::{Allowlist, ChannelPolicy, DmAuthResult, PairingManager, check_dm_auth};
 use tracing::{info, warn};
@@ -76,6 +76,42 @@ pub(crate) fn persist_auth_json_secret(key: &str, value: &str) -> bool {
     };
 
     std::fs::write(path, format!("{encoded}\n")).is_ok()
+}
+
+pub(crate) fn upsert_codex_config_entry() -> std::result::Result<(), String> {
+    let loader = opencrust_config::ConfigLoader::new()
+        .map_err(|e| format!("failed to initialize config loader: {e}"))?;
+    upsert_codex_config_entry_at(loader.config_dir())
+}
+
+fn upsert_codex_config_entry_at(config_dir: &std::path::Path) -> std::result::Result<(), String> {
+    let loader = opencrust_config::ConfigLoader::with_dir(config_dir);
+    loader
+        .ensure_dirs()
+        .map_err(|e| format!("failed to prepare config directory: {e}"))?;
+
+    let mut config = loader
+        .load()
+        .map_err(|e| format!("failed to load config: {e}"))?;
+
+    let mut codex = config.llm.remove("codex").unwrap_or(LlmProviderConfig {
+        provider: "codex".to_string(),
+        model: None,
+        api_key: None,
+        base_url: None,
+        extra: std::collections::HashMap::new(),
+    });
+    codex.provider = "codex".to_string();
+    codex.api_key = None;
+    config.llm.insert("codex".to_string(), codex);
+
+    let config_path = config_dir.join("config.yml");
+    let yaml =
+        serde_yaml::to_string(&config).map_err(|e| format!("failed to serialize config: {e}"))?;
+    std::fs::write(&config_path, yaml)
+        .map_err(|e| format!("failed to write {}: {e}", config_path.display()))?;
+
+    Ok(())
 }
 
 fn default_allowlist_path() -> PathBuf {
@@ -3845,6 +3881,22 @@ pub fn build_wechat_channels(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "opencrust-bootstrap-test-{}-{}-{}",
+            label,
+            std::process::id(),
+            nanos
+        ))
+    }
 
     #[test]
     fn build_agent_runtime_empty_config_no_crash() {
@@ -3914,5 +3966,39 @@ mod tests {
     fn resolve_api_key_returns_none_when_all_missing() {
         let result = resolve_api_key(None, "NONEXISTENT_VAULT_KEY", "NONEXISTENT_ENV_VAR_99999");
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn upsert_codex_config_entry_writes_codex_provider() {
+        let dir = temp_dir("codex-config");
+        fs::create_dir_all(&dir).expect("failed to create temp dir");
+
+        let mut config = AppConfig::default();
+        config.llm.insert(
+            "main".to_string(),
+            LlmProviderConfig {
+                provider: "openai".to_string(),
+                model: Some("gpt-5".to_string()),
+                api_key: None,
+                base_url: None,
+                extra: HashMap::new(),
+            },
+        );
+        let yaml = serde_yaml::to_string(&config).expect("serialize config");
+        fs::write(dir.join("config.yml"), yaml).expect("write config");
+
+        upsert_codex_config_entry_at(&dir).expect("upsert codex config");
+
+        let loader = opencrust_config::ConfigLoader::with_dir(&dir);
+        let updated = loader.load().expect("load updated config");
+        let codex = updated.llm.get("codex").expect("codex config present");
+        assert_eq!(codex.provider, "codex");
+        assert_eq!(codex.model, None);
+        assert_eq!(
+            updated.llm.get("main").map(|cfg| cfg.provider.as_str()),
+            Some("openai")
+        );
+
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/crates/opencrust-gateway/src/router.rs
+++ b/crates/opencrust-gateway/src/router.rs
@@ -1801,10 +1801,10 @@ fn persist_api_key(vault_key: &str, value: &str) -> bool {
 }
 
 fn persist_secret(vault_key: &str, value: &str) -> bool {
-    if let Some(vault_path) = crate::bootstrap::default_vault_path() {
-        if opencrust_security::try_vault_set(&vault_path, vault_key, value) {
-            return true;
-        }
+    if let Some(vault_path) = crate::bootstrap::default_vault_path()
+        && opencrust_security::try_vault_set(&vault_path, vault_key, value)
+    {
+        return true;
     }
     if vault_key.starts_with("CODEX_") {
         return crate::bootstrap::persist_auth_json_secret(vault_key, value);

--- a/crates/opencrust-gateway/src/router.rs
+++ b/crates/opencrust-gateway/src/router.rs
@@ -905,7 +905,6 @@ async fn complete_codex_oauth(
         None,
     );
     state.agents.register_provider(Arc::new(provider));
-    state.agents.set_default_provider_id("codex");
 
     let success_message = match email {
         Some(email) => format!("Codex connected for {email}."),

--- a/crates/opencrust-gateway/src/router.rs
+++ b/crates/opencrust-gateway/src/router.rs
@@ -890,6 +890,9 @@ async fn complete_codex_oauth(
     if let Some(account_id) = account_id.as_deref() {
         persist_secret("CODEX_ACCOUNT_ID", account_id);
     }
+    if let Err(err) = crate::bootstrap::upsert_codex_config_entry() {
+        tracing::warn!("failed to persist codex provider config entry: {err}");
+    }
 
     let provider = CodexProvider::new(
         CodexAuthConfig {

--- a/crates/opencrust-gateway/src/router.rs
+++ b/crates/opencrust-gateway/src/router.rs
@@ -1802,7 +1802,12 @@ fn persist_api_key(vault_key: &str, value: &str) -> bool {
 
 fn persist_secret(vault_key: &str, value: &str) -> bool {
     if let Some(vault_path) = crate::bootstrap::default_vault_path() {
-        return opencrust_security::try_vault_set(&vault_path, vault_key, value);
+        if opencrust_security::try_vault_set(&vault_path, vault_key, value) {
+            return true;
+        }
+    }
+    if vault_key.starts_with("CODEX_") {
+        return crate::bootstrap::persist_auth_json_secret(vault_key, value);
     }
     false
 }

--- a/crates/opencrust-gateway/src/router.rs
+++ b/crates/opencrust-gateway/src/router.rs
@@ -3,16 +3,20 @@ use std::time::Duration;
 
 use axum::Router;
 use axum::body::Body;
-use axum::extract::Query;
+use axum::extract::{Query, State};
 use axum::http::{Request, StatusCode};
 use axum::middleware::Next;
 use axum::response::{Html, IntoResponse, Redirect};
 use axum::routing::{get, post};
+use base64::Engine;
+use opencrust_agents::{CodexAuthConfig, CodexProvider, parse_codex_id_token_claims};
 use opencrust_security::credentials::vault_passphrase_available;
+use ring::digest::{SHA256, digest};
 use tower_governor::GovernorLayer;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_http::services::ServeDir;
 use url::form_urlencoded;
+use uuid::Uuid;
 
 use crate::a2a;
 use crate::api;
@@ -113,6 +117,19 @@ pub fn build_router(
         )
         .route("/api/sessions/{id}/messages", post(api::send_message))
         .route("/api/providers", get(list_providers).post(add_provider))
+        .route(
+            "/api/providers/codex/oauth/start",
+            get(start_codex_provider_oauth),
+        )
+        .route(
+            "/api/providers/codex/oauth/callback",
+            get(handle_codex_provider_oauth_callback),
+        )
+        .route(
+            "/api/providers/codex/oauth/complete",
+            post(complete_codex_provider_oauth),
+        )
+        .route("/auth/callback", get(handle_codex_provider_oauth_callback))
         .route(
             "/api/integrations/google/callback",
             get(handle_google_integration_callback),
@@ -481,6 +498,14 @@ const GOOGLE_OAUTH_SCOPES_BASE: &[&str] = &[
 ];
 const GOOGLE_OAUTH_SCOPE_GMAIL_SEND: &str = "https://www.googleapis.com/auth/gmail.send";
 const GOOGLE_OAUTH_STATE_TTL_SECS: u64 = 600;
+const CODEX_OAUTH_ISSUER: &str = "https://auth.openai.com";
+const CODEX_OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const CODEX_OAUTH_STATE_TTL_SECS: u64 = 600;
+const CODEX_OAUTH_LOOPBACK_HOST: &str = "localhost";
+const CODEX_OAUTH_LOOPBACK_PORT: u16 = 1455;
+const CODEX_OAUTH_CALLBACK_PATH: &str = "/auth/callback";
+const CODEX_OAUTH_SCOPE: &str =
+    "openid profile email offline_access api.connectors.read api.connectors.invoke";
 
 fn google_gmail_send_scope_enabled() -> bool {
     std::env::var("OPENCRUST_GOOGLE_ENABLE_GMAIL_SEND_SCOPE")
@@ -539,6 +564,82 @@ struct GoogleUserInfo {
     email: Option<String>,
 }
 
+#[derive(serde::Deserialize)]
+struct CodexOAuthCallbackQuery {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct CodexOAuthTokenResponse {
+    id_token: String,
+    access_token: String,
+    refresh_token: String,
+}
+
+#[derive(serde::Deserialize)]
+struct CodexOAuthManualCompleteRequest {
+    redirect_url: String,
+}
+
+fn generate_codex_pkce() -> (String, String) {
+    let verifier_bytes = Uuid::new_v4().as_bytes().repeat(4);
+    let verifier = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(verifier_bytes);
+    let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(digest(&SHA256, verifier.as_bytes()).as_ref());
+    (verifier, challenge)
+}
+
+fn origin_from_headers(headers: &axum::http::HeaderMap, fallback_host: &str) -> String {
+    let proto = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .filter(|v| !v.is_empty())
+        .unwrap_or("http");
+    let host = headers
+        .get("x-forwarded-host")
+        .or_else(|| headers.get(axum::http::header::HOST))
+        .and_then(|v| v.to_str().ok())
+        .filter(|v| !v.is_empty())
+        .unwrap_or(fallback_host);
+    format!("{proto}://{host}")
+}
+
+fn codex_redirect_uri() -> String {
+    format!(
+        "http://{CODEX_OAUTH_LOOPBACK_HOST}:{CODEX_OAUTH_LOOPBACK_PORT}{CODEX_OAUTH_CALLBACK_PATH}"
+    )
+}
+
+fn codex_authorize_url(state: &SharedState, headers: &axum::http::HeaderMap) -> String {
+    let redirect_uri = codex_redirect_uri();
+    let opener_origin = origin_from_headers(headers, "127.0.0.1:3888");
+    let state_token = Uuid::new_v4().to_string();
+    let (code_verifier, code_challenge) = generate_codex_pkce();
+    state.issue_codex_oauth_state(
+        state_token.clone(),
+        code_verifier,
+        redirect_uri.clone(),
+        opener_origin,
+    );
+
+    let query = form_urlencoded::Serializer::new(String::new())
+        .append_pair("response_type", "code")
+        .append_pair("client_id", CODEX_OAUTH_CLIENT_ID)
+        .append_pair("redirect_uri", &redirect_uri)
+        .append_pair("scope", CODEX_OAUTH_SCOPE)
+        .append_pair("code_challenge", &code_challenge)
+        .append_pair("code_challenge_method", "S256")
+        .append_pair("id_token_add_organizations", "true")
+        .append_pair("codex_cli_simplified_flow", "true")
+        .append_pair("state", &state_token)
+        .append_pair("originator", "codex_cli_rs")
+        .finish();
+    format!("{CODEX_OAUTH_ISSUER}/oauth/authorize?{query}")
+}
+
 /// GET /api/integrations/google/connect — start Google OAuth consent flow.
 async fn start_google_integration_connect(
     axum::extract::State(state): axum::extract::State<SharedState>,
@@ -576,6 +677,13 @@ async fn get_google_integration_connect_url(
             })),
         ),
     }
+}
+
+async fn start_codex_provider_oauth(
+    State(state): State<SharedState>,
+    headers: axum::http::HeaderMap,
+) -> impl IntoResponse {
+    Redirect::temporary(&codex_authorize_url(&state, &headers)).into_response()
 }
 
 fn google_authorize_url(state: &SharedState) -> Result<String, String> {
@@ -702,6 +810,169 @@ async fn parse_google_error(context: &str, resp: reqwest::Response) -> String {
         format!("{context} (HTTP {status}): {details}")
     };
     format!("{message}{}", invalid_client_hint(&details))
+}
+
+async fn handle_codex_provider_oauth_callback(
+    State(state): State<SharedState>,
+    Query(query): Query<CodexOAuthCallbackQuery>,
+) -> impl IntoResponse {
+    let target_origin = query
+        .state
+        .as_deref()
+        .and_then(|state_token| state.codex_oauth_target_origin(state_token));
+    match complete_codex_oauth(state, query).await {
+        Ok(message) => codex_oauth_popup_result(true, &message, target_origin.as_deref()),
+        Err(error) => codex_oauth_popup_result(false, &error, target_origin.as_deref()),
+    }
+}
+
+async fn complete_codex_oauth(
+    state: SharedState,
+    query: CodexOAuthCallbackQuery,
+) -> Result<String, String> {
+    if let Some(error) = query.error {
+        let details = query.error_description.unwrap_or(error);
+        return Err(format!("Codex authorization failed: {details}"));
+    }
+
+    let Some(code) = query.code else {
+        return Err("Missing OAuth code in callback".to_string());
+    };
+    let Some(state_token) = query.state else {
+        return Err("Missing OAuth state in callback".to_string());
+    };
+
+    let Some(pending) = state.consume_codex_oauth_state(
+        &state_token,
+        Duration::from_secs(CODEX_OAUTH_STATE_TTL_SECS),
+    ) else {
+        return Err("OAuth state invalid or expired".to_string());
+    };
+
+    let http = reqwest::Client::new();
+    let token_response = match http
+        .post(format!("{CODEX_OAUTH_ISSUER}/oauth/token"))
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code.as_str()),
+            ("redirect_uri", pending.redirect_uri.as_str()),
+            ("client_id", CODEX_OAUTH_CLIENT_ID),
+            ("code_verifier", pending.code_verifier.as_str()),
+        ])
+        .send()
+        .await
+    {
+        Ok(resp) => {
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                return Err(format!("Codex token exchange failed ({status}): {body}"));
+            }
+            match resp.json::<CodexOAuthTokenResponse>().await {
+                Ok(token) => token,
+                Err(err) => {
+                    return Err(format!("Failed to parse Codex token response: {err}"));
+                }
+            }
+        }
+        Err(err) => {
+            return Err(format!("Codex token exchange failed: {err}"));
+        }
+    };
+
+    let claims = parse_codex_id_token_claims(&token_response.id_token).ok();
+    let account_id = claims.as_ref().and_then(|claims| claims.account_id.clone());
+    let email = claims.as_ref().and_then(|claims| claims.email.clone());
+
+    persist_secret("CODEX_ACCESS_TOKEN", &token_response.access_token);
+    persist_secret("CODEX_REFRESH_TOKEN", &token_response.refresh_token);
+    persist_secret("CODEX_ID_TOKEN", &token_response.id_token);
+    if let Some(account_id) = account_id.as_deref() {
+        persist_secret("CODEX_ACCOUNT_ID", account_id);
+    }
+
+    let provider = CodexProvider::new(
+        CodexAuthConfig {
+            access_token: Some(token_response.access_token),
+            refresh_token: Some(token_response.refresh_token),
+            account_id: account_id.clone(),
+            id_token: Some(token_response.id_token),
+        },
+        None,
+        None,
+    );
+    state.agents.register_provider(Arc::new(provider));
+    state.agents.set_default_provider_id("codex");
+
+    let success_message = match email {
+        Some(email) => format!("Codex connected for {email}."),
+        None => "Codex connected.".to_string(),
+    };
+    Ok(success_message)
+}
+
+pub fn build_codex_loopback_router(state: SharedState) -> Router {
+    Router::new()
+        .route(
+            CODEX_OAUTH_CALLBACK_PATH,
+            get(
+                |State(state): State<SharedState>, Query(query): Query<CodexOAuthCallbackQuery>| async move {
+                    let target_origin = query
+                        .state
+                        .as_deref()
+                        .and_then(|state_token| state.codex_oauth_target_origin(state_token));
+                    match complete_codex_oauth(state, query).await {
+                        Ok(message) => codex_oauth_popup_result(true, &message, target_origin.as_deref()),
+                        Err(error) => codex_oauth_popup_result(false, &error, target_origin.as_deref()),
+                    }
+                },
+            ),
+        )
+        .with_state(state)
+}
+
+async fn complete_codex_provider_oauth(
+    State(state): State<SharedState>,
+    axum::Json(body): axum::Json<CodexOAuthManualCompleteRequest>,
+) -> (axum::http::StatusCode, axum::Json<serde_json::Value>) {
+    let parsed = match url::Url::parse(body.redirect_url.trim()) {
+        Ok(url) => url,
+        Err(err) => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                axum::Json(serde_json::json!({
+                    "status": "error",
+                    "message": format!("Invalid redirect URL: {err}"),
+                })),
+            );
+        }
+    };
+
+    let params: std::collections::HashMap<String, String> =
+        parsed.query_pairs().into_owned().collect();
+    let query = CodexOAuthCallbackQuery {
+        code: params.get("code").cloned(),
+        state: params.get("state").cloned(),
+        error: params.get("error").cloned(),
+        error_description: params.get("error_description").cloned(),
+    };
+
+    match complete_codex_oauth(state, query).await {
+        Ok(message) => (
+            axum::http::StatusCode::OK,
+            axum::Json(serde_json::json!({
+                "status": "ok",
+                "message": message,
+            })),
+        ),
+        Err(message) => (
+            axum::http::StatusCode::BAD_REQUEST,
+            axum::Json(serde_json::json!({
+                "status": "error",
+                "message": message,
+            })),
+        ),
+    }
 }
 
 /// GET /api/integrations/google/callback — OAuth callback for Google connect.
@@ -1061,6 +1332,7 @@ async fn set_google_integration_config(
 const KNOWN_PROVIDERS: &[(&str, &str, bool)] = &[
     ("anthropic", "Anthropic", true),
     ("openai", "OpenAI", true),
+    ("codex", "Codex OAuth", false),
     ("deepseek", "DeepSeek", true),
     ("mistral", "Mistral", true),
     ("sansa", "Sansa", true),
@@ -1200,6 +1472,54 @@ async fn add_provider(
             );
             state.agents.register_provider(Arc::new(provider));
             persist_api_key("OPENAI_API_KEY", key);
+        }
+        "codex" => {
+            let access_token = body
+                .api_key
+                .clone()
+                .or_else(|| {
+                    crate::bootstrap::default_vault_path().and_then(|vault_path| {
+                        opencrust_security::try_vault_get(&vault_path, "CODEX_ACCESS_TOKEN")
+                    })
+                })
+                .or_else(|| std::env::var("CODEX_ACCESS_TOKEN").ok());
+            let refresh_token = crate::bootstrap::default_vault_path()
+                .and_then(|vault_path| {
+                    opencrust_security::try_vault_get(&vault_path, "CODEX_REFRESH_TOKEN")
+                })
+                .or_else(|| std::env::var("CODEX_REFRESH_TOKEN").ok());
+            let account_id = crate::bootstrap::default_vault_path()
+                .and_then(|vault_path| {
+                    opencrust_security::try_vault_get(&vault_path, "CODEX_ACCOUNT_ID")
+                })
+                .or_else(|| std::env::var("CODEX_ACCOUNT_ID").ok());
+            let id_token = crate::bootstrap::default_vault_path()
+                .and_then(|vault_path| {
+                    opencrust_security::try_vault_get(&vault_path, "CODEX_ID_TOKEN")
+                })
+                .or_else(|| std::env::var("CODEX_ID_TOKEN").ok());
+
+            if access_token.is_none() && refresh_token.is_none() {
+                return (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    axum::Json(serde_json::json!({
+                        "status": "error",
+                        "message": "codex oauth credentials not found; use Connect with Codex first",
+                    })),
+                );
+            }
+
+            let provider = CodexProvider::new(
+                CodexAuthConfig {
+                    access_token,
+                    refresh_token,
+                    account_id,
+                    id_token,
+                },
+                body.model.clone(),
+                body.base_url.clone(),
+            );
+            state.agents.register_provider(Arc::new(provider));
         }
         "sansa" => {
             let Some(key) = &body.api_key else {
@@ -1477,6 +1797,10 @@ async fn add_provider(
 
 /// Best-effort: persist an API key in the vault.
 fn persist_api_key(vault_key: &str, value: &str) -> bool {
+    persist_secret(vault_key, value)
+}
+
+fn persist_secret(vault_key: &str, value: &str) -> bool {
     if let Some(vault_path) = crate::bootstrap::default_vault_path() {
         return opencrust_security::try_vault_set(&vault_path, vault_key, value);
     }
@@ -1587,19 +1911,28 @@ fn is_valid_google_client_id(value: &str) -> bool {
     has_domain && has_dash && numeric_prefix
 }
 
-fn oauth_popup_result(success: bool, message: &str) -> Html<String> {
+fn oauth_popup_result_with_event(
+    success: bool,
+    message: &str,
+    event_type: &str,
+    success_title: &str,
+    failure_title: &str,
+    target_origin: Option<&str>,
+) -> Html<String> {
     let escaped_message = message
         .replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;");
     let json_message = serde_json::to_string(message).unwrap_or_else(|_| "\"\"".to_string());
     let title = if success {
-        "Google Connected"
+        success_title
     } else {
-        "Google Connection Failed"
+        failure_title
     };
     let status = if success { "success" } else { "error" };
     let payload = if success { "true" } else { "false" };
+    let target_origin_json =
+        serde_json::to_string(&target_origin).unwrap_or_else(|_| "null".to_string());
 
     Html(format!(
         r#"<!doctype html>
@@ -1652,7 +1985,8 @@ fn oauth_popup_result(success: bool, message: &str) -> Html<String> {
   <script>
     try {{
       if (window.opener && !window.opener.closed) {{
-        window.opener.postMessage({{ type: "opencrust.google.oauth", success: {payload}, message: {json_message} }}, window.location.origin);
+        const targetOrigin = {target_origin_json} ?? window.location.origin;
+        window.opener.postMessage({{ type: {event_type:?}, success: {payload}, message: {json_message} }}, targetOrigin);
       }}
     }} catch (e) {{}}
     setTimeout(() => window.close(), 600);
@@ -1660,6 +1994,32 @@ fn oauth_popup_result(success: bool, message: &str) -> Html<String> {
 </body>
 </html>"#
     ))
+}
+
+fn oauth_popup_result(success: bool, message: &str) -> Html<String> {
+    oauth_popup_result_with_event(
+        success,
+        message,
+        "opencrust.google.oauth",
+        "Google Connected",
+        "Google Connection Failed",
+        None,
+    )
+}
+
+fn codex_oauth_popup_result(
+    success: bool,
+    message: &str,
+    target_origin: Option<&str>,
+) -> Html<String> {
+    oauth_popup_result_with_event(
+        success,
+        message,
+        "opencrust.codex.oauth",
+        "Codex Connected",
+        "Codex Connection Failed",
+        target_origin,
+    )
 }
 
 /// GET /api/mcp — list connected MCP servers with tool counts and status.

--- a/crates/opencrust-gateway/src/router.rs
+++ b/crates/opencrust-gateway/src/router.rs
@@ -129,7 +129,6 @@ pub fn build_router(
             "/api/providers/codex/oauth/complete",
             post(complete_codex_provider_oauth),
         )
-        .route("/auth/callback", get(handle_codex_provider_oauth_callback))
         .route(
             "/api/integrations/google/callback",
             get(handle_google_integration_callback),

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -19,7 +19,7 @@ use crate::bootstrap::{
     build_mcp_tools, build_slack_channels, build_telegram_channels, build_wechat_channels,
     build_whatsapp_channels, build_whatsapp_web_channels, resolve_api_key,
 };
-use crate::router::build_router;
+use crate::router::{build_codex_loopback_router, build_router};
 use crate::state::AppState;
 
 /// The main gateway server that binds to a port and serves the API + WebSocket.
@@ -317,7 +317,30 @@ impl GatewayServer {
             Arc::new(wechat_channels);
 
         let state_for_shutdown = Arc::clone(&state);
+        let codex_loopback_state = Arc::clone(&state);
         let app = build_router(state, whatsapp_state, line_state, wechat_state);
+
+        tokio::spawn(async move {
+            let loopback_addr = "127.0.0.1:1455";
+            match TcpListener::bind(loopback_addr).await {
+                Ok(listener) => {
+                    info!("Codex OAuth callback listening on {}", loopback_addr);
+                    if let Err(err) =
+                        axum::serve(listener, build_codex_loopback_router(codex_loopback_state))
+                            .with_graceful_shutdown(shutdown_signal())
+                            .await
+                    {
+                        warn!("Codex OAuth callback server failed: {err}");
+                    }
+                }
+                Err(err) => {
+                    warn!(
+                        "failed to bind Codex OAuth callback on {}: {}. Codex OAuth login will not work until that port is free",
+                        loopback_addr, err
+                    );
+                }
+            }
+        });
 
         let listener = TcpListener::bind(&addr).await?;
         info!("OpenCrust gateway listening on {}", addr);

--- a/crates/opencrust-gateway/src/state.rs
+++ b/crates/opencrust-gateway/src/state.rs
@@ -56,6 +56,8 @@ pub struct AppState {
     google_workspace_email: RwLock<Option<String>>,
     /// Pending Google OAuth state values (anti-CSRF), keyed by state token.
     google_oauth_states: DashMap<String, Instant>,
+    /// Pending Codex OAuth state values (anti-CSRF + PKCE verifier).
+    codex_oauth_states: DashMap<String, CodexOAuthState>,
     /// Runtime Google OAuth client configuration set from the web UI.
     google_oauth_runtime_config: RwLock<Option<GoogleOAuthRuntimeConfig>>,
     /// Receives hot-reloaded config updates. `None` if watcher is not active.
@@ -81,6 +83,14 @@ pub struct GoogleOAuthRuntimeConfig {
     pub client_id: String,
     pub client_secret: String,
     pub redirect_uri: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexOAuthState {
+    pub code_verifier: String,
+    pub redirect_uri: String,
+    pub opener_origin: String,
+    pub created_at: Instant,
 }
 
 /// Per-connection session tracking.
@@ -113,6 +123,7 @@ impl AppState {
             google_workspace_integration_connected: AtomicBool::new(false),
             google_workspace_email: RwLock::new(None),
             google_oauth_states: DashMap::new(),
+            codex_oauth_states: DashMap::new(),
             google_oauth_runtime_config: RwLock::new(None),
             config_rx: None,
             user_rate_limits: DashMap::new(),
@@ -219,6 +230,46 @@ impl AppState {
         if let Ok(mut slot) = self.google_oauth_runtime_config.write() {
             *slot = Some(config);
         }
+    }
+
+    pub fn issue_codex_oauth_state(
+        &self,
+        state: String,
+        code_verifier: String,
+        redirect_uri: String,
+        opener_origin: String,
+    ) {
+        self.codex_oauth_states.insert(
+            state,
+            CodexOAuthState {
+                code_verifier,
+                redirect_uri,
+                opener_origin,
+                created_at: Instant::now(),
+            },
+        );
+    }
+
+    pub fn consume_codex_oauth_state(
+        &self,
+        state: &str,
+        max_age: Duration,
+    ) -> Option<CodexOAuthState> {
+        self.codex_oauth_states
+            .remove(state)
+            .and_then(|(_, value)| {
+                if value.created_at.elapsed() <= max_age {
+                    Some(value)
+                } else {
+                    None
+                }
+            })
+    }
+
+    pub fn codex_oauth_target_origin(&self, state: &str) -> Option<String> {
+        self.codex_oauth_states
+            .get(state)
+            .map(|pending| pending.opener_origin.clone())
     }
 
     /// Read runtime Google OAuth config from memory.

--- a/crates/opencrust-gateway/src/webchat.html
+++ b/crates/opencrust-gateway/src/webchat.html
@@ -253,7 +253,11 @@
               <div id="provider-key-section" style="display:none">
                 <input id="provider-api-key" type="password" placeholder="Enter API key..." autocomplete="off"
                   class="provider-key-input">
+                <input id="provider-oauth-redirect" type="text"
+                  placeholder="Paste Codex redirect URL or replace localhost:1455 with this host"
+                  autocomplete="off" class="provider-key-input" style="display:none">
                 <button id="provider-activate" class="provider-activate-btn">Save & Activate</button>
+                <button id="provider-oauth-complete" class="provider-activate-btn" style="display:none">Complete Codex Login</button>
               </div>
             </div>
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -29,7 +29,7 @@ A single 17 MB binary that runs your AI agents across Telegram, Discord, Slack, 
 
 ## Features
 
-- **LLM Providers**: 15 providers - Anthropic Claude, OpenAI, Ollama, and 12 OpenAI-compatible (Sansa, DeepSeek, Mistral, Gemini, Falcon, Jais, Qwen, Yi, Cohere, MiniMax, Moonshot).
+- **LLM Providers**: 15 providers - Anthropic Claude, OpenAI, Codex OAuth, Ollama, and 11 OpenAI-compatible (Sansa, DeepSeek, Mistral, Gemini, Falcon, Jais, Qwen, Yi, Cohere, MiniMax, Moonshot).
 - **Channels**: Telegram, Discord, Slack, WhatsApp, LINE, iMessage.
 - **MCP**: Connect any MCP-compatible server for external tools.
 - **Personality (DNA)**: Conversational bootstrap on first message - the agent asks your preferences and writes `~/.opencrust/dna.md`. Hot-reloads on edit.

--- a/docs/src/providers.md
+++ b/docs/src/providers.md
@@ -1,6 +1,6 @@
 # Providers
 
-OpenCrust supports 15 LLM providers. Three are native implementations with provider-specific APIs. The remaining eleven use the OpenAI-compatible chat completions format and are built on top of the `OpenAiProvider` with custom base URLs.
+OpenCrust supports 15 LLM providers. Four are native implementations with provider-specific APIs. The remaining eleven use the OpenAI-compatible chat completions format and are built on top of the `OpenAiProvider` with custom base URLs.
 
 All providers support streaming responses and tool use.
 
@@ -117,6 +117,31 @@ llm:
     provider: ollama
     model: llama3.1
     base_url: "http://localhost:11434"
+```
+
+### Codex OAuth
+
+Codex models through OpenAI's ChatGPT-backed Codex Responses API, authenticated with OAuth tokens instead of an API key.
+
+| Field | Value |
+|-------|-------|
+| Config type | `codex` |
+| Default model | `gpt-5.3-codex` |
+| Base URL | `https://chatgpt.com/backend-api/codex` |
+| Env vars | `CODEX_ACCESS_TOKEN`, `CODEX_REFRESH_TOKEN`, `CODEX_ACCOUNT_ID`, `CODEX_ID_TOKEN` |
+
+You can connect this provider directly from the webchat sidebar with `Connect with Codex`.
+
+```yaml
+llm:
+  codex:
+    provider: codex
+    model: gpt-5.3-codex
+    # Optional config keys if you are not using env vars or the vault:
+    # access_token: eyJ...
+    # refresh_token: ...
+    # account_id: org_...
+    # id_token: eyJ...
 ```
 
 ## OpenAI-Compatible Providers


### PR DESCRIPTION
## Summary
I don't have a openapi token account, but do have an oauth account.

## Changes
Added chatgpt oauth flow through the webpage, note however I didn't include a proper oauth 2 callback flow as this matches the codex app.  While oauth seems ok at the moment, I don't want to stick out in the logs, in case they do an anthropic. 

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Manual testing: <!-- describe how you tested -->

tested logging in using the auth flow, waited for connection, ran some queries.


## Related Issues

<!-- Link related issues: Closes #123, Fixes #456 -->
closes #187 