### PR TITLE
fix: rate limiter memory leak, LINE webhook URL, SessionStore path on macOS

### DIFF
--- a/crates/opencrust-channels/src/line/webhook.rs
+++ b/crates/opencrust-channels/src/line/webhook.rs
@@ -13,7 +13,7 @@ use super::fmt;
 /// Shared state passed to LINE webhook handlers.
 pub type LineWebhookState = Arc<Vec<Arc<LineChannel>>>;
 
-/// POST /line/webhook — receives webhook events from the LINE platform.
+/// POST /webhooks/line — receives webhook events from the LINE platform.
 ///
 /// Verifies the `X-Line-Signature` header (HMAC-SHA256 with channel secret),
 /// then dispatches each text message event to the configured channel.
@@ -234,7 +234,7 @@ mod tests {
 
     fn make_router(state: LineWebhookState) -> Router {
         Router::new()
-            .route("/line/webhook", post(line_webhook))
+            .route("/webhooks/line", post(line_webhook))
             .with_state(state)
     }
 
@@ -263,7 +263,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/line/webhook")
+                    .uri("/webhooks/line")
                     .header("x-line-signature", sig)
                     .header("content-type", "application/json")
                     .body(Body::from(body))
@@ -283,7 +283,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/line/webhook")
+                    .uri("/webhooks/line")
                     .header("x-line-signature", "badsig")
                     .header("content-type", "application/json")
                     .body(Body::from(body))
@@ -303,7 +303,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/line/webhook")
+                    .uri("/webhooks/line")
                     .header("content-type", "application/json")
                     .body(Body::from(body))
                     .unwrap(),
@@ -329,7 +329,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/line/webhook")
+                    .uri("/webhooks/line")
                     .header("x-line-signature", sig)
                     .header("content-type", "application/json")
                     .body(Body::from(body))
@@ -362,7 +362,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/line/webhook")
+                    .uri("/webhooks/line")
                     .header("x-line-signature", sig)
                     .header("content-type", "application/json")
                     .body(Body::from(body))
@@ -401,7 +401,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/line/webhook")
+                    .uri("/webhooks/line")
                     .header("x-line-signature", sig)
                     .header("content-type", "application/json")
                     .body(Body::from(body))
@@ -440,7 +440,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/line/webhook")
+                    .uri("/webhooks/line")
                     .header("x-line-signature", sig)
                     .header("content-type", "application/json")
                     .body(Body::from(body))
@@ -479,7 +479,7 @@ mod tests {
             .oneshot(
                 Request::builder()
                     .method("POST")
-                    .uri("/line/webhook")
+                    .uri("/webhooks/line")
                     .header("x-line-signature", sig)
                     .header("content-type", "application/json")
                     .body(Body::from(body))

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -52,12 +52,10 @@ impl GatewayServer {
         state.mcp_manager_arc = Some(Arc::clone(&mcp_manager_arc));
 
         // Initialize persistent session storage used by channel memory bus hydration.
-        let data_dir = state
-            .config
-            .data_dir
-            .clone()
-            .or_else(|| dirs::home_dir().map(|h| h.join(".opencrust").join("data")))
-            .unwrap_or_else(|| ".opencrust/data".into());
+        let data_dir =
+            state.config.data_dir.clone().unwrap_or_else(|| {
+                opencrust_config::ConfigLoader::default_config_dir().join("data")
+            });
         if let Err(e) = std::fs::create_dir_all(&data_dir) {
             warn!("failed to create data directory: {e}");
         }

--- a/crates/opencrust-gateway/src/state.rs
+++ b/crates/opencrust-gateway/src/state.rs
@@ -670,6 +670,22 @@ impl AppState {
         self.agents
             .retain_session_tool_configs(|session_id| self.sessions.contains_key(session_id));
 
+        // Evict rate-limit entries whose sliding window has fully expired and
+        // whose cooldown (if any) has also elapsed. Without this, the DashMap
+        // grows unboundedly on public bots with many unique users.
+        self.user_rate_limits.retain(|_, entry| {
+            let window_active = entry
+                .timestamps
+                .back()
+                .map(|t| now.duration_since(*t) < RATE_LIMIT_WINDOW)
+                .unwrap_or(false);
+            let cooldown_active = entry
+                .cooldown_until
+                .map(|until| now < until)
+                .unwrap_or(false);
+            window_active || cooldown_active
+        });
+
         if removed > 0 {
             info!("cleaned up {removed} expired sessions");
         }
@@ -965,5 +981,45 @@ mod tests {
         state.cleanup_expired_sessions();
 
         assert!(!state.session_token_counts.contains_key(&id));
+    }
+
+    #[test]
+    fn cleanup_evicts_stale_rate_limit_entries() {
+        let state = test_state();
+        let cfg = rate_limit_config(60, 5, 0);
+
+        // Record a message for "user_a" so an entry is created.
+        assert!(state.check_user_rate_limit("user_a", &cfg).is_ok());
+        assert!(state.user_rate_limits.contains_key("user_a"));
+
+        // Backdate the timestamps so they fall outside the sliding window.
+        if let Some(mut entry) = state.user_rate_limits.get_mut("user_a") {
+            for ts in entry.timestamps.iter_mut() {
+                *ts = Instant::now() - RATE_LIMIT_WINDOW - Duration::from_secs(1);
+            }
+        }
+
+        state.cleanup_expired_sessions();
+
+        assert!(
+            !state.user_rate_limits.contains_key("user_a"),
+            "stale rate-limit entry should be evicted by cleanup"
+        );
+    }
+
+    #[test]
+    fn cleanup_retains_active_rate_limit_entries() {
+        let state = test_state();
+        let cfg = rate_limit_config(60, 5, 0);
+
+        // Record a fresh message — entry is within the window.
+        assert!(state.check_user_rate_limit("user_b", &cfg).is_ok());
+
+        state.cleanup_expired_sessions();
+
+        assert!(
+            state.user_rate_limits.contains_key("user_b"),
+            "active rate-limit entry should NOT be evicted"
+        );
     }
 }

--- a/docs/src/channels/line.md
+++ b/docs/src/channels/line.md
@@ -26,7 +26,7 @@ You can also use environment variables: `LINE_CHANNEL_ACCESS_TOKEN` and `LINE_CH
 ## Webhook Setup
 
 1.  In the LINE Developers Console, go to **Messaging API** settings.
-2.  Set the **Webhook URL** to: `https://your-domain.com/line/webhook`
+2.  Set the **Webhook URL** to: `https://your-domain.com/webhooks/line`
 3.  Enable **Use webhook**.
 4.  (Optional) Disable **Auto-response messages** and **Greeting messages** in the LINE Official Account manager to avoid duplicate responses.
 


### PR DESCRIPTION
## Summary

Closes #244, closes #245, closes #247.

### Rate limiter memory leak (#244)

`user_rate_limits: DashMap<String, UserRateLimitEntry>` in `state.rs` was never pruned. On a public bot with many unique users this is a slow but unbounded memory leak.

Fix: added `user_rate_limits.retain(...)` to `cleanup_expired_sessions()` that removes entries where all timestamps have left the 60-second sliding window **and** no cooldown is active. The cleanup task already runs on a periodic interval so no new infrastructure is needed.

New tests: `cleanup_evicts_stale_rate_limit_entries`, `cleanup_retains_active_rate_limit_entries`.

### LINE docs: wrong webhook URL (#245)

`docs/src/channels/line.md` and the doc comment in `line/webhook.rs` both said `/line/webhook`, but the actual route registered in `router.rs` is `/webhooks/line`. Users following the docs would configure the wrong URL in LINE Developers Console and get 404s.

Fix: updated the doc comment, all test route strings in `webhook.rs`, and the docs to `/webhooks/line`.

### SessionStore wrong path on macOS (#247)

The `data_dir` fallback in `server.rs` was `dirs::home_dir()/.opencrust/data`, which is XDG-unaware. On macOS this opened `sessions.db` at `~/.opencrust/data/sessions.db` while `memory.db` and the document store used `~/Library/Application Support/opencrust/data/`. The path mismatch caused `database is locked` errors at startup.

Fix: replaced the fallback with `ConfigLoader::default_config_dir().join("data")` — the same path resolver used everywhere else in the codebase.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean
- [x] New tests: `cleanup_evicts_stale_rate_limit_entries`, `cleanup_retains_active_rate_limit_entries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)