### PR TITLE
docs: add opencrust doctor command to all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ opencrust init
 
 # Start - on first message, the agent will introduce itself and learn your preferences
 opencrust start
+
+# Diagnose configuration, connectivity, and database health
+opencrust doctor
 ```
 
 <details>
@@ -167,6 +170,7 @@ OpenCrust is built for the security requirements of always-on AI agents that acc
 - **Migration tool** - `opencrust migrate openclaw` imports skills, channels, and credentials
 - **Conversation summarization** - rolling summary at 75% context window, session summaries persisted across restarts
 - **Interactive setup** - `opencrust init` wizard for provider and channel configuration
+- **Diagnostics** - `opencrust doctor` checks config, data directory, credential vault, LLM provider reachability, channel credentials, MCP server connectivity, and database integrity
 
 ## Migrating from OpenClaw?
 
@@ -255,7 +259,7 @@ crates/
 | Memory (SQLite, vector search, summarization) | Working |
 | Security (vault, allowlist, pairing) | Working |
 | Scheduling (cron, interval, one-shot) | Working |
-| CLI (init, start/stop/restart, update, migrate, mcp, skills) | Working |
+| CLI (init, start/stop/restart, update, migrate, mcp, skills, doctor) | Working |
 | Plugin system (WASM sandbox) | Scaffolded |
 | Media processing | Scaffolded |
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -36,6 +36,7 @@ A single 17 MB binary that runs your AI agents across Telegram, Discord, Slack, 
 - **Agent Runtime**: 6 built-in tools (bash, file_read, file_write, web_fetch, web_search, schedule_heartbeat), memory with vector search, conversation summarization, scheduled tasks.
 - **Skills**: Define skills as Markdown files.
 - **Infrastructure**: Config hot-reload, daemonization, self-update, migration tools.
+- **Diagnostics**: `opencrust doctor` checks config, credential vault, LLM provider reachability, channel credentials, MCP server connectivity, and database integrity.
 
 ## Documentation Structure
 

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -47,6 +47,9 @@ opencrust init
 
 # เริ่มใช้งาน - เมื่อได้รับข้อความแรก agent จะแนะนำตัวและเรียนรู้ความชอบของคุณ
 opencrust start
+
+# ตรวจสอบ config, connectivity และ database health
+opencrust doctor
 ```
 
 <details>
@@ -165,6 +168,7 @@ OpenCrust ถูกออกแบบสำหรับ AI agent ที่ทำ
 - **Migration tool** - `opencrust migrate openclaw` นำเข้า skills, channels และ credentials
 - **Conversation summarization** - rolling summary ที่ 75% context window, บันทึก session summary ข้ามการ restart
 - **Interactive setup** - wizard `opencrust init` สำหรับตั้งค่า provider และช่องทาง
+- **Diagnostics** - `opencrust doctor` ตรวจสอบ config, data directory, credential vault, ความสามารถเข้าถึง LLM provider, credentials ของ channel, ความสามารถเชื่อมต่อ MCP server และ database integrity
 
 ## ย้ายจาก OpenClaw?
 
@@ -253,7 +257,7 @@ crates/
 | Memory (SQLite, vector search, summarization) | ใช้งานได้ |
 | Security (vault, allowlist, pairing) | ใช้งานได้ |
 | Scheduling (cron, interval, one-shot) | ใช้งานได้ |
-| CLI (init, start/stop/restart, update, migrate, mcp, skills) | ใช้งานได้ |
+| CLI (init, start/stop/restart, update, migrate, mcp, skills, doctor) | ใช้งานได้ |
 | Plugin system (WASM sandbox) | Scaffolded |
 | Media processing | Scaffolded |
 


### PR DESCRIPTION
## Summary

- Add `opencrust doctor` to the Quick Start section in `README.md` and `i18n/README.th.md`
- Add Diagnostics entry to the Infrastructure features section in all three READMEs
- Update the CLI row in the Architecture status table to include `doctor`

## What doctor does

`opencrust doctor` runs pre-flight diagnostic checks across 8 areas: config file, data directory, credential vault, LLM provider reachability, channel credentials, MCP server connectivity, sessions/memory database integrity, and dna.md presence.

## Test plan

- [x] Run `opencrust doctor` against a fresh install and verify output matches documentation
- [x] Verify all links and formatting render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)