### PR TITLE
feat(skills): hot-reload skills directory and install from local path

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -40,6 +40,7 @@ pub struct AgentRuntime {
     tools: Vec<Box<dyn Tool>>,
     system_prompt: Option<String>,
     dna_content: RwLock<Option<String>>,
+    skills_content: RwLock<Option<String>>,
     max_tokens: Option<u32>,
     max_context_tokens: Option<usize>,
     recall_limit: usize,
@@ -83,6 +84,7 @@ impl AgentRuntime {
             tools: Vec::new(),
             system_prompt: None,
             dna_content: RwLock::new(None),
+            skills_content: RwLock::new(None),
             max_tokens: None,
             max_context_tokens: None,
             recall_limit: 10,
@@ -128,6 +130,17 @@ impl AgentRuntime {
     /// Get a clone of the current DNA content.
     pub fn dna_content(&self) -> Option<String> {
         self.dna_content.read().unwrap().clone()
+    }
+
+    /// Set the skills block injected into the system prompt. Uses `&self` via RwLock
+    /// so it works after Arc wrapping for hot-reload.
+    pub fn set_skills_content(&self, content: Option<String>) {
+        *self.skills_content.write().unwrap() = content;
+    }
+
+    /// Get a clone of the current skills content.
+    pub fn skills_content(&self) -> Option<String> {
+        self.skills_content.read().unwrap().clone()
     }
 
     pub fn set_max_tokens(&mut self, max_tokens: u32) {
@@ -761,11 +774,13 @@ impl AgentRuntime {
         };
 
         let dna = self.dna_content();
+        let skills = self.skills_content();
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(user_text).await;
         let user_display = self.session_user_name(session_id);
         let system = build_system_prompt(
             base_prompt.as_deref(),
+            skills.as_deref(),
             dna.as_deref(),
             rag_context.as_deref(),
             memory_context.as_deref(),
@@ -920,11 +935,13 @@ impl AgentRuntime {
         };
 
         let dna = self.dna_content();
+        let skills = self.skills_content();
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(user_text).await;
         let user_display = self.session_user_name(session_id);
         let system = build_system_prompt(
             base_prompt.as_deref(),
+            skills.as_deref(),
             dna.as_deref(),
             rag_context.as_deref(),
             memory_context.as_deref(),
@@ -958,6 +975,7 @@ impl AgentRuntime {
         let system = if new_summary.is_some() {
             build_system_prompt(
                 base_prompt.as_deref(),
+                skills.as_deref(),
                 dna.as_deref(),
                 rag_context.as_deref(),
                 memory_context.as_deref(),
@@ -1090,11 +1108,13 @@ impl AgentRuntime {
         };
 
         let dna = self.dna_content();
+        let skills = self.skills_content();
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(memory_text).await;
         let user_display = self.session_user_name(session_id);
         let system = build_system_prompt(
             base_prompt.as_deref(),
+            skills.as_deref(),
             dna.as_deref(),
             rag_context.as_deref(),
             memory_context.as_deref(),
@@ -1305,11 +1325,13 @@ impl AgentRuntime {
         };
 
         let dna = self.dna_content();
+        let skills = self.skills_content();
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(memory_text).await;
         let user_display = self.session_user_name(session_id);
         let system = build_system_prompt(
             base_prompt.as_deref(),
+            skills.as_deref(),
             dna.as_deref(),
             rag_context.as_deref(),
             memory_context.as_deref(),
@@ -1608,11 +1630,13 @@ impl AgentRuntime {
         };
 
         let dna = self.dna_content();
+        let skills = self.skills_content();
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(memory_text).await;
         let user_display = self.session_user_name(session_id);
         let system = build_system_prompt(
             base_prompt.as_deref(),
+            skills.as_deref(),
             dna.as_deref(),
             rag_context.as_deref(),
             memory_context.as_deref(),
@@ -1644,6 +1668,7 @@ impl AgentRuntime {
         let system = if new_summary.is_some() {
             build_system_prompt(
                 base_prompt.as_deref(),
+                skills.as_deref(),
                 dna.as_deref(),
                 rag_context.as_deref(),
                 memory_context.as_deref(),
@@ -1786,11 +1811,13 @@ impl AgentRuntime {
         };
 
         let dna = self.dna_content();
+        let skills = self.skills_content();
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(memory_text).await;
         let user_display = self.session_user_name(session_id);
         let system = build_system_prompt(
             base_prompt.as_deref(),
+            skills.as_deref(),
             dna.as_deref(),
             rag_context.as_deref(),
             memory_context.as_deref(),
@@ -1821,6 +1848,7 @@ impl AgentRuntime {
         let system = if new_summary.is_some() {
             build_system_prompt(
                 base_prompt.as_deref(),
+                skills.as_deref(),
                 dna.as_deref(),
                 rag_context.as_deref(),
                 memory_context.as_deref(),
@@ -2437,6 +2465,7 @@ fn bootstrap_instruction() -> String {
 /// so the agent can collect user preferences on first interaction.
 fn build_system_prompt(
     effective_prompt: Option<&str>,
+    skills_content: Option<&str>,
     dna_content: Option<&str>,
     _rag_context: Option<&str>,
     memory_context: Option<&str>,
@@ -2446,6 +2475,9 @@ fn build_system_prompt(
     let mut parts = Vec::new();
     if let Some(prompt) = effective_prompt {
         parts.push(prompt.to_string());
+    }
+    if let Some(skills) = skills_content {
+        parts.push(skills.to_string());
     }
     if let Some(dna) = dna_content {
         parts.push(dna.to_string());
@@ -2525,7 +2557,7 @@ mod tests {
         let dna = Some("Be kind.");
         let mem = Some("User likes Rust.");
         let sum = Some("We discussed project setup.");
-        let result = build_system_prompt(base, dna, None, mem, sum, None).unwrap();
+        let result = build_system_prompt(base, None, dna, None, mem, sum, None).unwrap();
         assert!(result.contains("You are helpful."));
         assert!(result.contains("Be kind."));
         assert!(result.contains("User likes Rust."));
@@ -2538,7 +2570,7 @@ mod tests {
     fn build_system_prompt_base_before_dna() {
         let base = Some("You are helpful.");
         let dna = Some("You are a pirate.");
-        let result = build_system_prompt(base, dna, None, None, None, None).unwrap();
+        let result = build_system_prompt(base, None, dna, None, None, None, None).unwrap();
         let base_pos = result.find("helpful").unwrap();
         let dna_pos = result.find("pirate").unwrap();
         assert!(base_pos < dna_pos);
@@ -2547,7 +2579,7 @@ mod tests {
     #[test]
     fn build_system_prompt_no_summary() {
         let result =
-            build_system_prompt(Some("Base."), Some("DNA."), None, None, None, None).unwrap();
+            build_system_prompt(Some("Base."), None, Some("DNA."), None, None, None, None).unwrap();
         assert!(result.contains("Base."));
         assert!(result.contains("DNA."));
         assert!(!result.contains("Conversation summary"));
@@ -2555,22 +2587,31 @@ mod tests {
 
     #[test]
     fn build_system_prompt_summary_only() {
-        let result = build_system_prompt(None, None, None, None, Some("A summary."), None).unwrap();
+        let result =
+            build_system_prompt(None, None, None, None, None, Some("A summary."), None).unwrap();
         assert!(result.contains("Conversation summary"));
         assert!(result.contains("A summary."));
     }
 
     #[test]
     fn build_system_prompt_bootstrap_when_no_dna() {
-        let result = build_system_prompt(None, None, None, None, None, None).unwrap();
+        let result = build_system_prompt(None, None, None, None, None, None, None).unwrap();
         assert!(result.contains("have not been personalized yet"));
         assert!(result.contains("dna.md"));
     }
 
     #[test]
     fn build_system_prompt_dna_only() {
-        let result =
-            build_system_prompt(None, Some("You are a pirate."), None, None, None, None).unwrap();
+        let result = build_system_prompt(
+            None,
+            None,
+            Some("You are a pirate."),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         assert!(result.contains("You are a pirate."));
     }
 
@@ -2578,6 +2619,7 @@ mod tests {
     fn build_system_prompt_with_user_name() {
         let result = build_system_prompt(
             Some("You are helpful."),
+            None,
             Some("DNA content."),
             None,
             None,
@@ -2592,7 +2634,7 @@ mod tests {
     #[test]
     fn build_system_prompt_user_name_none_no_effect() {
         let result =
-            build_system_prompt(Some("Base."), Some("DNA."), None, None, None, None).unwrap();
+            build_system_prompt(Some("Base."), None, Some("DNA."), None, None, None, None).unwrap();
         assert!(!result.contains("currently speaking with"));
     }
 

--- a/crates/opencrust-cli/src/main.rs
+++ b/crates/opencrust-cli/src/main.rs
@@ -160,8 +160,8 @@ enum PluginCommands {
 enum SkillCommands {
     /// List installed skills
     List,
-    /// Install a skill from a URL
-    Install { url: String },
+    /// Install a skill from a URL or local file path
+    Install { source: String },
     /// Remove a skill by name
     Remove { name: String },
 }
@@ -944,11 +944,18 @@ async fn async_main(
                         Err(e) => println!("error scanning skills: {}", e),
                     }
                 }
-                SkillCommands::Install { url } => {
+                SkillCommands::Install { source } => {
                     let installer = opencrust_skills::SkillInstaller::new(&skills_dir);
-                    match installer.install_from_url(&url).await {
-                        Ok(skill) => println!("installed skill: {}", skill.frontmatter.name),
-                        Err(e) => println!("error installing skill: {}", e),
+                    if source.starts_with("http://") || source.starts_with("https://") {
+                        match installer.install_from_url(&source).await {
+                            Ok(skill) => println!("installed skill: {}", skill.frontmatter.name),
+                            Err(e) => println!("error installing skill: {}", e),
+                        }
+                    } else {
+                        match installer.install_from_path(std::path::Path::new(&source)) {
+                            Ok(skill) => println!("installed skill: {}", skill.frontmatter.name),
+                            Err(e) => println!("error installing skill: {}", e),
+                        }
                     }
                 }
                 SkillCommands::Remove { name } => {

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -587,28 +587,8 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     let scanner = opencrust_skills::SkillScanner::new(&skills_dir);
     match scanner.discover() {
         Ok(skills) if !skills.is_empty() => {
-            let mut skill_block = String::from("\n\n# Active Skills\n");
-            for skill in &skills {
-                skill_block.push_str(&format!(
-                    "\n## {}\n{}\n",
-                    skill.frontmatter.name, skill.frontmatter.description
-                ));
-                if !skill.frontmatter.triggers.is_empty() {
-                    skill_block.push_str(&format!(
-                        "Triggers: {}\n",
-                        skill.frontmatter.triggers.join(", ")
-                    ));
-                }
-                skill_block.push('\n');
-                skill_block.push_str(&skill.body);
-                skill_block.push('\n');
-            }
-
-            let new_prompt = match runtime.system_prompt() {
-                Some(existing) => format!("{existing}{skill_block}"),
-                None => skill_block,
-            };
-            runtime.set_system_prompt(new_prompt);
+            let skill_block = build_skill_block(&skills);
+            runtime.set_skills_content(Some(skill_block));
             info!("injected {} skill(s) into system prompt", skills.len());
         }
         Ok(_) => {} // no skills found
@@ -657,6 +637,27 @@ fn resolve_mcp_env(server_name: &str, env: &HashMap<String, String>) -> HashMap<
         resolved.insert(key.clone(), value.clone());
     }
     resolved
+}
+
+/// Render a list of skill definitions into the `# Active Skills` prompt block.
+pub fn build_skill_block(skills: &[opencrust_skills::SkillDefinition]) -> String {
+    let mut block = String::from("# Active Skills\n");
+    for skill in skills {
+        block.push_str(&format!(
+            "\n## {}\n{}\n",
+            skill.frontmatter.name, skill.frontmatter.description
+        ));
+        if !skill.frontmatter.triggers.is_empty() {
+            block.push_str(&format!(
+                "Triggers: {}\n",
+                skill.frontmatter.triggers.join(", ")
+            ));
+        }
+        block.push('\n');
+        block.push_str(&skill.body);
+        block.push('\n');
+    }
+    block
 }
 
 /// Build MCP tools from merged config (config.yml + mcp.json).

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -16,8 +16,9 @@ use tracing::{info, warn};
 use crate::bootstrap::build_imessage_channels;
 use crate::bootstrap::{
     build_agent_runtime, build_channels, build_discord_channels, build_line_channels,
-    build_mcp_tools, build_mqtt_channels, build_slack_channels, build_telegram_channels,
-    build_wechat_channels, build_whatsapp_channels, build_whatsapp_web_channels, resolve_api_key,
+    build_mcp_tools, build_mqtt_channels, build_skill_block, build_slack_channels,
+    build_telegram_channels, build_wechat_channels, build_whatsapp_channels,
+    build_whatsapp_web_channels, resolve_api_key,
 };
 use crate::router::build_router;
 use crate::state::AppState;
@@ -152,9 +153,10 @@ impl GatewayServer {
         state.spawn_session_cleanup();
         state.spawn_config_applier();
 
-        // Watch dna.md for hot-reload
+        // Watch dna.md and skills directory for hot-reload
         let config_dir = opencrust_config::ConfigLoader::default_config_dir();
-        spawn_dna_watcher(Arc::clone(&state), config_dir);
+        spawn_dna_watcher(Arc::clone(&state), config_dir.clone());
+        spawn_skills_watcher(Arc::clone(&state), config_dir);
 
         // Spawn MCP health monitor for auto-reconnect
         if let Some(ref arc) = mcp_manager_arc {
@@ -459,6 +461,80 @@ fn spawn_dna_watcher(state: Arc<AppState>, config_dir: PathBuf) {
                 }
                 Err(e) => {
                     warn!("failed to read dna.md: {e}");
+                }
+            }
+        }
+    });
+}
+
+/// Watch `{config_dir}/skills/` for `*.md` changes and hot-reload skill
+/// definitions into the agent runtime.
+fn spawn_skills_watcher(state: Arc<AppState>, config_dir: PathBuf) {
+    let skills_dir = config_dir.join("skills");
+    let (notify_tx, mut notify_rx) = tokio::sync::mpsc::channel::<()>(8);
+
+    let watcher_result =
+        notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
+            if let Ok(event) = event {
+                let dominated = matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                );
+                if dominated {
+                    let touches_skill = event
+                        .paths
+                        .iter()
+                        .any(|p| p.extension().and_then(|e| e.to_str()) == Some("md"));
+                    if touches_skill {
+                        let _ = notify_tx.try_send(());
+                    }
+                }
+            }
+        });
+
+    let mut watcher = match watcher_result {
+        Ok(w) => w,
+        Err(e) => {
+            warn!("failed to create skills watcher: {e}");
+            return;
+        }
+    };
+
+    if let Err(e) = watcher.watch(&skills_dir, RecursiveMode::NonRecursive) {
+        // Skills dir may not exist yet — only warn for unexpected errors
+        let is_not_found = matches!(&e.kind, notify::ErrorKind::Io(io_err)
+            if io_err.kind() == std::io::ErrorKind::NotFound);
+        if !is_not_found {
+            warn!("failed to watch skills dir: {e}");
+        }
+        return;
+    }
+
+    info!("watching skills directory for hot-reload");
+
+    tokio::spawn(async move {
+        let _watcher = watcher; // prevent drop
+        loop {
+            if notify_rx.recv().await.is_none() {
+                break;
+            }
+            // Debounce
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            while notify_rx.try_recv().is_ok() {}
+
+            let scanner = opencrust_skills::SkillScanner::new(&skills_dir);
+            match scanner.discover() {
+                Ok(skills) if !skills.is_empty() => {
+                    let block = build_skill_block(&skills);
+                    state.agents.set_skills_content(Some(block));
+                    info!("skills reloaded ({} skill(s))", skills.len());
+                }
+                Ok(_) => {
+                    state.agents.set_skills_content(None);
+                    info!("skills directory empty, cleared skills");
+                }
+                Err(e) => {
+                    warn!("failed to re-scan skills directory: {e}");
                 }
             }
         }


### PR DESCRIPTION
## Summary

- **Skill hot-reload**: `spawn_skills_watcher()` watches `~/.opencrust/skills/*.md` for Create/Modify/Remove events (500 ms debounce) and re-injects the skill block into the live agent runtime — no restart required. Follows the exact same pattern as the existing `spawn_dna_watcher()`.
- **Independent skill layer**: `AgentRuntime` gains a `skills_content: RwLock<Option<String>>` field. `build_system_prompt()` now takes it as a dedicated parameter (between base prompt and DNA), so all three layers are independently hot-reloadable.
- **CLI local path install**: `skill install <source>` now accepts a URL *or* a local file path — routes to `install_from_url` / `install_from_path` based on the `http(s)://` prefix.

## Changed files

| File | Change |
|------|--------|
| `crates/opencrust-agents/src/runtime.rs` | Add `skills_content` RwLock field + `set_skills_content` / `skills_content` methods; add `skills_content` param to `build_system_prompt` |
| `crates/opencrust-gateway/src/bootstrap.rs` | Extract `build_skill_block()` helper; store skills via `set_skills_content()` instead of baking into base prompt |
| `crates/opencrust-gateway/src/server.rs` | Add `spawn_skills_watcher()` and call it alongside `spawn_dna_watcher()` |
| `crates/opencrust-cli/src/main.rs` | `skill install` accepts URL or local path |

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — 500+ tests, 0 failed
- [x] `cargo fmt --check` — clean
- [x] Manual: drop a new `.md` skill file into `~/.opencrust/skills/` while gateway is running → agent picks it up within ~500 ms without restart
- [x] Manual: `opencrust skill install ./my-skill.md` installs from local path
- [x] Manual: `opencrust skill install https://...` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)