### PR TITLE
fix(skills): watcher dir creation, collision warning, sort order, installer tests

### DIFF
--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -500,13 +500,15 @@ fn spawn_skills_watcher(state: Arc<AppState>, config_dir: PathBuf) {
         }
     };
 
+    // Ensure the skills directory exists so the watcher can attach immediately,
+    // even on a fresh install where no skills have been added yet.
+    if let Err(e) = std::fs::create_dir_all(&skills_dir) {
+        warn!("failed to create skills directory: {e}");
+        return;
+    }
+
     if let Err(e) = watcher.watch(&skills_dir, RecursiveMode::NonRecursive) {
-        // Skills dir may not exist yet — only warn for unexpected errors
-        let is_not_found = matches!(&e.kind, notify::ErrorKind::Io(io_err)
-            if io_err.kind() == std::io::ErrorKind::NotFound);
-        if !is_not_found {
-            warn!("failed to watch skills dir: {e}");
-        }
+        warn!("failed to watch skills dir: {e}");
         return;
     }
 

--- a/crates/opencrust-skills/src/installer.rs
+++ b/crates/opencrust-skills/src/installer.rs
@@ -1,6 +1,15 @@
 use opencrust_common::{Error, Result};
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
+const VALID_SKILL_MD: &str = "\
+---
+name: test-skill
+description: A test skill for installer tests
+---
+Do something useful.
+";
+
 use crate::parser::{self, SkillDefinition};
 
 pub struct SkillInstaller {
@@ -79,7 +88,135 @@ impl SkillInstaller {
             std::fs::create_dir_all(&self.skills_dir)?;
         }
         let path = self.skill_path(name);
+        if path.exists() {
+            tracing::warn!("skill '{name}' already exists and will be overwritten");
+        }
         std::fs::write(&path, content)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_skills_dir(suffix: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("opencrust_installer_test_{suffix}"));
+        let _ = fs::remove_dir_all(&dir);
+        dir
+    }
+
+    #[test]
+    fn install_from_path_creates_dir_and_file() {
+        let skills_dir = temp_skills_dir("from_path");
+        let installer = SkillInstaller::new(&skills_dir);
+
+        // Write source skill to a temp file
+        let src = std::env::temp_dir().join("test-skill-src.md");
+        fs::write(&src, VALID_SKILL_MD).unwrap();
+
+        let skill = installer.install_from_path(&src).unwrap();
+        assert_eq!(skill.frontmatter.name, "test-skill");
+        assert!(skills_dir.join("test-skill.md").exists());
+        assert_eq!(skill.source_path, Some(skills_dir.join("test-skill.md")));
+
+        let _ = fs::remove_dir_all(&skills_dir);
+        let _ = fs::remove_file(&src);
+    }
+
+    #[test]
+    fn install_from_path_creates_skills_dir_if_missing() {
+        let skills_dir = temp_skills_dir("autocreate");
+        assert!(!skills_dir.exists());
+
+        let src = std::env::temp_dir().join("test-skill-autocreate.md");
+        fs::write(&src, VALID_SKILL_MD).unwrap();
+
+        let installer = SkillInstaller::new(&skills_dir);
+        installer.install_from_path(&src).unwrap();
+        assert!(skills_dir.exists());
+
+        let _ = fs::remove_dir_all(&skills_dir);
+        let _ = fs::remove_file(&src);
+    }
+
+    #[test]
+    fn install_from_path_invalid_skill_returns_error() {
+        let skills_dir = temp_skills_dir("invalid");
+        let installer = SkillInstaller::new(&skills_dir);
+
+        let src = std::env::temp_dir().join("bad-skill.md");
+        fs::write(&src, "no frontmatter here").unwrap();
+
+        let result = installer.install_from_path(&src);
+        assert!(result.is_err());
+        // Skills dir should NOT have been written to
+        assert!(!skills_dir.join("bad-skill.md").exists());
+
+        let _ = fs::remove_dir_all(&skills_dir);
+        let _ = fs::remove_file(&src);
+    }
+
+    #[test]
+    fn install_from_path_nonexistent_file_returns_error() {
+        let skills_dir = temp_skills_dir("nofile");
+        let installer = SkillInstaller::new(&skills_dir);
+        let result = installer.install_from_path(Path::new("/tmp/does-not-exist-opencrust.md"));
+        assert!(result.is_err());
+        let _ = fs::remove_dir_all(&skills_dir);
+    }
+
+    #[test]
+    fn remove_existing_skill() {
+        let skills_dir = temp_skills_dir("remove");
+        fs::create_dir_all(&skills_dir).unwrap();
+        fs::write(skills_dir.join("my-skill.md"), VALID_SKILL_MD).unwrap();
+
+        let installer = SkillInstaller::new(&skills_dir);
+        assert!(installer.remove("my-skill").unwrap());
+        assert!(!skills_dir.join("my-skill.md").exists());
+
+        let _ = fs::remove_dir_all(&skills_dir);
+    }
+
+    #[test]
+    fn remove_nonexistent_skill_returns_false() {
+        let skills_dir = temp_skills_dir("remove_missing");
+        fs::create_dir_all(&skills_dir).unwrap();
+
+        let installer = SkillInstaller::new(&skills_dir);
+        assert!(!installer.remove("ghost-skill").unwrap());
+
+        let _ = fs::remove_dir_all(&skills_dir);
+    }
+
+    #[test]
+    fn overwrite_existing_skill_succeeds() {
+        let skills_dir = temp_skills_dir("overwrite");
+        let installer = SkillInstaller::new(&skills_dir);
+
+        let src = std::env::temp_dir().join("test-skill-overwrite.md");
+        fs::write(&src, VALID_SKILL_MD).unwrap();
+
+        installer.install_from_path(&src).unwrap();
+
+        // Install again — should overwrite without error
+        let updated = "\
+---
+name: test-skill
+description: Updated description
+---
+Updated body.
+";
+        fs::write(&src, updated).unwrap();
+        let skill = installer.install_from_path(&src).unwrap();
+        assert_eq!(skill.frontmatter.description, "Updated description");
+
+        let content = fs::read_to_string(skills_dir.join("test-skill.md")).unwrap();
+        assert!(content.contains("Updated description"));
+
+        let _ = fs::remove_dir_all(&skills_dir);
+        let _ = fs::remove_file(&src);
     }
 }

--- a/crates/opencrust-skills/src/scanner.rs
+++ b/crates/opencrust-skills/src/scanner.rs
@@ -50,6 +50,7 @@ impl SkillScanner {
             }
         }
 
+        skills.sort_by(|a, b| a.frontmatter.name.cmp(&b.frontmatter.name));
         Ok(skills)
     }
 
@@ -85,6 +86,38 @@ mod tests {
         let scanner = SkillScanner::new("/tmp/opencrust_nonexistent_skills_dir");
         let skills = scanner.discover().unwrap();
         assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn skills_sorted_by_name() {
+        let dir = std::env::temp_dir().join("opencrust_test_sort_skills");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+
+        fs::write(
+            dir.join("zebra.md"),
+            "---\nname: zebra\ndescription: Z skill\n---\nDo Z.",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("apple.md"),
+            "---\nname: apple\ndescription: A skill\n---\nDo A.",
+        )
+        .unwrap();
+        fs::write(
+            dir.join("mango.md"),
+            "---\nname: mango\ndescription: M skill\n---\nDo M.",
+        )
+        .unwrap();
+
+        let scanner = SkillScanner::new(&dir);
+        let skills = scanner.discover().unwrap();
+        assert_eq!(skills.len(), 3);
+        assert_eq!(skills[0].frontmatter.name, "apple");
+        assert_eq!(skills[1].frontmatter.name, "mango");
+        assert_eq!(skills[2].frontmatter.name, "zebra");
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up fixes to #293 based on post-merge audit of the skill system.

- **Bug fix — watcher dead on fresh install**: `spawn_skills_watcher()` previously returned early (silently) when `~/.opencrust/skills/` did not exist yet. Now calls `fs::create_dir_all` before attaching the watcher, so hot-reload works immediately even before any skill has been installed.
- **Collision warning**: `SkillInstaller::write_skill()` now emits a `tracing::warn!` when a skill with the same name already exists and will be overwritten — previously silent.
- **Deterministic skill order**: `SkillScanner::discover()` sorts results alphabetically by skill name before returning, so the system-prompt injection order is stable across platforms and re-runs.
- **Installer unit tests**: 7 new tests covering `install_from_path`, automatic directory creation, invalid-input rejection, `remove`, and overwrite behaviour. Scanner gets a `skills_sorted_by_name` test to pin the sort contract.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — 17 skill tests pass (up from 9), 0 failed overall
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)