### PR TITLE
ci: add auto-labeler for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,88 @@
+channel:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-channels/**"
+
+gateway:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-gateway/**"
+
+agent:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-agents/**"
+
+database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-db/**"
+
+plugin:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-plugins/**"
+
+security:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-security/**"
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-cli/**"
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-config/**"
+
+media:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-media/**"
+
+skills:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-skills/**"
+
+mcp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-agents/src/mcp/**"
+          - "crates/opencrust-config/src/*mcp*"
+
+telegram:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "crates/opencrust-channels/src/telegram*"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+          - "i18n/**"
+
+infra:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/Cargo.toml"
+          - "Cargo.lock"
+
+testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/tests/**"
+
+rust:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.rs"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Label PR
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Auto-label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `.github/labeler.yml` mapping crate paths to existing repo labels
- Add `.github/workflows/labeler.yml` using `actions/labeler@v5`
- Triggers on `pull_request_target` (opened, synchronize, reopened)
- `github-actions` bot will automatically tag PRs based on changed files

## Label mapping

| Files changed | Label added |
|---|---|
| `crates/opencrust-channels/**` | `channel` |
| `crates/opencrust-gateway/**` | `gateway` |
| `crates/opencrust-agents/**` | `agent` |
| `crates/opencrust-db/**` | `database` |
| `crates/opencrust-plugins/**` | `plugin` |
| `crates/opencrust-security/**` | `security` |
| `crates/opencrust-cli/**` | `cli` |
| `crates/opencrust-config/**` | `config` |
| `crates/opencrust-media/**` | `media` |
| `crates/opencrust-skills/**` | `skills` |
| `crates/opencrust-agents/src/mcp/**` | `mcp` |
| `crates/opencrust-channels/src/telegram*` | `telegram` |
| `**/*.md`, `docs/**`, `i18n/**` | `documentation` |
| `.github/**` | `infra` |
| `**/Cargo.toml`, `Cargo.lock` | `dependencies` |
| `**/tests/**` | `testing` |
| `**/*.rs` | `rust` |

## Note

Labels will auto-apply to all future PRs after this is merged into `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)