### PR TITLE
perf(db): replace single-connection SessionStore with r2d2 connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,6 +2637,8 @@ dependencies = [
  "chrono-tz",
  "cron",
  "opencrust-common",
+ "r2d2",
+ "r2d2_sqlite",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3135,6 +3137,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb14dba8247a6a15b7fdbc7d389e2e6f03ee9f184f87117706d509c092dfe846"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3629,6 +3653,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -4941,6 +4974,7 @@ checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
+ "rand 0.9.2",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ toml = "0.8"
 
 # Database
 rusqlite = { version = "0.32", features = ["bundled", "vtab"] }
+r2d2 = "0.8"
+r2d2_sqlite = "0.25"
 sqlite-vec = "0.1"
 
 # CLI

--- a/crates/opencrust-agents/src/tools/schedule.rs
+++ b/crates/opencrust-agents/src/tools/schedule.rs
@@ -3,7 +3,6 @@ use opencrust_common::{Error, Result};
 use opencrust_db::SessionStore;
 use serde_json::json;
 use std::sync::Arc;
-use tokio::sync::Mutex;
 
 use crate::tools::{Tool, ToolContext, ToolOutput};
 
@@ -25,11 +24,11 @@ const MAX_HEARTBEAT_DEPTH: u8 = 3;
 
 /// Tool for scheduling a future "heartbeat" wake-up call for the agent.
 pub struct ScheduleHeartbeat {
-    store: Arc<Mutex<SessionStore>>,
+    store: Arc<SessionStore>,
 }
 
 impl ScheduleHeartbeat {
-    pub fn new(store: Arc<Mutex<SessionStore>>) -> Self {
+    pub fn new(store: Arc<SessionStore>) -> Self {
         Self { store }
     }
 }
@@ -207,10 +206,10 @@ impl Tool for ScheduleHeartbeat {
             .clone()
             .unwrap_or_else(|| "unknown".to_string());
 
-        let store = self.store.lock().await;
-
         // Enforce per-session pending task limit
-        let pending = store.count_pending_tasks_for_session(&context.session_id)?;
+        let pending = self
+            .store
+            .count_pending_tasks_for_session(&context.session_id)?;
         if pending >= MAX_PENDING_PER_SESSION {
             return Err(Error::Agent(format!(
                 "session already has {} pending heartbeats (max {})",
@@ -220,7 +219,7 @@ impl Tool for ScheduleHeartbeat {
 
         let next_depth = context.heartbeat_depth.saturating_add(1);
 
-        let task_id = store.schedule_task_full(
+        let task_id = self.store.schedule_task_full(
             &context.session_id,
             &user_id,
             execute_at,
@@ -259,11 +258,11 @@ impl Tool for ScheduleHeartbeat {
 
 /// Tool for cancelling a pending scheduled heartbeat.
 pub struct CancelHeartbeat {
-    store: Arc<Mutex<SessionStore>>,
+    store: Arc<SessionStore>,
 }
 
 impl CancelHeartbeat {
-    pub fn new(store: Arc<Mutex<SessionStore>>) -> Self {
+    pub fn new(store: Arc<SessionStore>) -> Self {
         Self { store }
     }
 }
@@ -296,8 +295,7 @@ impl Tool for CancelHeartbeat {
             .as_str()
             .ok_or_else(|| Error::Agent("missing or invalid 'task_id' argument".to_string()))?;
 
-        let store = self.store.lock().await;
-        let cancelled = store.cancel_task(task_id, &context.session_id)?;
+        let cancelled = self.store.cancel_task(task_id, &context.session_id)?;
 
         if cancelled {
             Ok(ToolOutput::success(format!(
@@ -319,11 +317,11 @@ impl Tool for CancelHeartbeat {
 
 /// Tool for listing pending scheduled heartbeats for the current session.
 pub struct ListHeartbeats {
-    store: Arc<Mutex<SessionStore>>,
+    store: Arc<SessionStore>,
 }
 
 impl ListHeartbeats {
-    pub fn new(store: Arc<Mutex<SessionStore>>) -> Self {
+    pub fn new(store: Arc<SessionStore>) -> Self {
         Self { store }
     }
 }
@@ -346,8 +344,7 @@ impl Tool for ListHeartbeats {
     }
 
     async fn execute(&self, context: &ToolContext, _args: serde_json::Value) -> Result<ToolOutput> {
-        let store = self.store.lock().await;
-        let tasks = store.list_pending_tasks(&context.session_id)?;
+        let tasks = self.store.list_pending_tasks(&context.session_id)?;
 
         if tasks.is_empty() {
             return Ok(ToolOutput::success("No pending heartbeats."));
@@ -407,16 +404,12 @@ mod tests {
         }
     }
 
-    async fn setup_store(session_id: &str) -> Arc<Mutex<SessionStore>> {
+    async fn setup_store(session_id: &str) -> Arc<SessionStore> {
         let store = SessionStore::in_memory().expect("in-memory store should open");
-        let store = Arc::new(Mutex::new(store));
-        {
-            let guard = store.lock().await;
-            guard
-                .upsert_session(session_id, "web", "u-1", &serde_json::json!({}))
-                .expect("session upsert should succeed");
-        }
         store
+            .upsert_session(session_id, "web", "u-1", &serde_json::json!({}))
+            .expect("session upsert should succeed");
+        Arc::new(store)
     }
 
     #[tokio::test]
@@ -591,16 +584,13 @@ mod tests {
     #[tokio::test]
     async fn pending_limit_is_per_session() {
         let store = SessionStore::in_memory().expect("in-memory store should open");
-        let store = Arc::new(Mutex::new(store));
-        {
-            let guard = store.lock().await;
-            guard
-                .upsert_session("s1", "web", "u1", &serde_json::json!({}))
-                .unwrap();
-            guard
-                .upsert_session("s2", "web", "u2", &serde_json::json!({}))
-                .unwrap();
-        }
+        store
+            .upsert_session("s1", "web", "u1", &serde_json::json!({}))
+            .unwrap();
+        store
+            .upsert_session("s2", "web", "u2", &serde_json::json!({}))
+            .unwrap();
+        let store = Arc::new(store);
 
         let tool = ScheduleHeartbeat::new(Arc::clone(&store));
 
@@ -666,24 +656,20 @@ mod tests {
         assert!(cancel_out.content.contains("cancelled"));
 
         // Verify it's gone from pending
-        let guard = store.lock().await;
-        let pending = guard.count_pending_tasks_for_session("sess-1").unwrap();
+        let pending = store.count_pending_tasks_for_session("sess-1").unwrap();
         assert_eq!(pending, 0);
     }
 
     #[tokio::test]
     async fn cancel_wrong_session_fails() {
         let store = SessionStore::in_memory().expect("in-memory store should open");
-        let store = Arc::new(Mutex::new(store));
-        {
-            let guard = store.lock().await;
-            guard
-                .upsert_session("s1", "web", "u1", &serde_json::json!({}))
-                .unwrap();
-            guard
-                .upsert_session("s2", "web", "u2", &serde_json::json!({}))
-                .unwrap();
-        }
+        store
+            .upsert_session("s1", "web", "u1", &serde_json::json!({}))
+            .unwrap();
+        store
+            .upsert_session("s2", "web", "u2", &serde_json::json!({}))
+            .unwrap();
+        let store = Arc::new(store);
 
         let schedule_tool = ScheduleHeartbeat::new(Arc::clone(&store));
         let cancel_tool = CancelHeartbeat::new(Arc::clone(&store));

--- a/crates/opencrust-cli/src/doctor.rs
+++ b/crates/opencrust-cli/src/doctor.rs
@@ -310,10 +310,8 @@ fn check_sqlite_integrity(db_path: &Path, label: &str) -> Check {
 
     match opencrust_db::SessionStore::open(db_path) {
         Ok(store) => {
-            match store
-                .connection()
-                .query_row("PRAGMA integrity_check", [], |row| row.get::<_, String>(0))
-            {
+            let conn = store.connection().unwrap();
+            match conn.query_row("PRAGMA integrity_check", [], |row| row.get::<_, String>(0)) {
                 Ok(ref s) if s == "ok" => Check::Pass("integrity_check passed".into()),
                 Ok(s) => Check::Fail(format!("integrity_check returned: {s}")),
                 Err(e) => Check::Fail(format!("could not run integrity_check: {e}")),

--- a/crates/opencrust-db/Cargo.toml
+++ b/crates/opencrust-db/Cargo.toml
@@ -8,6 +8,8 @@ description = "SQLite storage and vector search for OpenCrust"
 [dependencies]
 opencrust-common = { workspace = true }
 rusqlite = { workspace = true }
+r2d2 = { workspace = true }
+r2d2_sqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/opencrust-db/src/session_store.rs
+++ b/crates/opencrust-db/src/session_store.rs
@@ -1,5 +1,6 @@
 use opencrust_common::{Error, Result};
-use rusqlite::Connection;
+use r2d2::PooledConnection;
+use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::params;
 use std::path::Path;
 use tracing::{info, warn};
@@ -34,36 +35,45 @@ pub struct UsageAttribution<'a> {
 
 /// Persistent storage for conversation sessions and message history.
 pub struct SessionStore {
-    conn: Connection,
+    pool: r2d2::Pool<SqliteConnectionManager>,
 }
 
 impl SessionStore {
     pub fn open(db_path: &Path) -> Result<Self> {
         info!("opening session store at {}", db_path.display());
-        let conn = Connection::open(db_path)
-            .map_err(|e| Error::Database(format!("failed to open database: {e}")))?;
-
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
-            .map_err(|e| Error::Database(format!("failed to set pragmas: {e}")))?;
-
-        let store = Self { conn };
+        let manager = SqliteConnectionManager::file(db_path)
+            .with_init(|c| c.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;"));
+        let pool = r2d2::Pool::builder()
+            .max_size(8)
+            .build(manager)
+            .map_err(|e| Error::Database(format!("failed to create connection pool: {e}")))?;
+        let store = Self { pool };
         store.run_migrations()?;
         Ok(store)
     }
 
     pub fn in_memory() -> Result<Self> {
-        let conn = Connection::open_in_memory()
-            .map_err(|e| Error::Database(format!("failed to open in-memory database: {e}")))?;
-
-        let store = Self { conn };
+        let manager = SqliteConnectionManager::memory()
+            .with_init(|c| c.execute_batch("PRAGMA foreign_keys=ON;"));
+        let pool = r2d2::Pool::builder()
+            .max_size(1)
+            .build(manager)
+            .map_err(|e| Error::Database(format!("failed to create in-memory pool: {e}")))?;
+        let store = Self { pool };
         store.run_migrations()?;
         Ok(store)
     }
 
+    fn conn(&self) -> Result<PooledConnection<SqliteConnectionManager>> {
+        self.pool
+            .get()
+            .map_err(|e| Error::Database(format!("failed to get db connection: {e}")))
+    }
+
     fn run_migrations(&self) -> Result<()> {
-        self.conn
-            .execute_batch(
-                "CREATE TABLE IF NOT EXISTS sessions (
+        let conn = self.conn()?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS sessions (
                     id TEXT PRIMARY KEY,
                     channel_id TEXT NOT NULL,
                     user_id TEXT NOT NULL,
@@ -97,25 +107,23 @@ impl SessionStore {
 
                 CREATE INDEX IF NOT EXISTS idx_tasks_execute_at
                     ON scheduled_tasks(execute_at) WHERE status = 'pending';",
-            )
-            .map_err(|e| Error::Database(format!("migration failed: {e}")))?;
+        )
+        .map_err(|e| Error::Database(format!("migration failed: {e}")))?;
 
         // Apply versioned migrations (idempotent: CREATE TABLE IF NOT EXISTS)
-        self.conn
-            .execute_batch(USAGE_SCHEMA_V1.sql)
+        conn.execute_batch(USAGE_SCHEMA_V1.sql)
             .map_err(|e| Error::Database(format!("usage migration failed: {e}")))?;
 
         // v2: add user_id and channel_id to usage_log (idempotent)
         for (col, col_type) in USAGE_SCHEMA_V2_COLUMNS {
             let sql = format!("ALTER TABLE usage_log ADD COLUMN {col} {col_type}");
-            if let Err(e) = self.conn.execute(&sql, [])
+            if let Err(e) = conn.execute(&sql, [])
                 && !e.to_string().contains("duplicate column")
             {
                 return Err(Error::Database(format!("usage v2 migration failed: {e}")));
             }
         }
-        self.conn
-            .execute_batch(USAGE_SCHEMA_V2_INDEX_SQL)
+        conn.execute_batch(USAGE_SCHEMA_V2_INDEX_SQL)
             .map_err(|e| Error::Database(format!("usage v2 index migration failed: {e}")))?;
 
         // Idempotent column additions for scheduling overhaul
@@ -133,7 +141,7 @@ impl SessionStore {
         for (col, col_type) in &columns {
             let sql = format!("ALTER TABLE scheduled_tasks ADD COLUMN {col} {col_type}");
             // Ignore "duplicate column" errors - column already exists
-            if let Err(e) = self.conn.execute(&sql, []) {
+            if let Err(e) = conn.execute(&sql, []) {
                 let msg = e.to_string();
                 if !msg.contains("duplicate column") {
                     return Err(Error::Database(format!("migration failed: {e}")));
@@ -144,8 +152,9 @@ impl SessionStore {
         Ok(())
     }
 
-    pub fn connection(&self) -> &Connection {
-        &self.conn
+    /// Expose a pooled connection for raw SQL access (used in tests).
+    pub fn connection(&self) -> Result<PooledConnection<SqliteConnectionManager>> {
+        self.conn()
     }
 
     /// Create or update a session row.
@@ -156,18 +165,18 @@ impl SessionStore {
         user_id: &str,
         metadata: &serde_json::Value,
     ) -> Result<()> {
-        self.conn
-            .execute(
-                "INSERT INTO sessions (id, channel_id, user_id, metadata)
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO sessions (id, channel_id, user_id, metadata)
                  VALUES (?1, ?2, ?3, ?4)
                  ON CONFLICT(id) DO UPDATE SET
                    channel_id = excluded.channel_id,
                    user_id = excluded.user_id,
                    metadata = excluded.metadata,
                    updated_at = datetime('now')",
-                params![session_id, channel_id, user_id, metadata.to_string()],
-            )
-            .map_err(|e| Error::Database(format!("failed to upsert session: {e}")))?;
+            params![session_id, channel_id, user_id, metadata.to_string()],
+        )
+        .map_err(|e| Error::Database(format!("failed to upsert session: {e}")))?;
         Ok(())
     }
 
@@ -181,20 +190,20 @@ impl SessionStore {
         metadata: &serde_json::Value,
     ) -> Result<()> {
         let message_id = uuid::Uuid::new_v4().to_string();
-        self.conn
-            .execute(
-                "INSERT INTO messages (id, session_id, direction, content, timestamp, metadata)
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO messages (id, session_id, direction, content, timestamp, metadata)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                params![
-                    message_id,
-                    session_id,
-                    direction,
-                    content,
-                    timestamp.to_rfc3339(),
-                    metadata.to_string()
-                ],
-            )
-            .map_err(|e| Error::Database(format!("failed to append message: {e}")))?;
+            params![
+                message_id,
+                session_id,
+                direction,
+                content,
+                timestamp.to_rfc3339(),
+                metadata.to_string()
+            ],
+        )
+        .map_err(|e| Error::Database(format!("failed to append message: {e}")))?;
         Ok(())
     }
 
@@ -204,8 +213,8 @@ impl SessionStore {
         session_id: &str,
         limit: usize,
     ) -> Result<Vec<StoredMessage>> {
-        let mut stmt = self
-            .conn
+        let conn = self.conn()?;
+        let mut stmt = conn
             .prepare(
                 "SELECT direction, content, timestamp, metadata
                  FROM messages
@@ -250,26 +259,26 @@ impl SessionStore {
         payload: &str,
     ) -> Result<String> {
         let task_id = uuid::Uuid::new_v4().to_string();
-        self.conn
-            .execute(
-                "INSERT INTO scheduled_tasks (id, session_id, user_id, execute_at, payload, status)
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO scheduled_tasks (id, session_id, user_id, execute_at, payload, status)
                  VALUES (?1, ?2, ?3, ?4, ?5, 'pending')",
-                params![
-                    task_id,
-                    session_id,
-                    user_id,
-                    execute_at.to_rfc3339(),
-                    payload
-                ],
-            )
-            .map_err(|e| Error::Database(format!("failed to schedule task: {e}")))?;
+            params![
+                task_id,
+                session_id,
+                user_id,
+                execute_at.to_rfc3339(),
+                payload
+            ],
+        )
+        .map_err(|e| Error::Database(format!("failed to schedule task: {e}")))?;
         Ok(task_id)
     }
 
     /// Poll for pending tasks that are due for execution.
     pub fn poll_due_tasks(&self) -> Result<Vec<ScheduledTask>> {
-        let mut stmt = self
-            .conn
+        let conn = self.conn()?;
+        let mut stmt = conn
             .prepare(
                 "SELECT t.id, t.session_id, s.channel_id, t.user_id, t.execute_at, t.payload,
                         s.metadata, t.retry_count, t.max_retries, t.heartbeat_depth,
@@ -321,8 +330,8 @@ impl SessionStore {
     /// Returns true if the task was still pending and is now completed,
     /// false if it was already cancelled or in another terminal state.
     pub fn complete_task(&self, task_id: &str) -> Result<bool> {
-        let rows = self
-            .conn
+        let conn = self.conn()?;
+        let rows = conn
             .execute(
                 "UPDATE scheduled_tasks SET status = 'completed' WHERE id = ?1 AND status = 'pending'",
                 params![task_id],
@@ -333,19 +342,19 @@ impl SessionStore {
 
     /// Mark a scheduled task as failed so it won't be retried.
     pub fn fail_task(&self, task_id: &str) -> Result<()> {
-        self.conn
-            .execute(
-                "UPDATE scheduled_tasks SET status = 'failed' WHERE id = ?1",
-                params![task_id],
-            )
-            .map_err(|e| Error::Database(format!("failed to mark task as failed: {e}")))?;
+        let conn = self.conn()?;
+        conn.execute(
+            "UPDATE scheduled_tasks SET status = 'failed' WHERE id = ?1",
+            params![task_id],
+        )
+        .map_err(|e| Error::Database(format!("failed to mark task as failed: {e}")))?;
         Ok(())
     }
 
     /// Load the metadata JSON for a session.
     pub fn load_session_metadata(&self, session_id: &str) -> Result<Option<serde_json::Value>> {
-        let mut stmt = self
-            .conn
+        let conn = self.conn()?;
+        let mut stmt = conn
             .prepare("SELECT metadata FROM sessions WHERE id = ?1")
             .map_err(|e| Error::Database(format!("failed to prepare metadata query: {e}")))?;
 
@@ -368,8 +377,8 @@ impl SessionStore {
     /// Delete all but the most recent `keep` messages for a session.
     /// Returns the number of deleted rows.
     pub fn prune_old_messages(&self, session_id: &str, keep: usize) -> Result<usize> {
-        let deleted = self
-            .conn
+        let conn = self.conn()?;
+        let deleted = conn
             .execute(
                 "DELETE FROM messages WHERE session_id = ?1 AND rowid NOT IN (
                     SELECT rowid FROM messages WHERE session_id = ?1
@@ -383,8 +392,8 @@ impl SessionStore {
 
     /// Count pending scheduled tasks for a given session.
     pub fn count_pending_tasks_for_session(&self, session_id: &str) -> Result<i64> {
-        let count: i64 = self
-            .conn
+        let conn = self.conn()?;
+        let count: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM scheduled_tasks WHERE session_id = ?1 AND status = 'pending'",
                 params![session_id],
@@ -397,8 +406,8 @@ impl SessionStore {
     /// Retry a failed task with exponential backoff, or mark it as permanently failed.
     /// Backoff schedule: 30s, 60s, 120s, 240s (doubles each retry).
     pub fn retry_or_fail_task(&self, task_id: &str) -> Result<bool> {
-        let (retry_count, max_retries): (i32, i32) = self
-            .conn
+        let conn = self.conn()?;
+        let (retry_count, max_retries): (i32, i32) = conn
             .query_row(
                 "SELECT COALESCE(retry_count, 0), COALESCE(max_retries, 3) FROM scheduled_tasks WHERE id = ?1",
                 params![task_id],
@@ -408,26 +417,29 @@ impl SessionStore {
 
         let new_count = retry_count + 1;
         if new_count > max_retries {
-            self.fail_task(task_id)?;
+            conn.execute(
+                "UPDATE scheduled_tasks SET status = 'failed' WHERE id = ?1",
+                params![task_id],
+            )
+            .map_err(|e| Error::Database(format!("failed to mark task as failed: {e}")))?;
             return Ok(false);
         }
 
         let backoff_secs = 30i64 * (1 << retry_count.min(7));
         let next_retry = chrono::Utc::now() + chrono::Duration::seconds(backoff_secs);
 
-        self.conn
-            .execute(
-                "UPDATE scheduled_tasks SET retry_count = ?1, next_retry_at = ?2 WHERE id = ?3",
-                params![new_count, next_retry.to_rfc3339(), task_id],
-            )
-            .map_err(|e| Error::Database(format!("failed to set retry: {e}")))?;
+        conn.execute(
+            "UPDATE scheduled_tasks SET retry_count = ?1, next_retry_at = ?2 WHERE id = ?3",
+            params![new_count, next_retry.to_rfc3339(), task_id],
+        )
+        .map_err(|e| Error::Database(format!("failed to set retry: {e}")))?;
         Ok(true)
     }
 
     /// Cancel a pending task, scoped to a session for safety.
     pub fn cancel_task(&self, task_id: &str, session_id: &str) -> Result<bool> {
-        let rows = self
-            .conn
+        let conn = self.conn()?;
+        let rows = conn
             .execute(
                 "UPDATE scheduled_tasks SET status = 'cancelled' WHERE id = ?1 AND session_id = ?2 AND status = 'pending'",
                 params![task_id, session_id],
@@ -438,8 +450,8 @@ impl SessionStore {
 
     /// List pending tasks for a session, ordered by execute_at.
     pub fn list_pending_tasks(&self, session_id: &str) -> Result<Vec<ScheduledTask>> {
-        let mut stmt = self
-            .conn
+        let conn = self.conn()?;
+        let mut stmt = conn
             .prepare(
                 "SELECT t.id, t.session_id, s.channel_id, t.user_id, t.execute_at, t.payload,
                         s.metadata, t.retry_count, t.max_retries, t.heartbeat_depth,
@@ -489,16 +501,15 @@ impl SessionStore {
     /// along with all their associated messages. Returns the number of sessions deleted.
     pub fn cleanup_stale_sessions(&self, inactive_days: i64) -> Result<usize> {
         let interval = format!("-{inactive_days} days");
-        self.conn
-            .execute(
-                "DELETE FROM messages WHERE session_id IN (
+        let conn = self.conn()?;
+        conn.execute(
+            "DELETE FROM messages WHERE session_id IN (
                      SELECT id FROM sessions WHERE updated_at < datetime('now', ?1)
                  )",
-                params![interval],
-            )
-            .map_err(|e| Error::Database(format!("failed to cleanup session messages: {e}")))?;
-        let deleted = self
-            .conn
+            params![interval],
+        )
+        .map_err(|e| Error::Database(format!("failed to cleanup session messages: {e}")))?;
+        let deleted = conn
             .execute(
                 "DELETE FROM sessions WHERE updated_at < datetime('now', ?1)",
                 params![interval],
@@ -510,8 +521,8 @@ impl SessionStore {
     /// Delete completed, failed, and cancelled tasks older than `older_than_days`.
     /// Returns the number of deleted rows.
     pub fn cleanup_completed_tasks(&self, older_than_days: i64) -> Result<usize> {
-        let deleted = self
-            .conn
+        let conn = self.conn()?;
+        let deleted = conn
             .execute(
                 "DELETE FROM scheduled_tasks
                  WHERE status IN ('completed', 'failed', 'cancelled')
@@ -539,27 +550,27 @@ impl SessionStore {
     ) -> Result<String> {
         let task_id = uuid::Uuid::new_v4().to_string();
         let end_at_str = recurrence_end_at.map(|dt| dt.to_rfc3339());
-        self.conn
-            .execute(
-                "INSERT INTO scheduled_tasks (id, session_id, user_id, execute_at, payload, status,
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO scheduled_tasks (id, session_id, user_id, execute_at, payload, status,
                     heartbeat_depth, recurrence_type, recurrence_value, recurrence_end_at,
                     deliver_to_channel, timezone)
                  VALUES (?1, ?2, ?3, ?4, ?5, 'pending', ?6, ?7, ?8, ?9, ?10, ?11)",
-                params![
-                    task_id,
-                    session_id,
-                    user_id,
-                    execute_at.to_rfc3339(),
-                    payload,
-                    heartbeat_depth,
-                    recurrence_type,
-                    recurrence_value,
-                    end_at_str,
-                    deliver_to_channel,
-                    timezone,
-                ],
-            )
-            .map_err(|e| Error::Database(format!("failed to schedule task: {e}")))?;
+            params![
+                task_id,
+                session_id,
+                user_id,
+                execute_at.to_rfc3339(),
+                payload,
+                heartbeat_depth,
+                recurrence_type,
+                recurrence_value,
+                end_at_str,
+                deliver_to_channel,
+                timezone,
+            ],
+        )
+        .map_err(|e| Error::Database(format!("failed to schedule task: {e}")))?;
         Ok(task_id)
     }
 
@@ -572,7 +583,8 @@ impl SessionStore {
         output_tokens: u32,
     ) -> Result<()> {
         let id = uuid::Uuid::new_v4().to_string();
-        self.conn
+        let conn = self.conn()?;
+        conn
             .execute(
                 "INSERT INTO usage_log
                      (id, session_id, user_id, channel_id, provider, model, input_tokens, output_tokens)
@@ -607,8 +619,8 @@ impl SessionStore {
              COALESCE(SUM(input_tokens+output_tokens),0) \
              FROM usage_log WHERE user_id = ?1{date_filter}"
         );
-        let row: (i64, i64, i64) = self
-            .conn
+        let conn = self.conn()?;
+        let row: (i64, i64, i64) = conn
             .query_row(&sql, params![user_id], |row| {
                 Ok((row.get(0)?, row.get(1)?, row.get(2)?))
             })
@@ -656,16 +668,15 @@ impl SessionStore {
             )
         };
 
+        let conn = self.conn()?;
         let row: (i64, i64, i64) = if params_vec.is_empty() {
-            self.conn
-                .query_row(&sql, [], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            conn.query_row(&sql, [], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
                 .map_err(|e| Error::Database(format!("failed to query usage: {e}")))?
         } else {
-            self.conn
-                .query_row(&sql, params![params_vec[0]], |row| {
-                    Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-                })
-                .map_err(|e| Error::Database(format!("failed to query usage: {e}")))?
+            conn.query_row(&sql, params![params_vec[0]], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .map_err(|e| Error::Database(format!("failed to query usage: {e}")))?
         };
 
         Ok(UsageRecord {
@@ -1217,6 +1228,7 @@ mod tests {
         // Backdate the created_at to 8 days ago so it qualifies for 7-day cleanup
         store
             .connection()
+            .unwrap()
             .execute(
                 "UPDATE scheduled_tasks SET created_at = datetime('now', '-8 days') WHERE id = ?1",
                 rusqlite::params![task_id],
@@ -1237,6 +1249,7 @@ mod tests {
             .unwrap();
         store
             .connection()
+            .unwrap()
             .execute(
                 "UPDATE scheduled_tasks SET created_at = datetime('now', '-8 days') WHERE id = ?1",
                 rusqlite::params![task_id2],
@@ -1270,6 +1283,7 @@ mod tests {
         // Backdate s1 to 91 days ago so it qualifies for 90-day cleanup
         store
             .connection()
+            .unwrap()
             .execute(
                 "UPDATE sessions SET updated_at = datetime('now', '-91 days') WHERE id = 's1'",
                 [],
@@ -1282,6 +1296,7 @@ mod tests {
         // Messages belonging to s1 should also be gone
         let msg_count: i64 = store
             .connection()
+            .unwrap()
             .query_row(
                 "SELECT COUNT(*) FROM messages WHERE session_id = 's1'",
                 [],
@@ -1293,6 +1308,7 @@ mod tests {
         // s2 should still exist
         let session_count: i64 = store
             .connection()
+            .unwrap()
             .query_row("SELECT COUNT(*) FROM sessions WHERE id = 's2'", [], |r| {
                 r.get(0)
             })

--- a/crates/opencrust-gateway/src/router.rs
+++ b/crates/opencrust-gateway/src/router.rs
@@ -299,10 +299,7 @@ async fn get_usage(
         }));
     };
 
-    let result = {
-        let guard = store.lock().await;
-        guard.query_usage(session_id, period)
-    };
+    let result = store.query_usage(session_id, period);
 
     match result {
         Ok(record) => axum::Json(serde_json::json!({

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -9,7 +9,6 @@ use opencrust_common::{
 use opencrust_config::{AppConfig, ConfigWatcher};
 use opencrust_db::SessionStore;
 use tokio::net::TcpListener;
-use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 #[cfg(target_os = "macos")]
@@ -65,7 +64,7 @@ impl GatewayServer {
         let sessions_db = data_dir.join("sessions.db");
         match SessionStore::open(&sessions_db) {
             Ok(store) => {
-                let store = Arc::new(Mutex::new(store));
+                let store = Arc::new(store);
                 state.set_session_store(Arc::clone(&store));
                 state
                     .agents
@@ -164,9 +163,8 @@ impl GatewayServer {
                 tick_count = tick_count.wrapping_add(1);
                 // Cleanup old completed/failed/cancelled tasks every ~hour (720 * 5s)
                 if tick_count.is_multiple_of(720)
-                    && let Some(store_mutex) = &scheduler_state.session_store
+                    && let Some(store) = &scheduler_state.session_store
                 {
-                    let store = store_mutex.lock().await;
                     match store.cleanup_completed_tasks(7) {
                         Ok(n) if n > 0 => info!("cleaned up {n} old scheduled tasks"),
                         Err(e) => tracing::error!("task cleanup failed: {e}"),
@@ -415,15 +413,12 @@ fn spawn_dna_watcher(state: Arc<AppState>, config_dir: PathBuf) {
 }
 
 async fn run_scheduler(state: &AppState) -> Result<()> {
-    let store_mutex = match &state.session_store {
+    let store = match &state.session_store {
         Some(s) => s,
         None => return Ok(()),
     };
 
-    let tasks = {
-        let store = store_mutex.lock().await;
-        store.poll_due_tasks()?
-    };
+    let tasks = store.poll_due_tasks()?;
 
     if tasks.is_empty() {
         return Ok(());
@@ -432,9 +427,8 @@ async fn run_scheduler(state: &AppState) -> Result<()> {
     info!("scheduler executing {} due tasks", tasks.len());
 
     for task in tasks {
-        if let Err(e) = execute_scheduled_task(state, store_mutex, &task).await {
+        if let Err(e) = execute_scheduled_task(state, store, &task).await {
             tracing::error!("Scheduled task {} failed: {e}", task.id);
-            let store = store_mutex.lock().await;
             match store.retry_or_fail_task(&task.id) {
                 Ok(true) => {
                     info!(
@@ -457,7 +451,7 @@ async fn run_scheduler(state: &AppState) -> Result<()> {
 
 async fn execute_scheduled_task(
     state: &AppState,
-    store_mutex: &Arc<Mutex<SessionStore>>,
+    store: &Arc<SessionStore>,
     task: &opencrust_db::ScheduledTask,
 ) -> Result<()> {
     // Resolve delivery channel: use override only if a sender is actually registered,
@@ -489,16 +483,13 @@ async fn execute_scheduled_task(
     };
 
     // 1. Persist system message to history so agent has context
-    {
-        let store = store_mutex.lock().await;
-        store.append_message(
-            &task.session_id,
-            "system",
-            &task.payload,
-            message.timestamp,
-            &task.session_metadata,
-        )?;
-    }
+    store.append_message(
+        &task.session_id,
+        "system",
+        &task.payload,
+        message.timestamp,
+        &task.session_metadata,
+    )?;
 
     // 2. Hydrate session history with the ORIGINAL session channel to avoid
     //    corrupting the session's channel_id when delivering cross-channel.
@@ -539,16 +530,13 @@ async fn execute_scheduled_task(
     };
 
     // 3. Persist assistant response regardless of outbound channel availability.
-    {
-        let store = store_mutex.lock().await;
-        store.append_message(
-            &task.session_id,
-            "assistant",
-            &response_text,
-            response_msg.timestamp,
-            &task.session_metadata,
-        )?;
-    }
+    store.append_message(
+        &task.session_id,
+        "assistant",
+        &response_text,
+        response_msg.timestamp,
+        &task.session_metadata,
+    )?;
 
     // 4. Best-effort delivery to channel adapter via sender handle.
     if let Some(sender) = state.channel_senders.get(delivery_channel) {
@@ -565,7 +553,6 @@ async fn execute_scheduled_task(
     // 5. Complete task and reschedule if recurring.
     //    Only reschedule if the task was still pending (not cancelled during execution).
     {
-        let store = store_mutex.lock().await;
         let was_completed = store.complete_task(&task.id)?;
         if was_completed {
             match store.reschedule_recurring_task(task) {

--- a/crates/opencrust-gateway/src/state.rs
+++ b/crates/opencrust-gateway/src/state.rs
@@ -12,7 +12,7 @@ use opencrust_config::{
     model::{GuardrailsConfig, RateLimitConfig},
 };
 use opencrust_db::SessionStore;
-use tokio::sync::{Mutex, watch};
+use tokio::sync::watch;
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -44,7 +44,7 @@ pub struct AppState {
     pub a2a_tasks: DashMap<String, opencrust_agents::a2a::A2ATask>,
     /// MCP manager wrapped in Arc for health monitoring and resource access.
     pub mcp_manager_arc: Option<Arc<opencrust_agents::McpManager>>,
-    pub session_store: Option<Arc<Mutex<SessionStore>>>,
+    pub session_store: Option<Arc<SessionStore>>,
     /// Per-session rolling summary string used by long-context agent flows.
     session_summaries: DashMap<String, String>,
     /// Runtime connection state for Google Workspace integration.
@@ -107,7 +107,7 @@ impl AppState {
     }
 
     /// Attach a persistent session store used to hydrate and persist chat history.
-    pub fn set_session_store(&mut self, store: Arc<Mutex<SessionStore>>) {
+    pub fn set_session_store(&mut self, store: Arc<SessionStore>) {
         self.session_store = Some(store);
     }
 
@@ -363,13 +363,12 @@ impl AppState {
 
         let mut loaded_history = Vec::new();
         {
-            let guard = store.lock().await;
-            if let Err(e) = guard.upsert_session(session_id, channel, user, &metadata) {
+            if let Err(e) = store.upsert_session(session_id, channel, user, &metadata) {
                 warn!("failed to upsert session {session_id} in session store: {e}");
             }
 
             if should_load {
-                match guard.load_recent_messages(session_id, 100) {
+                match store.load_recent_messages(session_id, 100) {
                     Ok(messages) => {
                         loaded_history = messages
                             .into_iter()
@@ -456,12 +455,11 @@ impl AppState {
             }
         }
 
-        let guard = store.lock().await;
-        if let Err(e) = guard.upsert_session(session_id, channel, user, &metadata) {
+        if let Err(e) = store.upsert_session(session_id, channel, user, &metadata) {
             warn!("failed to upsert session {session_id}: {e}");
             return;
         }
-        if let Err(e) = guard.append_message(
+        if let Err(e) = store.append_message(
             session_id,
             "user",
             user_text,
@@ -470,7 +468,7 @@ impl AppState {
         ) {
             warn!("failed to persist user message for {session_id}: {e}");
         }
-        if let Err(e) = guard.append_message(
+        if let Err(e) = store.append_message(
             session_id,
             "assistant",
             assistant_text,
@@ -517,8 +515,7 @@ impl AppState {
             })
             .unwrap_or_else(|| ("anonymous".to_string(), "unknown".to_string()));
 
-        let guard = store.lock().await;
-        if let Err(e) = guard.record_usage(
+        if let Err(e) = store.record_usage(
             session_id,
             opencrust_db::UsageAttribution {
                 user_id: &user_id,
@@ -569,10 +566,9 @@ impl AppState {
             let Some(store) = &self.session_store else {
                 return Ok(());
             };
-            let guard = store.lock().await;
 
             if let Some(daily_budget) = config.token_budget_user_daily {
-                match guard.query_usage_for_user(user_id, Some("today")) {
+                match store.query_usage_for_user(user_id, Some("today")) {
                     Ok(usage) if usage.total_tokens >= daily_budget as u64 => {
                         return Err(format!(
                             "token budget exceeded: you have used {} tokens today (daily limit: {daily_budget})",
@@ -585,7 +581,7 @@ impl AppState {
             }
 
             if let Some(monthly_budget) = config.token_budget_user_monthly {
-                match guard.query_usage_for_user(user_id, Some("month")) {
+                match store.query_usage_for_user(user_id, Some("month")) {
                     Ok(usage) if usage.total_tokens >= monthly_budget as u64 => {
                         return Err(format!(
                             "token budget exceeded: you have used {} tokens this month (monthly limit: {monthly_budget})",


### PR DESCRIPTION
## Summary

- Replaces `Arc<Mutex<SessionStore>>` (global serialisation lock) with `r2d2::Pool<SqliteConnectionManager>` (8 concurrent connections)
- `open()` configures WAL + `foreign_keys=ON` via `.with_init()` — pragma is applied to every new connection in the pool
- `in_memory()` uses `max_size(1)` so all test queries share the same in-memory database
- All callers in `state.rs`, `server.rs`, `router.rs`, `schedule.rs`, and `doctor.rs` have the `Mutex` wrapper and `.lock().await` removed — sessions can now read/write the store concurrently
- `retry_or_fail_task` refactored to reuse the same pooled connection for the entire operation, avoiding a nested checkout that would deadlock the single-connection test pool

Closes #169

## Test plan

- [x] `cargo test` — all 36 session-store tests pass, all 101 agent tests pass, full suite green
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)