### PR TITLE
feat(db): ranked keyword search and hybrid vector+text scoring (issue #281)

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -2171,19 +2171,20 @@ impl AgentRuntime {
         const THRESHOLD: f64 = 0.42;
         const TOP_K: usize = 3;
 
-        let chunks = if let Some(embedding) = self.embed_query(user_text).await {
-            let results = store
-                .search_chunks(&embedding, TOP_K, THRESHOLD)
-                .unwrap_or_default();
-            info!("auto_rag: found {} chunks above threshold", results.len());
-            for c in &results {
-                tracing::debug!("auto_rag: chunk '{}' score={:.4}", c.document_name, c.score);
-            }
-            results
-        } else {
+        let query_embedding = self.embed_query(user_text).await;
+        if query_embedding.is_none() {
             warn!("auto_rag: no embedding provider, skipping");
             return None;
-        };
+        }
+
+        let chunks = store
+            .hybrid_search_chunks(user_text, query_embedding.as_deref(), TOP_K, THRESHOLD)
+            .unwrap_or_default();
+
+        info!("auto_rag: found {} chunks above threshold", chunks.len());
+        for c in &chunks {
+            tracing::debug!("auto_rag: chunk '{}' score={:.4}", c.document_name, c.score);
+        }
 
         if chunks.is_empty() {
             return None;

--- a/crates/opencrust-agents/src/tools/doc_search_tool.rs
+++ b/crates/opencrust-agents/src/tools/doc_search_tool.rs
@@ -83,18 +83,24 @@ impl Tool for DocSearchTool {
         let store = DocumentStore::open(&self.db_path)
             .map_err(|e| Error::Agent(format!("failed to open document store: {e}")))?;
 
-        let chunks = if let Some(embed_fn) = &self.embed_fn {
-            let query_embedding = embed_fn(query)
-                .await
-                .map_err(|e| Error::Agent(format!("failed to embed query: {e}")))?;
-            store
-                .search_chunks(&query_embedding, limit, DEFAULT_MIN_SIMILARITY)
-                .map_err(|e| Error::Agent(format!("document search failed: {e}")))?
+        let query_embedding = if let Some(embed_fn) = &self.embed_fn {
+            Some(
+                embed_fn(query)
+                    .await
+                    .map_err(|e| Error::Agent(format!("failed to embed query: {e}")))?,
+            )
         } else {
-            store
-                .keyword_search_chunks(query, limit)
-                .map_err(|e| Error::Agent(format!("keyword search failed: {e}")))?
+            None
         };
+
+        let chunks = store
+            .hybrid_search_chunks(
+                query,
+                query_embedding.as_deref(),
+                limit,
+                DEFAULT_MIN_SIMILARITY,
+            )
+            .map_err(|e| Error::Agent(format!("document search failed: {e}")))?;
 
         if chunks.is_empty() {
             return Ok(ToolOutput::success(

--- a/crates/opencrust-db/src/document_store.rs
+++ b/crates/opencrust-db/src/document_store.rs
@@ -525,37 +525,127 @@ impl DocumentStore {
         Ok(scored.into_iter().map(|(_, chunk)| chunk).collect())
     }
 
-    /// Search document chunks by keyword (case-insensitive LIKE match).
+    /// Search document chunks by keyword with term-frequency ranking.
     ///
-    /// Used as a fallback when no embedding provider is configured.
+    /// Candidates are found via `LIKE` (broad net), then ranked by
+    /// `text_match_score` so partial-term matches are ordered by relevance
+    /// rather than all returning `score = 1.0`. Chunks with zero term overlap
+    /// are excluded.
     pub fn keyword_search_chunks(&self, query: &str, limit: usize) -> Result<Vec<DocumentChunk>> {
         let conn = self.connection()?;
-        let pattern = format!("%{}%", query.replace('%', "\\%").replace('_', "\\_"));
+
+        // Broaden the LIKE pattern to any chunk that contains at least one
+        // query word, then rank in Rust where we have full scoring logic.
+        let terms: Vec<String> = query
+            .split_whitespace()
+            .map(|t| t.to_lowercase())
+            .filter(|t| !t.is_empty())
+            .collect();
+
+        if terms.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Build OR-of-LIKE conditions: text LIKE '%term1%' OR text LIKE '%term2%' ...
+        let conditions: String = terms
+            .iter()
+            .enumerate()
+            .map(|(i, _)| format!("LOWER(c.text) LIKE ?{}", i + 1))
+            .collect::<Vec<_>>()
+            .join(" OR ");
+
+        let sql = format!(
+            "SELECT c.id, c.document_id, d.name, c.chunk_index, c.text
+             FROM document_chunks c
+             JOIN documents d ON d.id = c.document_id
+             WHERE {conditions}
+             LIMIT ?{}",
+            terms.len() + 1
+        );
+
         let mut stmt = conn
-            .prepare(
-                "SELECT c.id, c.document_id, d.name, c.chunk_index, c.text
-                 FROM document_chunks c
-                 JOIN documents d ON d.id = c.document_id
-                 WHERE c.text LIKE ?1 ESCAPE '\\'
-                 LIMIT ?2",
-            )
+            .prepare(&sql)
             .map_err(|e| Error::Database(format!("failed to prepare keyword search: {e}")))?;
 
+        // Bind each term pattern then the limit.
+        let mut params: Vec<Box<dyn rusqlite::ToSql>> = terms
+            .iter()
+            .map(|t| {
+                let p = format!("%{}%", t.replace('%', "\\%").replace('_', "\\_"));
+                Box::new(p) as Box<dyn rusqlite::ToSql>
+            })
+            .collect();
+        params.push(Box::new(limit as i64 * 4)); // fetch extra for post-ranking
+
+        let param_refs: Vec<&dyn rusqlite::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+
         let rows = stmt
-            .query_map(rusqlite::params![pattern, limit as i64], |row| {
+            .query_map(param_refs.as_slice(), |row| {
                 Ok(DocumentChunk {
                     id: row.get(0)?,
                     document_id: row.get(1)?,
                     document_name: row.get(2)?,
                     chunk_index: row.get::<_, i64>(3)? as usize,
                     text: row.get(4)?,
-                    score: 1.0,
+                    score: 0.0,
                 })
             })
             .map_err(|e| Error::Database(format!("failed to execute keyword search: {e}")))?;
 
-        rows.collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|e| Error::Database(format!("failed to read keyword search rows: {e}")))
+        let mut scored: Vec<DocumentChunk> = rows
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| Error::Database(format!("failed to read keyword search rows: {e}")))?
+            .into_iter()
+            .filter_map(|mut chunk| {
+                let s = text_match_score(query, &chunk.text);
+                if s > 0.0 {
+                    chunk.score = s as f64;
+                    Some(chunk)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(Ordering::Equal));
+        scored.truncate(limit);
+        Ok(scored)
+    }
+
+    /// Hybrid search: combine vector similarity with text match scoring.
+    ///
+    /// When an embedding is available, the final score is a weighted blend of
+    /// cosine similarity (0.8) and term-frequency text match (0.2), improving
+    /// results when the vector model underweights exact keyword occurrences.
+    ///
+    /// When no embedding is provided, falls back to `keyword_search_chunks`.
+    pub fn hybrid_search_chunks(
+        &self,
+        query: &str,
+        query_embedding: Option<&[f32]>,
+        limit: usize,
+        min_similarity: f64,
+    ) -> Result<Vec<DocumentChunk>> {
+        let Some(embedding) = query_embedding else {
+            return self.keyword_search_chunks(query, limit);
+        };
+
+        // Get vector candidates (fetch extra to re-rank).
+        let fetch_k = (limit * 2).max(limit + 8);
+        let mut candidates = self.search_chunks(embedding, fetch_k, min_similarity * 0.8)?;
+
+        // Re-score with hybrid: 0.8 * vector + 0.2 * text_match.
+        for chunk in &mut candidates {
+            let text_score = text_match_score(query, &chunk.text) as f64;
+            chunk.score = chunk.score * 0.8 + text_score * 0.2;
+        }
+
+        candidates.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(Ordering::Equal));
+
+        // Apply final similarity threshold and cap at limit.
+        candidates.retain(|c| c.score >= min_similarity);
+        candidates.truncate(limit);
+        Ok(candidates)
     }
 
     /// List all documents with their metadata.
@@ -696,6 +786,27 @@ fn blob_to_embedding(blob: &[u8]) -> Result<Vec<f32>> {
         out.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
     }
     Ok(out)
+}
+
+/// Term-frequency text match score in [0, 1].
+///
+/// Returns 1.0 if the full query appears verbatim (case-insensitive),
+/// otherwise returns the fraction of query terms found in `content`.
+fn text_match_score(query: &str, content: &str) -> f32 {
+    let query = query.trim().to_lowercase();
+    if query.is_empty() {
+        return 0.0;
+    }
+    let content_lc = content.to_lowercase();
+    if content_lc.contains(&query) {
+        return 1.0;
+    }
+    let terms: Vec<&str> = query.split_whitespace().filter(|s| !s.is_empty()).collect();
+    if terms.is_empty() {
+        return 0.0;
+    }
+    let matches = terms.iter().filter(|t| content_lc.contains(**t)).count();
+    matches as f32 / terms.len() as f32
 }
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {


### PR DESCRIPTION
Closes #281

## Changes

### `document_store.rs`
- **`text_match_score(query, content)`** — new helper: full match = 1.0, partial = matched_terms / total_terms
- **`keyword_search_chunks()`** — rewritten with ranked results instead of unranked LIKE (score was always 1.0)
  - Fetches candidates via OR-of-LIKE per term (broadens recall)
  - Scores and sorts by `text_match_score`, excludes zero-overlap chunks
- **`hybrid_search_chunks(query, embedding?, limit, min_similarity)`** — new unified search path
  - With embedding: `cosine × 0.8 + text_match × 0.2`
  - Without embedding: delegates to ranked `keyword_search_chunks`

### `doc_search_tool.rs`
- Uses `hybrid_search_chunks` instead of separate vector/keyword branches

### `runtime.rs`
- `auto_rag_context` uses `hybrid_search_chunks`

## Design rationale

Mirrors the hybrid scoring already used by `memory_store.rs` (same 0.7/0.2/0.1 pattern, adapted for documents without recency). No new dependencies — enabling FTS5 requires changing rusqlite to `features = ["bundled-full"]` which increases compile time and binary size; deferred to a follow-up.

## Score blending

| Mode | Formula |
|---|---|
| Vector only (before) | `cosine_similarity` |
| Hybrid (after) | `cosine × 0.8 + text_match × 0.2` |
| No embedding (before) | `LIKE` match, score = 1.0 always |
| No embedding (after) | `text_match_score` ranked, 0.0–1.0 |

## Test plan

- [x] `cargo test -p opencrust-db` — 37 tests pass
- [x] `cargo test -p opencrust-agents` — 106 tests pass
- [x] `cargo clippy -- -Dwarnings` — clean
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)