### PR TITLE
fix(wechat): add 5-second timeout and MsgId deduplication

### DIFF
--- a/crates/opencrust-channels/src/wechat/mod.rs
+++ b/crates/opencrust-channels/src/wechat/mod.rs
@@ -2,6 +2,7 @@ pub mod api;
 pub mod fmt;
 pub mod webhook;
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -40,6 +41,10 @@ pub type WeChatOnMessageFn = Arc<
 /// Refresh slightly early to avoid expiry during a request.
 const TOKEN_TTL: Duration = Duration::from_secs(7000);
 
+/// How long to remember a MsgId for deduplication.
+/// WeChat retries up to 3 times over ~15 seconds; 120 s gives a safe margin.
+const MSG_ID_TTL: Duration = Duration::from_secs(120);
+
 /// Cached access token with the instant it was fetched.
 type TokenCache = Arc<RwLock<Option<(String, Instant)>>>;
 
@@ -55,6 +60,8 @@ pub struct WeChatChannel {
     on_message: WeChatOnMessageFn,
     group_filter: WeChatGroupFilter,
     token_cache: TokenCache,
+    /// In-memory deduplication cache for WeChat MsgIds (TTL = MSG_ID_TTL).
+    msg_id_cache: Arc<RwLock<HashMap<String, Instant>>>,
 }
 
 impl WeChatChannel {
@@ -85,6 +92,7 @@ impl WeChatChannel {
             on_message,
             group_filter,
             token_cache: Arc::new(RwLock::new(None)),
+            msg_id_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -130,6 +138,24 @@ impl WeChatChannel {
             None,
         )
         .await
+    }
+
+    /// Check whether `msg_id` was already processed within `MSG_ID_TTL`.
+    ///
+    /// Returns `true` (duplicate — skip) or `false` (new — record and process).
+    /// Expired entries are pruned on every call to bound memory usage.
+    pub async fn check_and_mark_msg_id(&self, msg_id: &str) -> bool {
+        if msg_id.is_empty() {
+            return false;
+        }
+        let now = Instant::now();
+        let mut cache = self.msg_id_cache.write().await;
+        cache.retain(|_, seen_at| now.duration_since(*seen_at) < MSG_ID_TTL);
+        if cache.contains_key(msg_id) {
+            return true;
+        }
+        cache.insert(msg_id.to_string(), now);
+        false
     }
 }
 

--- a/crates/opencrust-channels/src/wechat/webhook.rs
+++ b/crates/opencrust-channels/src/wechat/webhook.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::body::Bytes;
 use axum::extract::{Query, Request, State};
@@ -8,6 +9,10 @@ use ring::digest;
 use serde::Deserialize;
 use subtle::ConstantTimeEq;
 use tracing::{info, warn};
+
+/// WeChat requires a passive-reply within 5 seconds or it retries.
+/// We use a 4-second budget to leave headroom for serialization.
+const WECHAT_SYNC_TIMEOUT: Duration = Duration::from_secs(4);
 
 use super::WeChatChannel;
 use super::api;
@@ -172,11 +177,25 @@ pub async fn wechat_webhook(
     let to_user = fmt::extract_xml_field(&xml, "ToUserName")
         .unwrap_or("")
         .to_string();
+    let msg_id = fmt::extract_xml_field(&xml, "MsgId")
+        .unwrap_or("")
+        .to_string();
 
     // WeChat does not have a concept of group chats on the Official Account API.
     let is_group = false;
 
     if !channel.group_filter()(is_group) {
+        return (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/xml")],
+            String::new(),
+        );
+    }
+
+    // Deduplicate: WeChat retries the same MsgId up to 3 times when no
+    // response arrives within 5 seconds. Drop already-seen messages.
+    if channel.check_and_mark_msg_id(&msg_id).await {
+        info!("wechat: duplicate MsgId={msg_id} from openid={from_user}, dropping");
         return (
             StatusCode::OK,
             [(header::CONTENT_TYPE, "text/xml")],
@@ -190,13 +209,17 @@ pub async fn wechat_webhook(
         content.len()
     );
 
-    // Attempt a synchronous reply within the 5-second window.
-    let result = channel
-        .handle_incoming(&from_user, &from_user, &content, is_group)
-        .await;
+    // Attempt a synchronous reply within the WeChat 5-second window.
+    // Use a 4-second timeout to leave headroom for response serialization.
+    let sync_result = tokio::time::timeout(
+        WECHAT_SYNC_TIMEOUT,
+        channel.handle_incoming(&from_user, &from_user, &content, is_group),
+    )
+    .await;
 
-    match result {
-        Ok(response) => {
+    match sync_result {
+        // Replied in time — send passive XML reply.
+        Ok(Ok(response)) => {
             let reply_text = fmt::to_wechat_text(&response);
             let reply_xml = fmt::build_reply_xml(&from_user, &to_user, &reply_text);
             info!("wechat: sync reply sent to openid={from_user}");
@@ -206,14 +229,15 @@ pub async fn wechat_webhook(
                 reply_xml,
             )
         }
-        Err(e) if e == "__blocked__" => (
+        // Silently blocked (e.g. unauthorized user).
+        Ok(Err(e)) if e == "__blocked__" => (
             StatusCode::OK,
             [(header::CONTENT_TYPE, "text/xml")],
             String::new(),
         ),
-        Err(e) => {
-            warn!("wechat: error processing message: {e}");
-            // Spawn an async push for the error reply so we don't time out.
+        // LLM error — push error message asynchronously and return empty.
+        Ok(Err(e)) => {
+            warn!("wechat: error processing message from openid={from_user}: {e}");
             let ch = Arc::clone(&channel);
             let openid = from_user.clone();
             tokio::spawn(async move {
@@ -231,6 +255,44 @@ pub async fn wechat_webhook(
                         .await;
                     }
                     Err(e) => warn!("wechat: failed to get access token for error push: {e}"),
+                }
+            });
+            (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "text/xml")],
+                String::new(),
+            )
+        }
+        // Timeout — LLM is taking too long. Return empty immediately so
+        // WeChat does not retry, then push the response via Customer Service
+        // API once the LLM finishes.
+        Err(_elapsed) => {
+            info!("wechat: LLM timeout for openid={from_user}, spawning async push");
+            let ch = Arc::clone(&channel);
+            let openid = from_user.clone();
+            let content_bg = content.clone();
+            tokio::spawn(async move {
+                let result = ch
+                    .handle_incoming(&openid, &openid, &content_bg, is_group)
+                    .await;
+                let reply = match result {
+                    Ok(r) => fmt::to_wechat_text(&r),
+                    Err(e) => {
+                        warn!("wechat: async LLM error for openid={openid}: {e}");
+                        "Sorry, an error occurred.".to_string()
+                    }
+                };
+                match api::get_access_token(ch.client(), ch.appid(), ch.secret(), ch.api_base_url())
+                    .await
+                {
+                    Ok(token) => {
+                        if let Err(e) =
+                            api::push(ch.client(), &token, &openid, &reply, ch.api_base_url()).await
+                        {
+                            warn!("wechat: async push failed for openid={openid}: {e}");
+                        }
+                    }
+                    Err(e) => warn!("wechat: failed to get access token for async push: {e}"),
                 }
             });
             (
@@ -285,6 +347,15 @@ mod tests {
     }
 
     fn text_message_xml(from_user: &str, to_user: &str, content: &str) -> String {
+        text_message_xml_with_id(from_user, to_user, content, "1234567890")
+    }
+
+    fn text_message_xml_with_id(
+        from_user: &str,
+        to_user: &str,
+        content: &str,
+        msg_id: &str,
+    ) -> String {
         format!(
             "<xml>\
                 <ToUserName><![CDATA[{to_user}]]></ToUserName>\
@@ -292,7 +363,7 @@ mod tests {
                 <CreateTime>1234567890</CreateTime>\
                 <MsgType><![CDATA[text]]></MsgType>\
                 <Content><![CDATA[{content}]]></Content>\
-                <MsgId>1234567890</MsgId>\
+                <MsgId>{msg_id}</MsgId>\
             </xml>"
         )
     }
@@ -530,5 +601,100 @@ mod tests {
         let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
         let reply = std::str::from_utf8(&bytes).unwrap();
         assert!(reply.contains("<![CDATA[reply]]>"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_msg_id_returns_empty_response() {
+        let token = "mytoken";
+        let timestamp = "1700000000";
+        let nonce = "abc123";
+        let sig = sign(token, timestamp, nonce);
+        let state = make_state(token);
+        let router = make_router(Arc::clone(&state));
+
+        let body = text_message_xml_with_id("oUser", "gh_account", "hello", "msg_unique_99");
+        let uri = format!("/wechat/webhook?signature={sig}&timestamp={timestamp}&nonce={nonce}");
+
+        // First request — should be processed normally.
+        let resp1 = router
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri(&uri)
+                    .header("content-type", "text/xml")
+                    .body(Body::from(body.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp1.status(), StatusCode::OK);
+        let bytes1 = axum::body::to_bytes(resp1.into_body(), 4096).await.unwrap();
+        assert!(!bytes1.is_empty(), "first request should return a reply");
+
+        // Second request with identical MsgId — should be dropped (empty body).
+        let resp2 = router
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri(&uri)
+                    .header("content-type", "text/xml")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp2.status(), StatusCode::OK);
+        let bytes2 = axum::body::to_bytes(resp2.into_body(), 256).await.unwrap();
+        assert!(
+            bytes2.is_empty(),
+            "duplicate MsgId should return empty body"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_returns_empty_response() {
+        let token = "mytoken";
+        let timestamp = "1700000000";
+        let nonce = "abc123";
+        let sig = sign(token, timestamp, nonce);
+
+        // on_message that takes longer than WECHAT_SYNC_TIMEOUT.
+        let on_msg: WeChatOnMessageFn = Arc::new(|_uid, _ctx, _text, _is_group, _| {
+            Box::pin(async {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                Ok("late reply".to_string())
+            })
+        });
+        let ch = Arc::new(WeChatChannel::new(
+            "appid".to_string(),
+            "secret".to_string(),
+            token.to_string(),
+            on_msg,
+        ));
+        let state: WeChatWebhookState = Arc::new(vec![ch]);
+        let router = make_router(state);
+
+        let body = text_message_xml_with_id("oUser", "gh_account", "slow", "msg_slow_1");
+        let uri = format!("/wechat/webhook?signature={sig}&timestamp={timestamp}&nonce={nonce}");
+
+        let resp = router
+            .oneshot(
+                axum::http::Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("content-type", "text/xml")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 256).await.unwrap();
+        assert!(
+            bytes.is_empty(),
+            "timed-out request should return empty body so WeChat does not retry"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #243.

Two related bugs in the WeChat webhook handler that caused duplicate message processing:

### 1. Timeout (no passive-reply within WeChat's 5-second window)

`handle_incoming` was awaited synchronously with no timeout. LLM responses commonly exceed 5 seconds, causing WeChat to retry the same message up to 3 times.

Fix: wrap `handle_incoming` in `tokio::time::timeout(4s)`:
- **In time** → send passive XML reply as before
- **Timeout** → return empty `200` immediately (WeChat stops retrying), then spawn a background task that calls the LLM and pushes the response via the Customer Service API

### 2. Deduplication (MsgId never checked)

`MsgId` was extracted from the XML but never used. Combined with the timeout issue, the same message was processed 2–3 times.

Fix: add `msg_id_cache: Arc<RwLock<HashMap<String, Instant>>>` to `WeChatChannel`:
- `check_and_mark_msg_id()` — returns `true` (duplicate, drop) or `false` (new, process)
- Entries expire after 120 s (well beyond WeChat's 15 s retry window)
- Expired entries pruned on every call to bound memory usage

## Test plan

- [x] `cargo test --features wechat` — all 25 tests pass (including 2 new tests)
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean
- [x] New tests:
  - `duplicate_msg_id_returns_empty_response` — second request with same MsgId returns empty body while first returns a reply
  - `timeout_returns_empty_response` — slow on_message (10 s) causes handler to return empty body within the 4-second budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)