### PR TITLE
feat(skills): self-learning agent via create_skill tool with 3-layer quality control

### DIFF
--- a/crates/opencrust-agents/Cargo.toml
+++ b/crates/opencrust-agents/Cargo.toml
@@ -8,6 +8,7 @@ description = "LLM agent runtime and orchestration for OpenCrust"
 [dependencies]
 opencrust-common = { workspace = true }
 opencrust-db = { workspace = true }
+opencrust-skills = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/opencrust-agents/src/lib.rs
+++ b/crates/opencrust-agents/src/lib.rs
@@ -20,8 +20,9 @@ pub use providers::{
 };
 pub use runtime::AgentRuntime;
 pub use tools::{
-    BashTool, CancelHeartbeat, DocSearchTool, FileReadTool, FileWriteTool, GoogleSearchTool,
-    ListHeartbeats, ScheduleHeartbeat, Tool, ToolContext, ToolOutput, WebFetchTool, WebSearchTool,
+    BashTool, CancelHeartbeat, CreateSkillTool, DocSearchTool, FileReadTool, FileWriteTool,
+    GoogleSearchTool, ListHeartbeats, ScheduleHeartbeat, Tool, ToolContext, ToolOutput,
+    WebFetchTool, WebSearchTool,
 };
 
 #[cfg(feature = "mcp")]

--- a/crates/opencrust-agents/src/tools/create_skill_tool.rs
+++ b/crates/opencrust-agents/src/tools/create_skill_tool.rs
@@ -1,0 +1,237 @@
+use async_trait::async_trait;
+use opencrust_common::Result;
+use std::path::PathBuf;
+
+use super::{Tool, ToolContext, ToolOutput};
+
+/// Allow the agent to save a reusable skill to the skills directory.
+///
+/// The skill is validated (name format, non-empty description and body),
+/// written to `{skills_dir}/{name}.md`, and immediately picked up by the
+/// hot-reload watcher without requiring a gateway restart.
+pub struct CreateSkillTool {
+    skills_dir: PathBuf,
+}
+
+impl CreateSkillTool {
+    pub fn new(skills_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            skills_dir: skills_dir.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for CreateSkillTool {
+    fn name(&self) -> &str {
+        "create_skill"
+    }
+
+    fn description(&self) -> &str {
+        "Save a reusable skill to the skills directory. The skill will be immediately \
+         available in future conversations without restarting the gateway."
+    }
+
+    fn system_hint(&self) -> Option<&str> {
+        Some(
+            "Use `create_skill` when you solve a novel multi-step problem or discover \
+             a reusable pattern. Good candidates: recurring task workflows, domain-specific \
+             sequences, or multi-tool chains you had to figure out step by step. \
+             Do NOT save trivial one-liners or things already in your base knowledge.",
+        )
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Unique skill name in hyphen-case (e.g. 'disk-cleanup'). Only alphanumeric characters and hyphens."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "One-line description of what this skill does."
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Markdown instructions for the skill — the reusable knowledge or step-by-step procedure."
+                },
+                "triggers": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional keywords or phrases that suggest using this skill (e.g. ['disk full', 'free space'])."
+                }
+            },
+            "required": ["name", "description", "body"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        _context: &ToolContext,
+        input: serde_json::Value,
+    ) -> Result<ToolOutput> {
+        let name = match input.get("name").and_then(|v| v.as_str()) {
+            Some(n) => n.to_string(),
+            None => return Ok(ToolOutput::error("missing required parameter: 'name'")),
+        };
+        let description = match input.get("description").and_then(|v| v.as_str()) {
+            Some(d) => d.to_string(),
+            None => {
+                return Ok(ToolOutput::error(
+                    "missing required parameter: 'description'",
+                ));
+            }
+        };
+        let body = match input.get("body").and_then(|v| v.as_str()) {
+            Some(b) => b.to_string(),
+            None => return Ok(ToolOutput::error("missing required parameter: 'body'")),
+        };
+        let triggers: Vec<String> = input
+            .get("triggers")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Build SKILL.md content
+        let mut content = format!("---\nname: {name}\ndescription: {description}\n");
+        if !triggers.is_empty() {
+            content.push_str("triggers:\n");
+            for t in &triggers {
+                content.push_str(&format!("  - {t}\n"));
+            }
+        }
+        content.push_str("---\n\n");
+        content.push_str(&body);
+        content.push('\n');
+
+        // Write via SkillInstaller — handles dir creation + validation
+        let installer = opencrust_skills::SkillInstaller::new(&self.skills_dir);
+        let tmp = std::env::temp_dir().join(format!("opencrust_skill_{name}.md"));
+        if let Err(e) = std::fs::write(&tmp, &content) {
+            return Ok(ToolOutput::error(format!(
+                "failed to stage skill file: {e}"
+            )));
+        }
+
+        match installer.install_from_path(&tmp) {
+            Ok(skill) => {
+                let _ = std::fs::remove_file(&tmp);
+                Ok(ToolOutput::success(format!(
+                    "skill '{}' saved to {} — active immediately",
+                    skill.frontmatter.name,
+                    self.skills_dir.join(format!("{name}.md")).display()
+                )))
+            }
+            Err(e) => {
+                let _ = std::fs::remove_file(&tmp);
+                Ok(ToolOutput::error(format!("invalid skill: {e}")))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            session_id: "test".into(),
+            user_id: None,
+            heartbeat_depth: 0,
+            allowed_tools: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn creates_skill_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tool = CreateSkillTool::new(dir.path());
+
+        let out = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "name": "disk-cleanup",
+                    "description": "Free up disk space on macOS",
+                    "body": "Run `df -h` to check usage, then `brew cleanup` to remove caches.",
+                    "triggers": ["disk full", "free space"]
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!out.is_error, "unexpected error: {}", out.content);
+        assert!(dir.path().join("disk-cleanup.md").exists());
+
+        let written = std::fs::read_to_string(dir.path().join("disk-cleanup.md")).unwrap();
+        assert!(written.contains("name: disk-cleanup"));
+        assert!(written.contains("triggers:"));
+        assert!(written.contains("brew cleanup"));
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_name() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tool = CreateSkillTool::new(dir.path());
+
+        let out = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "name": "bad name!",
+                    "description": "test",
+                    "body": "something"
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(out.is_error);
+        assert!(out.content.contains("invalid"));
+    }
+
+    #[tokio::test]
+    async fn rejects_missing_name() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tool = CreateSkillTool::new(dir.path());
+
+        let out = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({"description": "test", "body": "body"}),
+            )
+            .await
+            .unwrap();
+
+        assert!(out.is_error);
+    }
+
+    #[tokio::test]
+    async fn works_without_triggers() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tool = CreateSkillTool::new(dir.path());
+
+        let out = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "name": "simple-skill",
+                    "description": "A simple skill",
+                    "body": "Do something useful."
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!out.is_error, "{}", out.content);
+        let content = std::fs::read_to_string(dir.path().join("simple-skill.md")).unwrap();
+        assert!(!content.contains("triggers:"));
+    }
+}

--- a/crates/opencrust-agents/src/tools/create_skill_tool.rs
+++ b/crates/opencrust-agents/src/tools/create_skill_tool.rs
@@ -4,11 +4,20 @@ use std::path::PathBuf;
 
 use super::{Tool, ToolContext, ToolOutput};
 
-/// Allow the agent to save a reusable skill to the skills directory.
+/// Maximum number of skills allowed in the skills directory.
+const MAX_SKILLS: usize = 30;
+/// Minimum body length in characters to prevent trivial one-liner skills.
+const MIN_BODY_LEN: usize = 80;
+/// Minimum rationale length to ensure the agent genuinely reflects before saving.
+const MIN_RATIONALE_LEN: usize = 40;
+
+/// Allow the agent to save a reusable skill discovered during a conversation.
 ///
-/// The skill is validated (name format, non-empty description and body),
-/// written to `{skills_dir}/{name}.md`, and immediately picked up by the
-/// hot-reload watcher without requiring a gateway restart.
+/// Enforces three layers of quality control:
+/// - Layer 2 (mechanical): hard cap, min body length, duplicate guard
+/// - Layer 3 (reflection): `rationale` field forces the agent to justify the save
+///
+/// Layer 1 (prompt-level) lives in `system_hint()`.
 pub struct CreateSkillTool {
     skills_dir: PathBuf,
 }
@@ -19,6 +28,17 @@ impl CreateSkillTool {
             skills_dir: skills_dir.into(),
         }
     }
+
+    fn count_existing_skills(&self) -> usize {
+        std::fs::read_dir(&self.skills_dir)
+            .map(|entries| {
+                entries
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("md"))
+                    .count()
+            })
+            .unwrap_or(0)
+    }
 }
 
 #[async_trait]
@@ -28,16 +48,21 @@ impl Tool for CreateSkillTool {
     }
 
     fn description(&self) -> &str {
-        "Save a reusable skill to the skills directory. The skill will be immediately \
-         available in future conversations without restarting the gateway."
+        "Save a reusable skill to the skills directory. \
+         Active immediately in future conversations without restarting."
     }
 
     fn system_hint(&self) -> Option<&str> {
         Some(
-            "Use `create_skill` when you solve a novel multi-step problem or discover \
-             a reusable pattern. Good candidates: recurring task workflows, domain-specific \
-             sequences, or multi-tool chains you had to figure out step by step. \
-             Do NOT save trivial one-liners or things already in your base knowledge.",
+            "## When to use `create_skill`\n\
+             Before calling this tool, answer these 3 questions honestly:\n\
+             1. Would I need to figure this out again from scratch next time? (if no → do NOT save)\n\
+             2. Is this specific enough to be actionable? (vague tips → do NOT save)\n\
+             3. Does a similar skill already exist? (if yes → do NOT save, use what exists)\n\n\
+             Good candidates: multi-step workflows you had to reason through, \
+             domain-specific command sequences, multi-tool chains.\n\
+             Bad candidates: single commands, general knowledge, things obvious from context.\n\n\
+             You MUST provide a `rationale` explaining why this skill is worth persisting.",
         )
     }
 
@@ -47,7 +72,7 @@ impl Tool for CreateSkillTool {
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "Unique skill name in hyphen-case (e.g. 'disk-cleanup'). Only alphanumeric characters and hyphens."
+                    "description": "Unique skill name in hyphen-case (e.g. 'disk-cleanup'). Only alphanumeric and hyphens."
                 },
                 "description": {
                     "type": "string",
@@ -55,15 +80,23 @@ impl Tool for CreateSkillTool {
                 },
                 "body": {
                     "type": "string",
-                    "description": "Markdown instructions for the skill — the reusable knowledge or step-by-step procedure."
+                    "description": "Markdown step-by-step instructions (minimum 80 characters)."
+                },
+                "rationale": {
+                    "type": "string",
+                    "description": "Why is this skill worth saving? Would you need to figure this out again from scratch? (minimum 40 characters — be specific)"
                 },
                 "triggers": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "Optional keywords or phrases that suggest using this skill (e.g. ['disk full', 'free space'])."
+                    "description": "Keywords that suggest using this skill (e.g. ['disk full', 'free space'])."
+                },
+                "overwrite": {
+                    "type": "boolean",
+                    "description": "Set to true to explicitly replace an existing skill with the same name."
                 }
             },
-            "required": ["name", "description", "body"]
+            "required": ["name", "description", "body", "rationale"]
         })
     }
 
@@ -72,6 +105,7 @@ impl Tool for CreateSkillTool {
         _context: &ToolContext,
         input: serde_json::Value,
     ) -> Result<ToolOutput> {
+        // --- Parse parameters ---
         let name = match input.get("name").and_then(|v| v.as_str()) {
             Some(n) => n.to_string(),
             None => return Ok(ToolOutput::error("missing required parameter: 'name'")),
@@ -88,6 +122,15 @@ impl Tool for CreateSkillTool {
             Some(b) => b.to_string(),
             None => return Ok(ToolOutput::error("missing required parameter: 'body'")),
         };
+        let rationale = match input.get("rationale").and_then(|v| v.as_str()) {
+            Some(r) => r.to_string(),
+            None => {
+                return Ok(ToolOutput::error(
+                    "missing required parameter: 'rationale' — explain why this skill is \
+                     worth persisting before saving",
+                ));
+            }
+        };
         let triggers: Vec<String> = input
             .get("triggers")
             .and_then(|v| v.as_array())
@@ -97,8 +140,53 @@ impl Tool for CreateSkillTool {
                     .collect()
             })
             .unwrap_or_default();
+        let overwrite = input
+            .get("overwrite")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
-        // Build SKILL.md content
+        // --- Layer 3: Reflection gate ---
+        if rationale.trim().len() < MIN_RATIONALE_LEN {
+            return Ok(ToolOutput::error(format!(
+                "rationale too vague ({} chars, need ≥{MIN_RATIONALE_LEN}). \
+                 Explain specifically: would you need to figure this out from scratch next time? \
+                 If the answer isn't clearly yes, don't save this skill.",
+                rationale.trim().len()
+            )));
+        }
+
+        // --- Layer 2: Mechanical guardrails ---
+
+        // Min body length
+        if body.trim().len() < MIN_BODY_LEN {
+            return Ok(ToolOutput::error(format!(
+                "skill body too short ({} chars, need ≥{MIN_BODY_LEN}). \
+                 A useful skill needs enough detail to be actionable — \
+                 single commands or one-liners don't qualify.",
+                body.trim().len()
+            )));
+        }
+
+        // Hard cap
+        let existing = self.count_existing_skills();
+        if existing >= MAX_SKILLS {
+            return Ok(ToolOutput::error(format!(
+                "skill library full ({existing}/{MAX_SKILLS}). \
+                 Remove an outdated skill with `opencrust skill remove <name>` before adding new ones."
+            )));
+        }
+
+        // Duplicate guard
+        let skill_path = self.skills_dir.join(format!("{name}.md"));
+        if skill_path.exists() && !overwrite {
+            return Ok(ToolOutput::error(format!(
+                "skill '{name}' already exists. \
+                 If you want to update it, call create_skill again with `overwrite: true`. \
+                 If this is a different skill, choose a different name."
+            )));
+        }
+
+        // --- Build and write SKILL.md ---
         let mut content = format!("---\nname: {name}\ndescription: {description}\n");
         if !triggers.is_empty() {
             content.push_str("triggers:\n");
@@ -110,9 +198,15 @@ impl Tool for CreateSkillTool {
         content.push_str(&body);
         content.push('\n');
 
-        // Write via SkillInstaller — handles dir creation + validation
         let installer = opencrust_skills::SkillInstaller::new(&self.skills_dir);
-        let tmp = std::env::temp_dir().join(format!("opencrust_skill_{name}.md"));
+        // Use a unique tmp name per invocation to avoid races under parallel tests.
+        let tmp = std::env::temp_dir().join(format!(
+            "opencrust_skill_{name}_{}.md",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos())
+                .unwrap_or(0)
+        ));
         if let Err(e) = std::fs::write(&tmp, &content) {
             return Ok(ToolOutput::error(format!(
                 "failed to stage skill file: {e}"
@@ -122,10 +216,15 @@ impl Tool for CreateSkillTool {
         match installer.install_from_path(&tmp) {
             Ok(skill) => {
                 let _ = std::fs::remove_file(&tmp);
+                let action = if overwrite && skill_path.exists() {
+                    "updated"
+                } else {
+                    "saved"
+                };
                 Ok(ToolOutput::success(format!(
-                    "skill '{}' saved to {} — active immediately",
+                    "skill '{}' {action} ({}/{MAX_SKILLS} skills used) — active immediately",
                     skill.frontmatter.name,
-                    self.skills_dir.join(format!("{name}.md")).display()
+                    existing + 1,
                 )))
             }
             Err(e) => {
@@ -149,8 +248,16 @@ mod tests {
         }
     }
 
+    const GOOD_BODY: &str = "1. Run `df -h` to see disk usage by partition.\n\
+        2. Identify partitions above 90% — those need attention.\n\
+        3. Run `du -sh * | sort -rh | head -20` to find largest directories.\n\
+        4. Remove caches with `brew cleanup` or clear Xcode derived data.";
+
+    const GOOD_RATIONALE: &str = "This is a multi-step workflow I had to reason through — \
+         the specific command combination is not obvious and I would need to look it up again.";
+
     #[tokio::test]
-    async fn creates_skill_file() {
+    async fn creates_skill_with_all_layers_satisfied() {
         let dir = tempfile::TempDir::new().unwrap();
         let tool = CreateSkillTool::new(dir.path());
 
@@ -159,8 +266,9 @@ mod tests {
                 &ctx(),
                 serde_json::json!({
                     "name": "disk-cleanup",
-                    "description": "Free up disk space on macOS",
-                    "body": "Run `df -h` to check usage, then `brew cleanup` to remove caches.",
+                    "description": "Free up disk space step by step",
+                    "body": GOOD_BODY,
+                    "rationale": GOOD_RATIONALE,
                     "triggers": ["disk full", "free space"]
                 }),
             )
@@ -169,15 +277,11 @@ mod tests {
 
         assert!(!out.is_error, "unexpected error: {}", out.content);
         assert!(dir.path().join("disk-cleanup.md").exists());
-
-        let written = std::fs::read_to_string(dir.path().join("disk-cleanup.md")).unwrap();
-        assert!(written.contains("name: disk-cleanup"));
-        assert!(written.contains("triggers:"));
-        assert!(written.contains("brew cleanup"));
+        assert!(out.content.contains("1/30"));
     }
 
     #[tokio::test]
-    async fn rejects_invalid_name() {
+    async fn layer3_rejects_vague_rationale() {
         let dir = tempfile::TempDir::new().unwrap();
         let tool = CreateSkillTool::new(dir.path());
 
@@ -185,36 +289,21 @@ mod tests {
             .execute(
                 &ctx(),
                 serde_json::json!({
-                    "name": "bad name!",
-                    "description": "test",
-                    "body": "something"
+                    "name": "my-skill",
+                    "description": "Does something",
+                    "body": GOOD_BODY,
+                    "rationale": "useful"  // too short
                 }),
             )
             .await
             .unwrap();
 
         assert!(out.is_error);
-        assert!(out.content.contains("invalid"));
+        assert!(out.content.contains("rationale too vague"));
     }
 
     #[tokio::test]
-    async fn rejects_missing_name() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let tool = CreateSkillTool::new(dir.path());
-
-        let out = tool
-            .execute(
-                &ctx(),
-                serde_json::json!({"description": "test", "body": "body"}),
-            )
-            .await
-            .unwrap();
-
-        assert!(out.is_error);
-    }
-
-    #[tokio::test]
-    async fn works_without_triggers() {
+    async fn layer2_rejects_short_body() {
         let dir = tempfile::TempDir::new().unwrap();
         let tool = CreateSkillTool::new(dir.path());
 
@@ -222,16 +311,91 @@ mod tests {
             .execute(
                 &ctx(),
                 serde_json::json!({
-                    "name": "simple-skill",
-                    "description": "A simple skill",
-                    "body": "Do something useful."
+                    "name": "tiny",
+                    "description": "Too short",
+                    "body": "Run df -h.",
+                    "rationale": GOOD_RATIONALE
                 }),
             )
             .await
             .unwrap();
 
+        assert!(out.is_error);
+        assert!(out.content.contains("body too short"));
+    }
+
+    #[tokio::test]
+    async fn layer2_blocks_duplicate_without_overwrite() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tool = CreateSkillTool::new(dir.path());
+
+        let input = serde_json::json!({
+            "name": "disk-cleanup",
+            "description": "Free up disk space",
+            "body": GOOD_BODY,
+            "rationale": GOOD_RATIONALE
+        });
+
+        tool.execute(&ctx(), input.clone()).await.unwrap();
+        let out = tool.execute(&ctx(), input).await.unwrap();
+
+        assert!(out.is_error);
+        assert!(out.content.contains("already exists"));
+        assert!(out.content.contains("overwrite: true"));
+    }
+
+    #[tokio::test]
+    async fn layer2_allows_overwrite_when_flag_set() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tool = CreateSkillTool::new(dir.path());
+
+        let base = serde_json::json!({
+            "name": "disk-cleanup",
+            "description": "Original",
+            "body": GOOD_BODY,
+            "rationale": GOOD_RATIONALE
+        });
+        tool.execute(&ctx(), base).await.unwrap();
+
+        let update = serde_json::json!({
+            "name": "disk-cleanup",
+            "description": "Updated version",
+            "body": GOOD_BODY,
+            "rationale": GOOD_RATIONALE,
+            "overwrite": true
+        });
+        let out = tool.execute(&ctx(), update).await.unwrap();
         assert!(!out.is_error, "{}", out.content);
-        let content = std::fs::read_to_string(dir.path().join("simple-skill.md")).unwrap();
-        assert!(!content.contains("triggers:"));
+    }
+
+    #[tokio::test]
+    async fn layer2_enforces_hard_cap() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tool = CreateSkillTool::new(dir.path());
+
+        // Fill up to the cap
+        for i in 0..MAX_SKILLS {
+            let content = format!(
+                "---\nname: skill-{i:02}\ndescription: test\n---\n{}",
+                "x".repeat(MIN_BODY_LEN)
+            );
+            std::fs::write(dir.path().join(format!("skill-{i:02}.md")), content).unwrap();
+        }
+
+        let out = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "name": "overflow",
+                    "description": "One too many",
+                    "body": GOOD_BODY,
+                    "rationale": GOOD_RATIONALE
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(out.is_error);
+        assert!(out.content.contains("skill library full"));
     }
 }

--- a/crates/opencrust-agents/src/tools/mod.rs
+++ b/crates/opencrust-agents/src/tools/mod.rs
@@ -1,4 +1,5 @@
 pub mod bash_tool;
+pub mod create_skill_tool;
 pub mod doc_search_tool;
 pub mod file_read_tool;
 pub mod file_write_tool;
@@ -8,6 +9,7 @@ pub mod web_fetch_tool;
 pub mod web_search_tool;
 
 pub use bash_tool::BashTool;
+pub use create_skill_tool::CreateSkillTool;
 pub use doc_search_tool::DocSearchTool;
 pub use file_read_tool::FileReadTool;
 pub use file_write_tool::FileWriteTool;

--- a/crates/opencrust-config/src/model.rs
+++ b/crates/opencrust-config/src/model.rs
@@ -226,6 +226,9 @@ pub struct AgentConfig {
     pub default_provider: Option<String>,
     pub max_tokens: Option<u32>,
     pub max_context_tokens: Option<usize>,
+    /// Allow the agent to persist skills it discovers during conversations.
+    /// Registers the `create_skill` tool at startup. Default: true.
+    pub self_learning: Option<bool>,
 }
 
 /// A named agent configuration for multi-agent routing.

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -4,9 +4,9 @@ use std::sync::{Arc, Mutex};
 
 use opencrust_agents::tools::Tool;
 use opencrust_agents::{
-    AgentRuntime, AnthropicProvider, BashTool, ChatMessage, CohereEmbeddingProvider, DocSearchTool,
-    FileReadTool, FileWriteTool, GoogleSearchTool, McpManager, OllamaEmbeddingProvider,
-    OllamaProvider, OpenAiProvider, WebFetchTool, WebSearchTool,
+    AgentRuntime, AnthropicProvider, BashTool, ChatMessage, CohereEmbeddingProvider,
+    CreateSkillTool, DocSearchTool, FileReadTool, FileWriteTool, GoogleSearchTool, McpManager,
+    OllamaEmbeddingProvider, OllamaProvider, OpenAiProvider, WebFetchTool, WebSearchTool,
 };
 use opencrust_channels::{
     ChannelResponse, MediaAttachment, MqttChannel, MqttOnMessageFn, SlackChannel, SlackGroupFilter,
@@ -413,6 +413,11 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     runtime.register_tool(Box::new(FileReadTool::new(None)));
     runtime.register_tool(Box::new(FileWriteTool::new(None)));
     runtime.register_tool(Box::new(WebFetchTool::new(None)));
+
+    // Self-learning: agent can save reusable skills discovered during conversations
+    let skills_dir = opencrust_config::ConfigLoader::default_config_dir().join("skills");
+    runtime.register_tool(Box::new(CreateSkillTool::new(skills_dir)));
+    info!("create_skill tool registered (self-learning enabled)");
 
     // Web search (Brave or Google)
     let search_config = config.tools.web_search.as_ref();

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -414,10 +414,15 @@ pub fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     runtime.register_tool(Box::new(FileWriteTool::new(None)));
     runtime.register_tool(Box::new(WebFetchTool::new(None)));
 
-    // Self-learning: agent can save reusable skills discovered during conversations
-    let skills_dir = opencrust_config::ConfigLoader::default_config_dir().join("skills");
-    runtime.register_tool(Box::new(CreateSkillTool::new(skills_dir)));
-    info!("create_skill tool registered (self-learning enabled)");
+    // Self-learning: agent can save reusable skills discovered during conversations.
+    // Enabled by default; set `agent.self_learning: false` in config.yml to disable.
+    if config.agent.self_learning.unwrap_or(true) {
+        let skills_dir = opencrust_config::ConfigLoader::default_config_dir().join("skills");
+        runtime.register_tool(Box::new(CreateSkillTool::new(skills_dir)));
+        info!("create_skill tool registered (self-learning enabled)");
+    } else {
+        info!("self-learning disabled via config (agent.self_learning: false)");
+    }
 
     // Web search (Brave or Google)
     let search_config = config.tools.web_search.as_ref();


### PR DESCRIPTION
## Summary

Enables agents to learn from conversations by saving reusable skills to
\`~/.opencrust/skills/\` using a new \`create_skill\` tool. Skills are picked
up by the hot-reload watcher immediately — no restart required.

### New: \`create_skill\` tool

Agent calls \`create_skill(name, description, body, rationale, triggers?, overwrite?)\`.
The skill is validated, written to the skills directory, and injected into the
system prompt within 500 ms via the existing watcher.

### 3-layer quality control (prevents skill spam)

**Layer 1 — Prompt (\`system_hint\`)**: agent must answer 3 self-reflection
questions before calling the tool. Documents good vs bad candidate patterns.

**Layer 2 — Mechanical guardrails**:
- Hard cap: rejects when ≥30 skills already exist
- Min body length: 80 chars — prevents trivial one-liners
- Duplicate guard: error if name exists, requires \`overwrite: true\` to update

**Layer 3 — Reflection gate**: required \`rationale\` field (≥40 chars) forces
the agent to justify why the skill is worth persisting. Short or vague
rationale is rejected with guidance to reconsider.

### Config toggle

Self-learning is enabled by default and can be disabled per deployment:

\`\`\`yaml
# config.yml
agent:
  self_learning: false   # disables create_skill tool entirely
\`\`\`

Useful for shared deployments, regulated environments, or CI runs
where persistent skill creation is undesirable.

### Success message includes usage counter

\`\`\`
skill 'disk-cleanup' saved (2/30 skills used) — active immediately
\`\`\`

## Changed files

| File | Change |
|------|--------|
| \`crates/opencrust-agents/src/tools/create_skill_tool.rs\` | New tool with all 3 quality layers |
| \`crates/opencrust-agents/src/tools/mod.rs\` | Export CreateSkillTool |
| \`crates/opencrust-agents/src/lib.rs\` | Re-export CreateSkillTool |
| \`crates/opencrust-agents/Cargo.toml\` | Add opencrust-skills dependency |
| \`crates/opencrust-gateway/src/bootstrap.rs\` | Register tool (gated by config) |
| \`crates/opencrust-config/src/model.rs\` | Add \`agent.self_learning: Option<bool>\` |

## Test plan

- [x] \`cargo check\` — clean
- [x] \`cargo clippy -- -D warnings\` — no warnings
- [x] \`cargo test\` — 112 agents tests pass (6 new for create_skill), 0 failed
- [x] \`cargo fmt --check\` — clean
- [x] Live: agent called \`create_skill\`, file written, watcher logged \`skills reloaded\` within 500 ms
- [x] Live: vague rationale ("useful") correctly rejected by Layer 3
- [x] Live: "disk full" trigger → agent used saved skill to answer
- [x] Live: \`agent.self_learning: false\` → tool not registered, log confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)