### PR TITLE
feat(line): resolve bot name from LINE API and enable mention detection

### DIFF
--- a/crates/opencrust-channels/src/line/api.rs
+++ b/crates/opencrust-channels/src/line/api.rs
@@ -63,6 +63,58 @@ pub async fn reply(
     }
 }
 
+/// Bot profile returned by `GET /v2/bot/info`.
+pub struct BotInfo {
+    /// Display name shown to users (e.g. `"MyBot"`).
+    pub display_name: String,
+    /// LINE user ID of the bot (e.g. `"Uxxxxxxxxx"`), used for mention detection.
+    pub user_id: String,
+}
+
+/// Fetch the bot's profile from the LINE Bot API.
+///
+/// Calls `GET {base_url}/info` and returns `displayName` and `userId`.
+pub async fn get_bot_info(
+    client: &Client,
+    channel_access_token: &str,
+    base_url: &str,
+) -> Result<BotInfo, String> {
+    let resp = client
+        .get(format!("{base_url}/info"))
+        .bearer_auth(channel_access_token)
+        .send()
+        .await
+        .map_err(|e| format!("line get_bot_info request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!("line get_bot_info error {status}: {body}"));
+    }
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("line get_bot_info parse failed: {e}"))?;
+
+    let display_name = json
+        .get("displayName")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "line get_bot_info: displayName missing".to_string())?
+        .to_string();
+
+    let user_id = json
+        .get("userId")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "line get_bot_info: userId missing".to_string())?
+        .to_string();
+
+    Ok(BotInfo {
+        display_name,
+        user_id,
+    })
+}
+
 /// Send a push message to a user ID (paid tier, works at any time).
 pub async fn push(
     client: &Client,

--- a/crates/opencrust-channels/src/line/mod.rs
+++ b/crates/opencrust-channels/src/line/mod.rs
@@ -61,6 +61,9 @@ pub struct LineChannel {
     /// Defaults to `https://api-data.line.me/v2/bot`.
     data_api_base_url: String,
     display: String,
+    /// LINE user ID of this bot, resolved from `GET /v2/bot/info` on connect.
+    /// Used to detect `@mention` in group messages.
+    bot_user_id: Option<String>,
     status: ChannelStatus,
     on_message: LineOnMessageFn,
     group_filter: LineGroupFilter,
@@ -92,7 +95,8 @@ impl LineChannel {
             channel_secret,
             api_base_url: api::LINE_API_BASE.to_string(),
             data_api_base_url: api::LINE_DATA_API_BASE.to_string(),
-            display: "LINE".to_string(),
+            display: String::new(),
+            bot_user_id: None,
             status: ChannelStatus::Disconnected,
             on_message,
             group_filter,
@@ -125,6 +129,10 @@ impl LineChannel {
 
     pub fn group_filter(&self) -> &LineGroupFilter {
         &self.group_filter
+    }
+
+    pub fn bot_user_id(&self) -> Option<&str> {
+        self.bot_user_id.as_deref()
     }
 
     /// Verify the `X-Line-Signature` header.
@@ -202,6 +210,20 @@ impl ChannelLifecycle for LineChannel {
     async fn connect(&mut self) -> Result<()> {
         // LINE is webhook-driven — no persistent connection needed.
         // Register POST /line/webhook in the gateway router.
+        match api::get_bot_info(&self.client, &self.channel_access_token, &self.api_base_url).await
+        {
+            Ok(info) => {
+                info!(
+                    "line: bot resolved — name: {}, userId: {}",
+                    info.display_name, info.user_id
+                );
+                self.display = info.display_name;
+                self.bot_user_id = Some(info.user_id);
+            }
+            Err(e) => {
+                tracing::warn!("line: could not resolve bot info: {e}");
+            }
+        }
         self.status = ChannelStatus::Connected;
         info!("line channel connected (webhook mode)");
         Ok(())
@@ -283,7 +305,7 @@ mod tests {
     fn channel_type_is_line() {
         let ch = LineChannel::new("tok".to_string(), "sec".to_string(), make_on_msg());
         assert_eq!(ch.channel_type(), "line");
-        assert_eq!(ch.display_name(), "LINE");
+        assert_eq!(ch.display_name(), "");
         assert_eq!(ch.status(), ChannelStatus::Disconnected);
     }
 

--- a/crates/opencrust-channels/src/line/webhook.rs
+++ b/crates/opencrust-channels/src/line/webhook.rs
@@ -146,8 +146,24 @@ pub async fn line_webhook(
             user_id.clone()
         };
 
-        // Apply group filter — LINE has no reliable mention detection, so is_mentioned = false.
-        if is_group && !channel.group_filter()(false) {
+        // Detect @mention: LINE includes mention data in message.mention.mentionees.
+        // Each mentionee has a `userId` field; match against the bot's own userId.
+        let is_mentioned = if is_group {
+            let bot_uid = channel.bot_user_id().unwrap_or("");
+            msg.get("mention")
+                .and_then(|m| m.get("mentionees"))
+                .and_then(|v| v.as_array())
+                .map(|mentionees| {
+                    mentionees
+                        .iter()
+                        .any(|m| m.get("userId").and_then(|v| v.as_str()) == Some(bot_uid))
+                })
+                .unwrap_or(false)
+        } else {
+            false
+        };
+
+        if is_group && !channel.group_filter()(is_mentioned) {
             continue;
         }
 

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3128,7 +3128,7 @@ pub fn build_imessage_channels(
 pub fn build_line_channels(
     config: &AppConfig,
     state: &SharedState,
-) -> Vec<Arc<opencrust_channels::line::LineChannel>> {
+) -> Vec<opencrust_channels::line::LineChannel> {
     use opencrust_channels::line::{LineChannel, LineFile, LineGroupFilter, LineOnMessageFn};
 
     let mut channels = Vec::new();
@@ -3174,15 +3174,9 @@ pub fn build_line_channels(
             .and_then(|v| v.as_str())
             .unwrap_or("open");
 
-        if group_policy == "mention" {
-            warn!(
-                "line channel '{name}': group_policy 'mention' is not supported \
-                 (LINE has no mention detection API) — treating as 'disabled'"
-            );
-        }
-
         let group_filter: LineGroupFilter = match group_policy {
-            "disabled" | "mention" => Arc::new(|_| false),
+            "disabled" => Arc::new(|_| false),
+            "mention" => Arc::new(|is_mentioned| is_mentioned),
             _ => Arc::new(|_| true), // "open" — process all group messages
         };
 
@@ -3414,12 +3408,12 @@ pub fn build_line_channels(
             },
         );
 
-        let channel = Arc::new(LineChannel::with_group_filter(
+        let channel = LineChannel::with_group_filter(
             channel_access_token,
             channel_secret,
             on_message,
             group_filter,
-        ));
+        );
         channels.push(channel);
         info!("configured line channel: {name}");
     }

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -294,7 +294,14 @@ impl GatewayServer {
         }
 
         // Start LINE channels (webhook mode)
-        let line_channels = build_line_channels(&state.config, &state);
+        let mut line_channels_raw = build_line_channels(&state.config, &state);
+        for channel in &mut line_channels_raw {
+            if let Err(e) = channel.connect().await {
+                warn!("line channel failed to connect: {e}");
+            }
+        }
+        let line_channels: Vec<Arc<opencrust_channels::line::LineChannel>> =
+            line_channels_raw.into_iter().map(Arc::new).collect();
         for channel in &line_channels {
             let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
             state


### PR DESCRIPTION
## Summary

- Resolve LINE bot display name and `userId` from `GET /v2/bot/info` at startup instead of hardcoding `"LINE"`
- Store `bot_user_id` in `LineChannel` and use it to detect `@mention` in group messages via `message.mention.mentionees`
- Enable `group_policy: mention` for LINE (previously fell back to `disabled` with a warning)
- Call `connect()` for LINE channels in `server.rs` so bot info is fetched once at startup
- Change `build_line_channels()` to return `Vec<LineChannel>` to allow mutation before wrapping in `Arc`

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p opencrust-channels --features line` — 30/30 passed
- [x] Manual: configure a LINE channel with `group_policy: mention` and verify bot only responds when `@BotName` is used in a group

🤖 Generated with [Claude Code](https://claude.com/claude-code)