### PR TITLE
feat(rag): auto-inject document context into LLM messages (#252)

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex, RwLock};
 
 use dashmap::DashMap;
@@ -50,6 +51,8 @@ pub struct AgentRuntime {
     debug: bool,
     /// Debug info accumulated during message processing, keyed by session_id.
     debug_accumulator: Mutex<HashMap<String, Vec<String>>>,
+    /// Path to the document store DB for auto-RAG injection.
+    doc_db_path: Option<PathBuf>,
 }
 
 /// Per-session tool configuration set before processing a message.
@@ -73,6 +76,7 @@ impl AgentRuntime {
             max_tokens: None,
             max_context_tokens: None,
             recall_limit: 10,
+            doc_db_path: None,
             summarization_enabled: true,
             usage_accumulator: Mutex::new(HashMap::new()),
             session_tool_config: DashMap::new(),
@@ -720,9 +724,11 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let base_prompt = self.base_prompt_with_tools();
+        let rag_context = self.auto_rag_context(user_text).await;
         let system = build_system_prompt(
             base_prompt.as_deref(),
             dna.as_deref(),
+            rag_context.as_deref(),
             memory_context.as_deref(),
             None,
         );
@@ -875,9 +881,11 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let base_prompt = self.base_prompt_with_tools();
+        let rag_context = self.auto_rag_context(user_text).await;
         let system = build_system_prompt(
             base_prompt.as_deref(),
             dna.as_deref(),
+            rag_context.as_deref(),
             memory_context.as_deref(),
             session_summary,
         );
@@ -887,7 +895,10 @@ impl AgentRuntime {
         let mut messages: Vec<ChatMessage> = conversation_history.to_vec();
         messages.push(ChatMessage {
             role: ChatRole::User,
-            content: MessagePart::Text(user_text.to_string()),
+            content: inject_rag_into_content(
+                MessagePart::Text(user_text.to_string()),
+                rag_context.as_deref(),
+            ),
         });
 
         let max_ctx = self.max_context_tokens.unwrap_or(100_000);
@@ -906,6 +917,7 @@ impl AgentRuntime {
             build_system_prompt(
                 base_prompt.as_deref(),
                 dna.as_deref(),
+                rag_context.as_deref(),
                 memory_context.as_deref(),
                 new_summary.as_deref(),
             )
@@ -1036,9 +1048,11 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let base_prompt = self.base_prompt_with_tools();
+        let rag_context = self.auto_rag_context(memory_text).await;
         let system = build_system_prompt(
             base_prompt.as_deref(),
             dna.as_deref(),
+            rag_context.as_deref(),
             memory_context.as_deref(),
             None,
         );
@@ -1048,7 +1062,7 @@ impl AgentRuntime {
         let mut messages: Vec<ChatMessage> = conversation_history.to_vec();
         messages.push(ChatMessage {
             role: ChatRole::User,
-            content: user_content,
+            content: inject_rag_into_content(user_content, rag_context.as_deref()),
         });
 
         // Trim conversation history to fit context window
@@ -1247,9 +1261,11 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let base_prompt = self.base_prompt_with_tools();
+        let rag_context = self.auto_rag_context(memory_text).await;
         let system = build_system_prompt(
             base_prompt.as_deref(),
             dna.as_deref(),
+            rag_context.as_deref(),
             memory_context.as_deref(),
             None,
         );
@@ -1259,7 +1275,7 @@ impl AgentRuntime {
         let mut messages: Vec<ChatMessage> = conversation_history.to_vec();
         messages.push(ChatMessage {
             role: ChatRole::User,
-            content: user_content,
+            content: inject_rag_into_content(user_content, rag_context.as_deref()),
         });
 
         let max_ctx = self.max_context_tokens.unwrap_or(100_000);
@@ -1546,9 +1562,11 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let base_prompt = self.base_prompt_with_tools();
+        let rag_context = self.auto_rag_context(memory_text).await;
         let system = build_system_prompt(
             base_prompt.as_deref(),
             dna.as_deref(),
+            rag_context.as_deref(),
             memory_context.as_deref(),
             session_summary,
         );
@@ -1558,7 +1576,7 @@ impl AgentRuntime {
         let mut messages: Vec<ChatMessage> = conversation_history.to_vec();
         messages.push(ChatMessage {
             role: ChatRole::User,
-            content: user_content,
+            content: inject_rag_into_content(user_content, rag_context.as_deref()),
         });
 
         let max_ctx = self.max_context_tokens.unwrap_or(100_000);
@@ -1578,6 +1596,7 @@ impl AgentRuntime {
             build_system_prompt(
                 base_prompt.as_deref(),
                 dna.as_deref(),
+                rag_context.as_deref(),
                 memory_context.as_deref(),
                 new_summary.as_deref(),
             )
@@ -1718,9 +1737,11 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let base_prompt = self.base_prompt_with_tools();
+        let rag_context = self.auto_rag_context(memory_text).await;
         let system = build_system_prompt(
             base_prompt.as_deref(),
             dna.as_deref(),
+            rag_context.as_deref(),
             memory_context.as_deref(),
             session_summary,
         );
@@ -1730,7 +1751,7 @@ impl AgentRuntime {
         let mut messages: Vec<ChatMessage> = conversation_history.to_vec();
         messages.push(ChatMessage {
             role: ChatRole::User,
-            content: user_content,
+            content: inject_rag_into_content(user_content, rag_context.as_deref()),
         });
 
         let max_ctx = self.max_context_tokens.unwrap_or(100_000);
@@ -1749,6 +1770,7 @@ impl AgentRuntime {
             build_system_prompt(
                 base_prompt.as_deref(),
                 dna.as_deref(),
+                rag_context.as_deref(),
                 memory_context.as_deref(),
                 new_summary.as_deref(),
             )
@@ -2036,6 +2058,64 @@ impl AgentRuntime {
             .as_ref()
             .map(|provider| provider.model().to_string())
     }
+
+    /// Set the path to the document store for auto-RAG context injection.
+    pub fn set_doc_db_path(&mut self, path: PathBuf) {
+        self.doc_db_path = Some(path);
+    }
+
+    /// Auto-inject RAG context: embed the user query, search the document store,
+    /// and return a formatted context string if any chunks score above the threshold.
+    ///
+    /// Returns `None` when no embedding provider is set, no doc DB path is configured,
+    /// or no chunks score above the similarity threshold.
+    async fn auto_rag_context(&self, user_text: &str) -> Option<String> {
+        let db_path = self.doc_db_path.as_ref()?;
+        if !db_path.exists() {
+            warn!("auto_rag: doc_db_path does not exist: {:?}", db_path);
+            return None;
+        }
+
+        const THRESHOLD: f64 = 0.42;
+        const TOP_K: usize = 3;
+
+        let store = opencrust_db::DocumentStore::open(db_path).ok()?;
+
+        let chunks = if let Some(embedding) = self.embed_query(user_text).await {
+            info!(
+                "auto_rag: embedded query ({} dims), searching top={} threshold={}",
+                embedding.len(),
+                TOP_K,
+                THRESHOLD
+            );
+            let results = store
+                .search_chunks(&embedding, TOP_K, THRESHOLD)
+                .unwrap_or_default();
+            info!("auto_rag: found {} chunks above threshold", results.len());
+            for c in &results {
+                info!("auto_rag: chunk '{}' score={:.4}", c.document_name, c.score);
+            }
+            results
+        } else {
+            warn!("auto_rag: no embedding provider, skipping");
+            // No embedding provider — skip auto-injection (keyword fallback via tool is enough)
+            return None;
+        };
+
+        if chunks.is_empty() {
+            return None;
+        }
+
+        let mut parts = vec![
+            "=== DOCUMENT CONTEXT (retrieved) ===".to_string(),
+            "The following content has been retrieved from the document store. Use it to answer the user's question. Do NOT ask for a file path. Do NOT say you cannot access files.".to_string(),
+        ];
+        for chunk in &chunks {
+            parts.push(format!("--- {} ---\n{}", chunk.document_name, chunk.text));
+        }
+        parts.push("=== END DOCUMENT CONTEXT ===".to_string());
+        Some(parts.join("\n\n"))
+    }
 }
 
 impl Default for AgentRuntime {
@@ -2244,6 +2324,7 @@ fn bootstrap_instruction() -> String {
 fn build_system_prompt(
     effective_prompt: Option<&str>,
     dna_content: Option<&str>,
+    rag_context: Option<&str>,
     memory_context: Option<&str>,
     session_summary: Option<&str>,
 ) -> Option<String> {
@@ -2256,6 +2337,9 @@ fn build_system_prompt(
     } else {
         parts.push(bootstrap_instruction());
     }
+    if let Some(rag) = rag_context {
+        parts.push(rag.to_string());
+    }
     if let Some(ctx) = memory_context {
         parts.push(ctx.to_string());
     }
@@ -2263,6 +2347,21 @@ fn build_system_prompt(
         parts.push(format!("Conversation summary:\n{summary}"));
     }
     Some(parts.join("\n\n"))
+}
+
+/// Prepend RAG context directly into the user message so the model cannot ignore it.
+/// Only modifies Text messages; multipart (image) messages are returned unchanged.
+fn inject_rag_into_content(user_content: MessagePart, rag_context: Option<&str>) -> MessagePart {
+    let Some(rag) = rag_context else {
+        return user_content;
+    };
+    match user_content {
+        MessagePart::Text(text) => MessagePart::Text(format!(
+            "[Retrieved document context — answer using this information, do not ask for a file path]:\n{}\n\n---\n\n{}",
+            rag, text
+        )),
+        other => other,
+    }
 }
 
 fn extract_text(content: &[ContentBlock]) -> String {
@@ -2293,7 +2392,7 @@ mod tests {
         let dna = Some("Be kind.");
         let mem = Some("User likes Rust.");
         let sum = Some("We discussed project setup.");
-        let result = build_system_prompt(base, dna, mem, sum).unwrap();
+        let result = build_system_prompt(base, dna, None, mem, sum).unwrap();
         assert!(result.contains("You are helpful."));
         assert!(result.contains("Be kind."));
         assert!(result.contains("User likes Rust."));
@@ -2305,7 +2404,7 @@ mod tests {
     fn build_system_prompt_base_before_dna() {
         let base = Some("You are helpful.");
         let dna = Some("You are a pirate.");
-        let result = build_system_prompt(base, dna, None, None).unwrap();
+        let result = build_system_prompt(base, dna, None, None, None).unwrap();
         let base_pos = result.find("helpful").unwrap();
         let dna_pos = result.find("pirate").unwrap();
         assert!(base_pos < dna_pos);
@@ -2313,7 +2412,7 @@ mod tests {
 
     #[test]
     fn build_system_prompt_no_summary() {
-        let result = build_system_prompt(Some("Base."), Some("DNA."), None, None).unwrap();
+        let result = build_system_prompt(Some("Base."), Some("DNA."), None, None, None).unwrap();
         assert!(result.contains("Base."));
         assert!(result.contains("DNA."));
         assert!(!result.contains("Conversation summary:"));
@@ -2321,21 +2420,22 @@ mod tests {
 
     #[test]
     fn build_system_prompt_summary_only() {
-        let result = build_system_prompt(None, None, None, Some("A summary.")).unwrap();
+        let result = build_system_prompt(None, None, None, None, Some("A summary.")).unwrap();
         assert!(result.contains("Conversation summary:"));
         assert!(result.contains("A summary."));
     }
 
     #[test]
     fn build_system_prompt_bootstrap_when_no_dna() {
-        let result = build_system_prompt(None, None, None, None).unwrap();
+        let result = build_system_prompt(None, None, None, None, None).unwrap();
         assert!(result.contains("have not been personalized yet"));
         assert!(result.contains("dna.md"));
     }
 
     #[test]
     fn build_system_prompt_dna_only() {
-        let result = build_system_prompt(None, Some("You are a pirate."), None, None).unwrap();
+        let result =
+            build_system_prompt(None, Some("You are a pirate."), None, None, None).unwrap();
         assert!(result.contains("You are a pirate."));
     }
 

--- a/crates/opencrust-agents/src/tools/doc_search_tool.rs
+++ b/crates/opencrust-agents/src/tools/doc_search_tool.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use opencrust_common::{Error, Result};
 use opencrust_db::DocumentStore;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use super::{Tool, ToolContext, ToolOutput};
@@ -13,15 +14,20 @@ const DEFAULT_MIN_SIMILARITY: f64 = 0.3;
 pub type EmbedFn =
     Arc<dyn Fn(&str) -> futures::future::BoxFuture<'_, Result<Vec<f32>>> + Send + Sync>;
 
-/// Search ingested documents for relevant content using vector similarity.
+/// Search ingested documents for relevant content.
+///
+/// Opens the document store fresh on each call so documents ingested after
+/// startup are immediately visible without restarting the gateway.
+/// Uses vector similarity when an embedding function is provided, otherwise
+/// falls back to keyword (LIKE) search.
 pub struct DocSearchTool {
-    store: Arc<DocumentStore>,
-    embed_fn: EmbedFn,
+    db_path: PathBuf,
+    embed_fn: Option<EmbedFn>,
 }
 
 impl DocSearchTool {
-    pub fn new(store: Arc<DocumentStore>, embed_fn: EmbedFn) -> Self {
-        Self { store, embed_fn }
+    pub fn new(db_path: PathBuf, embed_fn: Option<EmbedFn>) -> Self {
+        Self { db_path, embed_fn }
     }
 }
 
@@ -74,18 +80,21 @@ impl Tool for DocSearchTool {
             .map(|v| (v as usize).clamp(1, MAX_LIMIT))
             .unwrap_or(DEFAULT_LIMIT);
 
-        // Embed the query
-        let query_embedding = (self.embed_fn)(query).await.map_err(|e| {
-            Error::Agent(format!(
-                "failed to embed query (is an embedding provider configured?): {e}"
-            ))
-        })?;
+        let store = DocumentStore::open(&self.db_path)
+            .map_err(|e| Error::Agent(format!("failed to open document store: {e}")))?;
 
-        // Search chunks
-        let chunks = self
-            .store
-            .search_chunks(&query_embedding, limit, DEFAULT_MIN_SIMILARITY)
-            .map_err(|e| Error::Agent(format!("document search failed: {e}")))?;
+        let chunks = if let Some(embed_fn) = &self.embed_fn {
+            let query_embedding = embed_fn(query)
+                .await
+                .map_err(|e| Error::Agent(format!("failed to embed query: {e}")))?;
+            store
+                .search_chunks(&query_embedding, limit, DEFAULT_MIN_SIMILARITY)
+                .map_err(|e| Error::Agent(format!("document search failed: {e}")))?
+        } else {
+            store
+                .keyword_search_chunks(query, limit)
+                .map_err(|e| Error::Agent(format!("keyword search failed: {e}")))?
+        };
 
         if chunks.is_empty() {
             return Ok(ToolOutput::success(
@@ -113,12 +122,18 @@ impl Tool for DocSearchTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::NamedTempFile;
+
+    fn make_tool_with_path(path: PathBuf) -> DocSearchTool {
+        DocSearchTool::new(path, None)
+    }
 
     #[test]
     fn returns_error_on_missing_query() {
-        let store = Arc::new(DocumentStore::in_memory().unwrap());
-        let embed_fn: EmbedFn = Arc::new(|_| Box::pin(async { Ok(vec![0.0; 384]) }));
-        let tool = DocSearchTool::new(store, embed_fn);
+        let tmp = NamedTempFile::new().unwrap();
+        // Initialise the schema by opening once.
+        DocumentStore::open(tmp.path()).unwrap();
+        let tool = make_tool_with_path(tmp.path().to_path_buf());
         let ctx = ToolContext {
             session_id: "test".into(),
             user_id: None,
@@ -132,9 +147,9 @@ mod tests {
 
     #[test]
     fn returns_no_results_on_empty_store() {
-        let store = Arc::new(DocumentStore::in_memory().unwrap());
-        let embed_fn: EmbedFn = Arc::new(|_| Box::pin(async { Ok(vec![0.0; 384]) }));
-        let tool = DocSearchTool::new(store, embed_fn);
+        let tmp = NamedTempFile::new().unwrap();
+        DocumentStore::open(tmp.path()).unwrap();
+        let tool = make_tool_with_path(tmp.path().to_path_buf());
         let ctx = ToolContext {
             session_id: "test".into(),
             user_id: None,

--- a/crates/opencrust-db/src/document_store.rs
+++ b/crates/opencrust-db/src/document_store.rs
@@ -238,6 +238,39 @@ impl DocumentStore {
         Ok(scored.into_iter().map(|(_, chunk)| chunk).collect())
     }
 
+    /// Search document chunks by keyword (case-insensitive LIKE match).
+    ///
+    /// Used as a fallback when no embedding provider is configured.
+    pub fn keyword_search_chunks(&self, query: &str, limit: usize) -> Result<Vec<DocumentChunk>> {
+        let conn = self.connection()?;
+        let pattern = format!("%{}%", query.replace('%', "\\%").replace('_', "\\_"));
+        let mut stmt = conn
+            .prepare(
+                "SELECT c.id, c.document_id, d.name, c.chunk_index, c.text
+                 FROM document_chunks c
+                 JOIN documents d ON d.id = c.document_id
+                 WHERE c.text LIKE ?1 ESCAPE '\\'
+                 LIMIT ?2",
+            )
+            .map_err(|e| Error::Database(format!("failed to prepare keyword search: {e}")))?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![pattern, limit as i64], |row| {
+                Ok(DocumentChunk {
+                    id: row.get(0)?,
+                    document_id: row.get(1)?,
+                    document_name: row.get(2)?,
+                    chunk_index: row.get::<_, i64>(3)? as usize,
+                    text: row.get(4)?,
+                    score: 1.0,
+                })
+            })
+            .map_err(|e| Error::Database(format!("failed to execute keyword search: {e}")))?;
+
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| Error::Database(format!("failed to read keyword search rows: {e}")))
+    }
+
     /// List all documents with their metadata.
     pub fn list_documents(&self) -> Result<Vec<DocumentInfo>> {
         let conn = self.connection()?;

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -532,24 +532,32 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
             .unwrap_or_else(|| opencrust_config::ConfigLoader::default_config_dir().join("data"));
         let memory_db_path = data_dir.join("memory.db");
 
-        if let Ok(doc_store) = opencrust_db::DocumentStore::open(&memory_db_path) {
-            let doc_store = Arc::new(doc_store);
-            // Check if there are any documents to search
-            let has_docs = doc_store
-                .list_documents()
-                .map(|d| !d.is_empty())
-                .unwrap_or(false);
-            if has_docs && let Some(embed) = runtime.embedding_provider() {
-                let embed_clone = embed.clone();
-                let embed_fn: opencrust_agents::tools::doc_search_tool::EmbedFn =
-                    Arc::new(move |text: &str| {
-                        let e = embed_clone.clone();
-                        let t = text.to_string();
-                        Box::pin(async move { e.embed_query(&t).await })
-                    });
-                runtime.register_tool(Box::new(DocSearchTool::new(doc_store, embed_fn)));
-                info!("doc_search tool registered (documents available for RAG)");
-            }
+        // Register doc_search whenever the memory DB exists — documents ingested
+        // after startup are visible because the tool opens the DB fresh per call.
+        // Embedding is optional: falls back to keyword search when unavailable.
+        if memory_db_path.exists() {
+            let embed_fn: Option<opencrust_agents::tools::doc_search_tool::EmbedFn> =
+                runtime.embedding_provider().map(|embed| {
+                    let embed_clone = embed.clone();
+                    let f: opencrust_agents::tools::doc_search_tool::EmbedFn =
+                        Arc::new(move |text: &str| {
+                            let e = embed_clone.clone();
+                            let t = text.to_string();
+                            Box::pin(async move { e.embed_query(&t).await })
+                        });
+                    f
+                });
+            let mode = if embed_fn.is_some() {
+                "vector"
+            } else {
+                "keyword"
+            };
+            runtime.register_tool(Box::new(DocSearchTool::new(
+                memory_db_path.clone(),
+                embed_fn,
+            )));
+            runtime.set_doc_db_path(memory_db_path.clone());
+            info!("doc_search tool registered ({mode} search)");
         }
     }
 


### PR DESCRIPTION
## Summary

- Implements #252: auto-inject RAG context before the LLM sees each message
- Embeds the user query, searches the DocumentStore, and prepends matching chunks directly into the user message — bypasses tool-calling entirely so it works reliably on all LLM backends (including vLLM without `--tool-call-parser`)
- Falls back gracefully: no embedding provider → keyword search via `doc_search` tool; no matching chunks → no injection
- `DocSearchTool` now opens the DB fresh per call so documents ingested after startup are immediately visible without restarting the gateway
- Similarity threshold tuned to 0.42 to prevent false positives on cross-lingual (Thai→English) queries with bge-m3

## Changes

- `AgentRuntime`: add `doc_db_path` field, `set_doc_db_path()`, `auto_rag_context()`, `inject_rag_into_content()` — RAG context prepended to user message in all `process_message_*` variants
- `DocSearchTool`: open DB fresh per call; accept `Option<EmbedFn>` with keyword fallback
- `DocumentStore`: add `keyword_search_chunks()` for LIKE-based fallback search
- `bootstrap`: wire `doc_db_path` on runtime when registering `doc_search` tool

## Test plan

- [x] `cargo test -p opencrust-agents` — 100 tests pass
- [x] Question about ingested resume → correct answer without asking for file path
- [x] Unrelated question → RAG not injected (score < threshold)
- [x] Document ingested after startup → immediately visible (no restart needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)