### PR TITLE
docs(readme): document optional gateway.api_key in config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ OpenCrust looks for config at `~/.opencrust/config.yml`:
 gateway:
   host: "127.0.0.1"
   port: 3888
+  # api_key: "your-secret-key"  # optional: protects /api/* endpoints when exposed publicly
+                                 # generate with: openssl rand -hex 32
 
 llm:
   claude:

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -207,6 +207,8 @@ OpenCrust `~/.opencrust/config.yml` से config पढ़ता है:
 gateway:
   host: "127.0.0.1"
   port: 3888
+  # api_key: "your-secret-key"  # वैकल्पिक: सार्वजनिक रूप से उजागर होने पर /api/* की सुरक्षा करता है
+                                 # generate करें: openssl rand -hex 32
 
 llm:
   claude:

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -207,6 +207,8 @@ OpenCrust อ่าน config จาก `~/.opencrust/config.yml`:
 gateway:
   host: "127.0.0.1"
   port: 3888
+  # api_key: "your-secret-key"  # ไม่บังคับ: ป้องกัน /api/* เมื่อเปิดให้เข้าถึงสาธารณะ
+                                 # สร้างด้วย: openssl rand -hex 32
 
 llm:
   claude:

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -208,6 +208,8 @@ OpenCrust 默认搜索路径为 `~/.opencrust/config.yml`:
 gateway:
   host: "127.0.0.1"
   port: 3888
+  # api_key: "your-secret-key"  # 可选：公开部署时保护 /api/* 端点
+                                 # 生成命令：openssl rand -hex 32
 
 llm:
   claude:


### PR DESCRIPTION
## Summary

- Adds a commented-out `api_key` field to the gateway config snippet in the README
- Makes the option discoverable without changing any defaults
- Includes a hint to generate a secure key with `openssl rand -hex 32`

## Motivation

Users exposing the gateway publicly (reverse proxy, VPS) have no indication that `gateway.api_key` exists until they hit a 403 or read the source. This two-line comment closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)