### PR TITLE
docs(line): document dm_policy, group_policy and env var config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,8 +231,10 @@ channels:
   line:
     type: line
     enabled: true
-    channel_access_token: "your-access-token"
-    channel_secret: "your-secret"
+    channel_access_token: "your-access-token"  # or LINE_CHANNEL_ACCESS_TOKEN env var
+    channel_secret: "your-secret"              # or LINE_CHANNEL_SECRET env var
+    dm_policy: pairing     # open | pairing | allowlist (default: pairing)
+    group_policy: mention  # open | mention | disabled (default: open)
 
 agent:
   # Personality is configured via ~/.opencrust/dna.md (auto-created on first message)

--- a/docs/src/channels/line.md
+++ b/docs/src/channels/line.md
@@ -21,7 +21,58 @@ channels:
     channel_secret: "YOUR_CHANNEL_SECRET"
 ```
 
-You can also use environment variables: `LINE_CHANNEL_ACCESS_TOKEN` and `LINE_CHANNEL_SECRET`.
+You can also use environment variables instead of hardcoding credentials:
+
+| Setting               | Environment variable         |
+|-----------------------|------------------------------|
+| `channel_access_token`| `LINE_CHANNEL_ACCESS_TOKEN`  |
+| `channel_secret`      | `LINE_CHANNEL_SECRET`        |
+
+## Access Control
+
+### DM policy (`dm_policy`)
+
+Controls who can send the bot direct messages.
+
+| Value       | Behaviour                                                           |
+|-------------|---------------------------------------------------------------------|
+| `open`      | Anyone can message the bot (no auth required).                      |
+| `pairing`   | New users must enter a 6-digit pairing code (default).              |
+| `allowlist` | Only LINE user IDs listed under `allowlist` are accepted.           |
+
+```yaml
+channels:
+  line:
+    type: line
+    enabled: true
+    channel_access_token: "YOUR_CHANNEL_ACCESS_TOKEN"
+    channel_secret: "YOUR_CHANNEL_SECRET"
+    dm_policy: pairing        # open | pairing | allowlist
+    allowlist:
+      - "Uxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"   # LINE user ID
+```
+
+### Group policy (`group_policy`)
+
+Controls how the bot behaves in LINE groups and rooms.
+
+| Value      | Behaviour                                                           |
+|------------|---------------------------------------------------------------------|
+| `open`     | Respond to every message in the group (default).                    |
+| `mention`  | Respond only when the bot is @mentioned in the group.               |
+| `disabled` | Ignore all group/room messages.                                     |
+
+```yaml
+channels:
+  line:
+    type: line
+    enabled: true
+    channel_access_token: "YOUR_CHANNEL_ACCESS_TOKEN"
+    channel_secret: "YOUR_CHANNEL_SECRET"
+    group_policy: mention     # open | mention | disabled
+```
+
+> **Note:** Mention detection uses `message.mention.mentionees` from the LINE webhook payload. The bot's own user ID is resolved automatically from `GET /v2/bot/info` at startup — no manual configuration required.
 
 ## Webhook Setup
 
@@ -38,11 +89,14 @@ OpenCrust uses a "Reply-first" strategy:
 -   **Push API**: Used as a fallback if the reply token expires or for proactive messages (like scheduled tasks). Note that Push messages may count toward your monthly free limit depending on your LINE plan.
 
 ### Groups and Rooms
-The agent works in LINE groups and rooms. 
--   **Session Isolation**: Each group/room has its own conversation session, shared by all members.
--   **Mentioning**: Standard LINE bots do not receive a "mentioned" flag for simple text messages. By default, the agent responds to *all* messages in a group if it is added. You can configure filters in the code if needed.
+The agent works in LINE groups and rooms.
+-   **Session isolation**: Each group/room has its own conversation session, shared by all members.
+-   **Mention detection**: With `group_policy: mention`, the bot responds only when directly @mentioned. The bot user ID is fetched from the LINE API automatically on startup.
 
-### Security
+### Voice Responses
+When `voice.auto_reply_voice` is enabled in your config, the bot synthesizes TTS audio and attempts to deliver it as a voice message. LINE requires an externally accessible CDN URL for audio delivery; if unavailable the bot falls back to a text response.
+
+## Security
 All incoming requests are verified using the `X-Line-Signature` header (HMAC-SHA256) to ensure they originate from the LINE platform.
 
 ## Diagnostics

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -230,8 +230,10 @@ channels:
   line:
     type: line
     enabled: true
-    channel_access_token: "your-access-token"
-    channel_secret: "your-secret"
+    channel_access_token: "your-access-token"  # या LINE_CHANNEL_ACCESS_TOKEN env var
+    channel_secret: "your-secret"              # या LINE_CHANNEL_SECRET env var
+    dm_policy: pairing     # open | pairing | allowlist (डिफ़ॉल्ट: pairing)
+    group_policy: mention  # open | mention | disabled (डिफ़ॉल्ट: open)
 
 agent:
   # Personality ~/.opencrust/dna.md के माध्यम से configure होती है

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -230,8 +230,10 @@ channels:
   line:
     type: line
     enabled: true
-    channel_access_token: "your-access-token"
-    channel_secret: "your-secret"
+    channel_access_token: "your-access-token"  # หรือ LINE_CHANNEL_ACCESS_TOKEN env var
+    channel_secret: "your-secret"              # หรือ LINE_CHANNEL_SECRET env var
+    dm_policy: pairing     # open | pairing | allowlist (default: pairing)
+    group_policy: mention  # open | mention | disabled (default: open)
 
 agent:
   # Personality ตั้งค่าผ่าน ~/.opencrust/dna.md (สร้างอัตโนมัติเมื่อได้รับข้อความแรก)

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -231,8 +231,10 @@ channels:
   line:
     type: line
     enabled: true
-    channel_access_token: "your-access-token"
-    channel_secret: "your-secret"
+    channel_access_token: "your-access-token"  # 或使用 LINE_CHANNEL_ACCESS_TOKEN 环境变量
+    channel_secret: "your-secret"              # 或使用 LINE_CHANNEL_SECRET 环境变量
+    dm_policy: pairing     # open | pairing | allowlist（默认：pairing）
+    group_policy: mention  # open | mention | disabled（默认：open）
 
 agent:
   # 个性化设置通过 ~/.opencrust/dna.md 配置 (首条消息后自动创建)


### PR DESCRIPTION
## Summary

- Expand LINE channel config examples in README (all 4 languages) to show `dm_policy` and `group_policy` options with their accepted values
- Add inline comments pointing to `LINE_CHANNEL_ACCESS_TOKEN` / `LINE_CHANNEL_SECRET` env var alternatives
- Rewrite `docs/src/channels/line.md` with a full access-control reference covering:
  - `dm_policy` table: `open` / `pairing` / `allowlist`
  - `group_policy` table: `open` / `mention` / `disabled`
  - Note on mention detection (bot user ID resolved automatically from `GET /v2/bot/info` at startup)
  - Voice response fallback behaviour

## Test plan

- [x] Verify YAML examples in README render correctly
- [x] Verify docs page content is accurate against code in `bootstrap.rs` and `policy.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)