### PR TITLE
Fix streaming tool execution for OpenAI-compatible providers

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -1084,10 +1084,21 @@ impl AgentRuntime {
                             StreamEvent::MessageDelta {
                                 stop_reason: sr, ..
                             } => {
+                                // OpenAI/vLLM never sends ContentBlockStop, so flush the
+                                // in-flight tool when the stream signals tool_calls done.
+                                if let Some(tool) = current_tool.take() {
+                                    tool_uses.push(tool);
+                                }
                                 _stop_reason = sr;
                             }
                             StreamEvent::MessageStop => break,
                         }
+                    }
+
+                    // Safety flush: if ContentBlockStop was never emitted (OpenAI/vLLM
+                    // streaming), the last tool may still be pending.
+                    if let Some(tool) = current_tool.take() {
+                        tool_uses.push(tool);
                     }
 
                     if tool_uses.is_empty() {
@@ -1517,10 +1528,21 @@ impl AgentRuntime {
                             StreamEvent::MessageDelta {
                                 stop_reason: sr, ..
                             } => {
+                                // OpenAI/vLLM never sends ContentBlockStop, so flush the
+                                // in-flight tool when the stream signals tool_calls done.
+                                if let Some(tool) = current_tool.take() {
+                                    tool_uses.push(tool);
+                                }
                                 _stop_reason = sr;
                             }
                             StreamEvent::MessageStop => break,
                         }
+                    }
+
+                    // Safety flush: if ContentBlockStop was never emitted (OpenAI/vLLM
+                    // streaming), the last tool may still be pending.
+                    if let Some(tool) = current_tool.take() {
+                        tool_uses.push(tool);
                     }
 
                     if tool_uses.is_empty() {


### PR DESCRIPTION
## Problem

When using OpenAI or vLLM (and any OpenAI-compatible provider) with streaming enabled, tool calls were silently dropped — the agent would respond with text as if it had executed the tool, but no tool was actually run.

**Root cause:** The streaming tool-collection loop used `ContentBlockStop` (an Anthropic SSE event) to finalize each in-flight tool and push it into `tool_uses`. OpenAI/vLLM never emit this event. So `tool_uses` was always empty, and the agent returned the text response without entering the tool execution branch.

Verified with vLLM serving `Qwen/Qwen2.5-7B-Instruct` via the hermes chat template: the raw API correctly returns `finish_reason: "tool_calls"` with a populated `tool_calls` array, but OpenCrust was not executing any of them.

## Fix

In both streaming loop implementations (`process_message_streaming_summarized_impl` and the non-summarized equivalent):

1. **Flush in `MessageDelta`** — OpenAI/vLLM emit `MessageDelta` with `stop_reason: "tool_use"` when `finish_reason` is `"tool_calls"`. Flush `current_tool` here before it is lost.
2. **Post-loop safety flush** — Catch any remaining `current_tool` after the stream ends for providers that don't emit a final `MessageDelta`.

The fix is backward-compatible: for Anthropic (which does send `ContentBlockStop`), the flush in `ContentBlockStop` already clears `current_tool`, so the new flushes are no-ops.

## Testing

- 79 existing unit tests pass (`cargo test -p opencrust-agents`)  
- Confirmed end-to-end with vLLM + Qwen3-8B-AWQ via Telegram: `file_write` and `bash` tools now execute and produce real side-effects on disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)