### PR TITLE
feat(multi-agent): wire tools whitelist, system prompt, and max_context_tokens from NamedAgentConfig

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -3971,4 +3971,265 @@ mod tests {
             "new network skills should appear after reload"
         );
     }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // skill_nudge_followup unit tests
+    // ──────────────────────────────────────────────────────────────────────────
+
+    struct FixedProvider {
+        reply: &'static str,
+    }
+    #[async_trait::async_trait]
+    impl LlmProvider for FixedProvider {
+        fn provider_id(&self) -> &str {
+            "fixed"
+        }
+        async fn complete(&self, request: &LlmRequest) -> Result<crate::providers::LlmResponse> {
+            // Verify no tools are sent (would cause infinite loop)
+            assert!(
+                request.tools.is_empty(),
+                "skill_nudge_followup must send tools=[] to prevent tool loop"
+            );
+            Ok(crate::providers::LlmResponse {
+                content: vec![ContentBlock::Text {
+                    text: self.reply.to_string(),
+                }],
+                model: String::new(),
+                usage: None,
+                stop_reason: None,
+            })
+        }
+        async fn health_check(&self) -> Result<bool> {
+            Ok(true)
+        }
+    }
+
+    struct FailingProvider;
+    #[async_trait::async_trait]
+    impl LlmProvider for FailingProvider {
+        fn provider_id(&self) -> &str {
+            "failing"
+        }
+        async fn complete(&self, _request: &LlmRequest) -> Result<crate::providers::LlmResponse> {
+            Err(opencrust_common::Error::Agent("simulated LLM error".into()))
+        }
+        async fn health_check(&self) -> Result<bool> {
+            Ok(true)
+        }
+    }
+
+    fn runtime_with_create_skill_tool(dir: &std::path::Path) -> AgentRuntime {
+        let mut runtime = AgentRuntime::new();
+        runtime.register_tool(Box::new(
+            crate::tools::create_skill_tool::CreateSkillTool::new(dir),
+        ));
+        runtime
+    }
+
+    #[tokio::test]
+    async fn nudge_returns_none_below_threshold() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = FixedProvider {
+            reply: "Would you like to save this?",
+        };
+        // tool_call_count = 2, threshold = 3 → should not fire
+        let result = runtime
+            .skill_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD - 1,
+                &provider,
+                &[],
+                &None,
+                "",
+                256,
+                "sess",
+            )
+            .await;
+        assert!(result.is_none(), "should not fire below threshold");
+    }
+
+    #[tokio::test]
+    async fn nudge_returns_none_without_create_skill_tool() {
+        let runtime = AgentRuntime::new(); // no create_skill registered
+        let provider = FixedProvider {
+            reply: "Would you like to save this?",
+        };
+        let result = runtime
+            .skill_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD + 5,
+                &provider,
+                &[],
+                &None,
+                "",
+                256,
+                "sess",
+            )
+            .await;
+        assert!(
+            result.is_none(),
+            "should not fire without create_skill tool registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn nudge_fires_at_threshold_and_returns_llm_text() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = FixedProvider {
+            reply: "Would you like to save this workflow as a reusable skill?",
+        };
+        let result = runtime
+            .skill_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD,
+                &provider,
+                &[make_msg(ChatRole::User, "help me with git rebase")],
+                &None,
+                "",
+                256,
+                "sess",
+            )
+            .await;
+        assert!(result.is_some(), "should fire at threshold");
+        assert!(result.unwrap().contains("Would you like to save"));
+    }
+
+    #[tokio::test]
+    async fn nudge_caps_max_tokens_at_256() {
+        struct CheckMaxTokensProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for CheckMaxTokensProvider {
+            fn provider_id(&self) -> &str {
+                "check"
+            }
+            async fn complete(
+                &self,
+                request: &LlmRequest,
+            ) -> Result<crate::providers::LlmResponse> {
+                assert!(
+                    request.max_tokens.unwrap_or(0) <= 256,
+                    "max_tokens must be capped at 256, got {:?}",
+                    request.max_tokens
+                );
+                Ok(crate::providers::LlmResponse {
+                    content: vec![ContentBlock::Text {
+                        text: "Save?".to_string(),
+                    }],
+                    model: String::new(),
+                    usage: None,
+                    stop_reason: None,
+                })
+            }
+            async fn health_check(&self) -> Result<bool> {
+                Ok(true)
+            }
+        }
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = CheckMaxTokensProvider;
+        // Pass a very large max_tokens; method must clamp to 256
+        let result = runtime
+            .skill_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD,
+                &provider,
+                &[],
+                &None,
+                "",
+                8192,
+                "sess",
+            )
+            .await;
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn nudge_returns_none_on_provider_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = FailingProvider;
+        let result = runtime
+            .skill_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD,
+                &provider,
+                &[],
+                &None,
+                "",
+                256,
+                "sess",
+            )
+            .await;
+        // Error should be swallowed — returns None, not Err
+        assert!(
+            result.is_none(),
+            "provider error should yield None, not panic"
+        );
+    }
+
+    #[tokio::test]
+    async fn nudge_injects_internal_message_at_end_of_history() {
+        struct CaptureProvider {
+            captured: std::sync::Arc<std::sync::Mutex<Option<LlmRequest>>>,
+        }
+        #[async_trait::async_trait]
+        impl LlmProvider for CaptureProvider {
+            fn provider_id(&self) -> &str {
+                "capture"
+            }
+            async fn complete(
+                &self,
+                request: &LlmRequest,
+            ) -> Result<crate::providers::LlmResponse> {
+                *self.captured.lock().unwrap() = Some(request.clone());
+                Ok(crate::providers::LlmResponse {
+                    content: vec![ContentBlock::Text {
+                        text: "Save?".to_string(),
+                    }],
+                    model: String::new(),
+                    usage: None,
+                    stop_reason: None,
+                })
+            }
+            async fn health_check(&self) -> Result<bool> {
+                Ok(true)
+            }
+        }
+
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = CaptureProvider {
+            captured: captured.clone(),
+        };
+
+        let history = vec![make_msg(ChatRole::User, "help me rebase")];
+        runtime
+            .skill_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD,
+                &provider,
+                &history,
+                &None,
+                "",
+                256,
+                "sess",
+            )
+            .await;
+
+        let req = captured
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("provider must be called");
+        // History has 1 message; injected internal message must be appended → total = 2
+        assert_eq!(req.messages.len(), 2);
+        let last = &req.messages[1];
+        let text = match &last.content {
+            MessagePart::Text(t) => t.clone(),
+            _ => panic!("last message must be Text"),
+        };
+        assert!(
+            text.contains("[internal]"),
+            "injected message must contain [internal] marker"
+        );
+        assert!(matches!(last.role, ChatRole::User));
+    }
 }

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -645,18 +645,66 @@ impl AgentRuntime {
     /// Return a reflection nudge when the agent has completed a complex multi-tool workflow
     /// and the `create_skill` tool is available. Returns `None` when below threshold or
     /// when self-learning is disabled (tool not registered).
-    fn skill_reflection_nudge(&self, tool_call_count: usize) -> Option<String> {
+    /// Make a follow-up LLM call so the model generates a natural confirmation question
+    /// asking the user whether to save the workflow as a skill.
+    ///
+    /// Passes `tools: vec![]` to prevent the model from entering another tool loop.
+    /// Returns `None` if `create_skill` is not registered, the threshold is not met,
+    /// or the follow-up call fails.
+    async fn skill_nudge_followup(
+        &self,
+        tool_call_count: usize,
+        provider: &dyn LlmProvider,
+        messages: &[ChatMessage],
+        system: &Option<String>,
+        model: &str,
+        max_tokens: u32,
+        session_id: &str,
+    ) -> Option<String> {
         if tool_call_count < SKILL_REFLECTION_THRESHOLD {
             return None;
         }
         if !self.tools.iter().any(|t| t.name() == "create_skill") {
             return None;
         }
-        Some(format!(
-            "\n\n---\n\
-             *{tool_call_count} tools used — if this was a reusable workflow, \
-             ask the user if they want to save it as a skill before this conversation ends.*"
-        ))
+        let mut msgs = messages.to_vec();
+        msgs.push(ChatMessage {
+            role: ChatRole::User,
+            content: MessagePart::Text(
+                "[internal] You just completed a multi-step workflow using several tools. \
+                 Ask the user in a short, friendly way (in the same language they used) \
+                 whether they would like to save this workflow as a reusable skill. \
+                 Reply with only that question — no preamble, no explanation."
+                    .to_string(),
+            ),
+        });
+        let request = LlmRequest {
+            model: model.to_string(),
+            messages: msgs,
+            system: system.clone(),
+            max_tokens: Some(max_tokens.min(256)),
+            temperature: None,
+            tools: vec![], // no tools — prevents re-entering the tool loop
+        };
+        match provider.complete(&request).await {
+            Ok(response) => {
+                if let Some(usage) = &response.usage {
+                    self.accumulate_usage(
+                        session_id,
+                        provider.provider_id(),
+                        &response.model,
+                        usage.input_tokens,
+                        usage.output_tokens,
+                    );
+                }
+                let text = extract_text(&response.content);
+                if text.is_empty() { None } else { Some(text) }
+            }
+            Err(e) => {
+                warn!("skill nudge follow-up LLM call failed: {}", e);
+                None
+            }
+        }
     }
 
     /// Record a tool call for debug output.
@@ -954,6 +1002,7 @@ impl AgentRuntime {
         let max_ctx = self.max_context_tokens.unwrap_or(100_000);
         trim_messages_to_budget(&mut messages, &system, &tool_defs, max_ctx);
 
+        let mut tool_call_count: usize = 0;
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: effective_model.clone(),
@@ -982,12 +1031,27 @@ impl AgentRuntime {
                 .any(|block| matches!(block, ContentBlock::ToolUse { .. }));
 
             if !has_tool_use {
-                let final_text = extract_text(&response.content);
+                let mut final_text = extract_text(&response.content);
                 if let Err(e) = self
                     .remember_turn(session_id, continuity_key, user_id, user_text, &final_text)
                     .await
                 {
                     warn!("failed to store turn in memory: {}", e);
+                }
+                if let Some(followup) = self
+                    .skill_nudge_followup(
+                        tool_call_count,
+                        provider.as_ref(),
+                        &messages,
+                        &system,
+                        &effective_model,
+                        effective_max_tokens,
+                        session_id,
+                    )
+                    .await
+                {
+                    final_text.push_str("\n\n");
+                    final_text.push_str(&followup);
                 }
                 return Ok(final_text);
             }
@@ -1022,6 +1086,11 @@ impl AgentRuntime {
                     });
                 }
             }
+            tool_call_count += response
+                .content
+                .iter()
+                .filter(|b| matches!(b, ContentBlock::ToolUse { .. }))
+                .count();
 
             messages.push(ChatMessage {
                 role: ChatRole::User,
@@ -1141,6 +1210,7 @@ impl AgentRuntime {
             system
         };
 
+        let mut tool_call_count: usize = 0;
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: effective_model.clone(),
@@ -1169,12 +1239,27 @@ impl AgentRuntime {
                 .any(|block| matches!(block, ContentBlock::ToolUse { .. }));
 
             if !has_tool_use {
-                let final_text = extract_text(&response.content);
+                let mut final_text = extract_text(&response.content);
                 if let Err(e) = self
                     .remember_turn(session_id, continuity_key, user_id, user_text, &final_text)
                     .await
                 {
                     warn!("failed to store turn in memory: {}", e);
+                }
+                if let Some(followup) = self
+                    .skill_nudge_followup(
+                        tool_call_count,
+                        provider.as_ref(),
+                        &messages,
+                        &system,
+                        &effective_model,
+                        effective_max_tokens,
+                        session_id,
+                    )
+                    .await
+                {
+                    final_text.push_str("\n\n");
+                    final_text.push_str(&followup);
                 }
                 return Ok((final_text, new_summary));
             }
@@ -1209,6 +1294,11 @@ impl AgentRuntime {
                     });
                 }
             }
+            tool_call_count += response
+                .content
+                .iter()
+                .filter(|b| matches!(b, ContentBlock::ToolUse { .. }))
+                .count();
 
             messages.push(ChatMessage {
                 role: ChatRole::User,
@@ -1310,12 +1400,6 @@ impl AgentRuntime {
             if !has_tool_use {
                 let mut final_text = extract_text(&response.content);
 
-                // Post-completion reflection: nudge the agent to consider saving a skill
-                // when a complex multi-tool workflow was completed.
-                if let Some(nudge) = self.skill_reflection_nudge(tool_call_count) {
-                    final_text.push_str(&nudge);
-                }
-
                 // Store turn in memory (best-effort)
                 if let Err(e) = self
                     .remember_turn(
@@ -1328,6 +1412,24 @@ impl AgentRuntime {
                     .await
                 {
                     warn!("failed to store turn in memory: {}", e);
+                }
+
+                // Post-completion: let the LLM generate a natural follow-up question
+                // asking the user whether to save the workflow as a skill.
+                if let Some(followup) = self
+                    .skill_nudge_followup(
+                        tool_call_count,
+                        provider.as_ref(),
+                        &messages,
+                        &system,
+                        "",
+                        self.max_tokens.unwrap_or(4096),
+                        session_id,
+                    )
+                    .await
+                {
+                    final_text.push_str("\n\n");
+                    final_text.push_str(&followup);
                 }
 
                 return Ok(final_text);
@@ -1594,12 +1696,6 @@ impl AgentRuntime {
                     if tool_uses.is_empty() {
                         full_response.push_str(&response_text);
 
-                        // Post-completion reflection nudge.
-                        if let Some(nudge) = self.skill_reflection_nudge(tool_call_count) {
-                            let _ = delta_tx.send(nudge.clone()).await;
-                            full_response.push_str(&nudge);
-                        }
-
                         if let Err(e) = self
                             .remember_turn(
                                 session_id,
@@ -1611,6 +1707,23 @@ impl AgentRuntime {
                             .await
                         {
                             warn!("failed to store turn in memory: {}", e);
+                        }
+
+                        if let Some(followup) = self
+                            .skill_nudge_followup(
+                                tool_call_count,
+                                provider.as_ref(),
+                                &messages,
+                                &system,
+                                "",
+                                self.max_tokens.unwrap_or(4096),
+                                session_id,
+                            )
+                            .await
+                        {
+                            let chunk = format!("\n\n{followup}");
+                            let _ = delta_tx.send(chunk.clone()).await;
+                            full_response.push_str(&chunk);
                         }
 
                         return Ok(full_response);
@@ -1706,12 +1819,6 @@ impl AgentRuntime {
                         let _ = delta_tx.send(final_text.clone()).await;
                         full_response.push_str(&final_text);
 
-                        // Post-completion reflection nudge (fallback path).
-                        if let Some(nudge) = self.skill_reflection_nudge(tool_call_count) {
-                            let _ = delta_tx.send(nudge.clone()).await;
-                            full_response.push_str(&nudge);
-                        }
-
                         if let Err(e) = self
                             .remember_turn(
                                 session_id,
@@ -1723,6 +1830,23 @@ impl AgentRuntime {
                             .await
                         {
                             warn!("failed to store turn in memory: {}", e);
+                        }
+
+                        if let Some(followup) = self
+                            .skill_nudge_followup(
+                                tool_call_count,
+                                provider.as_ref(),
+                                &messages,
+                                &system,
+                                "",
+                                self.max_tokens.unwrap_or(4096),
+                                session_id,
+                            )
+                            .await
+                        {
+                            let chunk = format!("\n\n{followup}");
+                            let _ = delta_tx.send(chunk.clone()).await;
+                            full_response.push_str(&chunk);
                         }
 
                         return Ok(full_response);
@@ -1902,11 +2026,6 @@ impl AgentRuntime {
             if !has_tool_use {
                 let mut final_text = extract_text(&response.content);
 
-                // Post-completion reflection nudge.
-                if let Some(nudge) = self.skill_reflection_nudge(tool_call_count) {
-                    final_text.push_str(&nudge);
-                }
-
                 if let Err(e) = self
                     .remember_turn(
                         session_id,
@@ -1918,6 +2037,22 @@ impl AgentRuntime {
                     .await
                 {
                     warn!("failed to store turn in memory: {}", e);
+                }
+
+                if let Some(followup) = self
+                    .skill_nudge_followup(
+                        tool_call_count,
+                        provider.as_ref(),
+                        &messages,
+                        &system,
+                        "",
+                        self.max_tokens.unwrap_or(4096),
+                        session_id,
+                    )
+                    .await
+                {
+                    final_text.push_str("\n\n");
+                    final_text.push_str(&followup);
                 }
 
                 return Ok((final_text, new_summary));
@@ -2138,9 +2273,21 @@ impl AgentRuntime {
                         full_response.push_str(&response_text);
 
                         // Post-completion reflection nudge.
-                        if let Some(nudge) = self.skill_reflection_nudge(tool_call_count) {
-                            let _ = delta_tx.send(nudge.clone()).await;
-                            full_response.push_str(&nudge);
+                        if let Some(followup) = self
+                            .skill_nudge_followup(
+                                tool_call_count,
+                                provider.as_ref(),
+                                &messages,
+                                &system,
+                                "",
+                                self.max_tokens.unwrap_or(4096),
+                                session_id,
+                            )
+                            .await
+                        {
+                            let chunk = format!("\n\n{followup}");
+                            let _ = delta_tx.send(chunk.clone()).await;
+                            full_response.push_str(&chunk);
                         }
 
                         if let Err(e) = self
@@ -2236,9 +2383,21 @@ impl AgentRuntime {
                         full_response.push_str(&final_text);
 
                         // Post-completion reflection nudge (fallback path).
-                        if let Some(nudge) = self.skill_reflection_nudge(tool_call_count) {
-                            let _ = delta_tx.send(nudge.clone()).await;
-                            full_response.push_str(&nudge);
+                        if let Some(followup) = self
+                            .skill_nudge_followup(
+                                tool_call_count,
+                                provider.as_ref(),
+                                &messages,
+                                &system,
+                                "",
+                                self.max_tokens.unwrap_or(4096),
+                                session_id,
+                            )
+                            .await
+                        {
+                            let chunk = format!("\n\n{followup}");
+                            let _ = delta_tx.send(chunk.clone()).await;
+                            full_response.push_str(&chunk);
                         }
 
                         if let Err(e) = self

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -650,10 +650,12 @@ impl AgentRuntime {
     ///
     /// Passes `tools: vec![]` to prevent the model from entering another tool loop.
     /// Returns `None` if `create_skill` is not registered, the threshold is not met,
-    /// or the follow-up call fails.
+    /// skills were already injected (agent is executing from an existing skill, not
+    /// discovering a new workflow), or the follow-up call fails.
     async fn skill_nudge_followup(
         &self,
         tool_call_count: usize,
+        skills_were_injected: bool,
         provider: &dyn LlmProvider,
         messages: &[ChatMessage],
         system: &Option<String>,
@@ -662,6 +664,11 @@ impl AgentRuntime {
         session_id: &str,
     ) -> Option<String> {
         if tool_call_count < SKILL_REFLECTION_THRESHOLD {
+            return None;
+        }
+        // If a skill was already retrieved for this query the agent is executing
+        // from an existing skill — suppress the nudge to avoid asking to save it again.
+        if skills_were_injected {
             return None;
         }
         if !self.tools.iter().any(|t| t.name() == "create_skill") {
@@ -1041,6 +1048,7 @@ impl AgentRuntime {
                 if let Some(followup) = self
                     .skill_nudge_followup(
                         tool_call_count,
+                        skills.is_some(),
                         provider.as_ref(),
                         &messages,
                         &system,
@@ -1249,6 +1257,7 @@ impl AgentRuntime {
                 if let Some(followup) = self
                     .skill_nudge_followup(
                         tool_call_count,
+                        skills.is_some(),
                         provider.as_ref(),
                         &messages,
                         &system,
@@ -1419,6 +1428,7 @@ impl AgentRuntime {
                 if let Some(followup) = self
                     .skill_nudge_followup(
                         tool_call_count,
+                        skills.is_some(),
                         provider.as_ref(),
                         &messages,
                         &system,
@@ -1712,6 +1722,7 @@ impl AgentRuntime {
                         if let Some(followup) = self
                             .skill_nudge_followup(
                                 tool_call_count,
+                                skills.is_some(),
                                 provider.as_ref(),
                                 &messages,
                                 &system,
@@ -1835,6 +1846,7 @@ impl AgentRuntime {
                         if let Some(followup) = self
                             .skill_nudge_followup(
                                 tool_call_count,
+                                skills.is_some(),
                                 provider.as_ref(),
                                 &messages,
                                 &system,
@@ -2042,6 +2054,7 @@ impl AgentRuntime {
                 if let Some(followup) = self
                     .skill_nudge_followup(
                         tool_call_count,
+                        skills.is_some(),
                         provider.as_ref(),
                         &messages,
                         &system,
@@ -2276,6 +2289,7 @@ impl AgentRuntime {
                         if let Some(followup) = self
                             .skill_nudge_followup(
                                 tool_call_count,
+                                skills.is_some(),
                                 provider.as_ref(),
                                 &messages,
                                 &system,
@@ -2386,6 +2400,7 @@ impl AgentRuntime {
                         if let Some(followup) = self
                             .skill_nudge_followup(
                                 tool_call_count,
+                                skills.is_some(),
                                 provider.as_ref(),
                                 &messages,
                                 &system,
@@ -4112,6 +4127,7 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD - 1,
+                false, // no skills injected
                 &provider,
                 &[],
                 &None,
@@ -4124,6 +4140,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn nudge_returns_none_when_skills_were_injected() {
+        // If a skill was injected the agent is executing from it — don't ask to save again.
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = FixedProvider {
+            reply: "Would you like to save this?",
+        };
+        let result = runtime
+            .skill_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD,
+                true, // skills were injected → suppress
+                &provider,
+                &[],
+                &None,
+                "",
+                256,
+                "sess",
+            )
+            .await;
+        assert!(
+            result.is_none(),
+            "should not fire when skills were already injected"
+        );
+    }
+
+    #[tokio::test]
     async fn nudge_returns_none_without_create_skill_tool() {
         let runtime = AgentRuntime::new(); // no create_skill registered
         let provider = FixedProvider {
@@ -4132,6 +4174,7 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD + 5,
+                false, // no skills injected
                 &provider,
                 &[],
                 &None,
@@ -4156,6 +4199,7 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
+                false, // no skills injected
                 &provider,
                 &[make_msg(ChatRole::User, "help me with git rebase")],
                 &None,
@@ -4206,6 +4250,7 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
+                false, // no skills injected
                 &provider,
                 &[],
                 &None,
@@ -4225,6 +4270,7 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
+                false, // no skills injected
                 &provider,
                 &[],
                 &None,
@@ -4280,6 +4326,7 @@ mod tests {
         runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
+                false, // no skills injected
                 &provider,
                 &history,
                 &None,

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -943,6 +943,7 @@ impl AgentRuntime {
         model_override: Option<&str>,
         system_prompt_override: Option<&str>,
         max_tokens_override: Option<u32>,
+        max_context_tokens_override: Option<usize>,
     ) -> Result<String> {
         let provider: Arc<dyn LlmProvider> = if let Some(pid) = provider_id {
             self.get_provider(pid)
@@ -1006,7 +1007,9 @@ impl AgentRuntime {
             content: MessagePart::Text(user_text.to_string()),
         });
 
-        let max_ctx = self.max_context_tokens.unwrap_or(100_000);
+        let max_ctx = max_context_tokens_override
+            .or(self.max_context_tokens)
+            .unwrap_or(100_000);
         trim_messages_to_budget(&mut messages, &system, &tool_defs, max_ctx);
 
         let mut tool_call_count: usize = 0;
@@ -1125,6 +1128,7 @@ impl AgentRuntime {
         model_override: Option<&str>,
         system_prompt_override: Option<&str>,
         max_tokens_override: Option<u32>,
+        max_context_tokens_override: Option<usize>,
         session_summary: Option<&str>,
     ) -> Result<(String, Option<String>)> {
         let provider: Arc<dyn LlmProvider> = if let Some(pid) = provider_id {
@@ -1192,7 +1196,9 @@ impl AgentRuntime {
             ),
         });
 
-        let max_ctx = self.max_context_tokens.unwrap_or(100_000);
+        let max_ctx = max_context_tokens_override
+            .or(self.max_context_tokens)
+            .unwrap_or(100_000);
         let new_summary = compact_messages(
             &mut messages,
             &system,

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -91,6 +91,15 @@ struct SessionToolConfig {
     budget: Option<u32>,
 }
 
+/// Bundles the LLM call parameters needed by `skill_nudge_followup`.
+struct NudgeContext<'a> {
+    provider: &'a dyn LlmProvider,
+    messages: &'a [ChatMessage],
+    system: &'a Option<String>,
+    model: &'a str,
+    max_tokens: u32,
+}
+
 impl AgentRuntime {
     pub fn new() -> Self {
         Self {
@@ -656,13 +665,16 @@ impl AgentRuntime {
         &self,
         tool_call_count: usize,
         skills_were_injected: bool,
-        provider: &dyn LlmProvider,
-        messages: &[ChatMessage],
-        system: &Option<String>,
-        model: &str,
-        max_tokens: u32,
+        ctx: NudgeContext<'_>,
         session_id: &str,
     ) -> Option<String> {
+        let NudgeContext {
+            provider,
+            messages,
+            system,
+            model,
+            max_tokens,
+        } = ctx;
         if tool_call_count < SKILL_REFLECTION_THRESHOLD {
             return None;
         }
@@ -1052,11 +1064,13 @@ impl AgentRuntime {
                     .skill_nudge_followup(
                         tool_call_count,
                         skills.is_some(),
-                        provider.as_ref(),
-                        &messages,
-                        &system,
-                        &effective_model,
-                        effective_max_tokens,
+                        NudgeContext {
+                            provider: provider.as_ref(),
+                            messages: &messages,
+                            system: &system,
+                            model: &effective_model,
+                            max_tokens: effective_max_tokens,
+                        },
                         session_id,
                     )
                     .await
@@ -1264,11 +1278,13 @@ impl AgentRuntime {
                     .skill_nudge_followup(
                         tool_call_count,
                         skills.is_some(),
-                        provider.as_ref(),
-                        &messages,
-                        &system,
-                        &effective_model,
-                        effective_max_tokens,
+                        NudgeContext {
+                            provider: provider.as_ref(),
+                            messages: &messages,
+                            system: &system,
+                            model: &effective_model,
+                            max_tokens: effective_max_tokens,
+                        },
                         session_id,
                     )
                     .await
@@ -1435,11 +1451,13 @@ impl AgentRuntime {
                     .skill_nudge_followup(
                         tool_call_count,
                         skills.is_some(),
-                        provider.as_ref(),
-                        &messages,
-                        &system,
-                        "",
-                        self.max_tokens.unwrap_or(4096),
+                        NudgeContext {
+                            provider: provider.as_ref(),
+                            messages: &messages,
+                            system: &system,
+                            model: "",
+                            max_tokens: self.max_tokens.unwrap_or(4096),
+                        },
                         session_id,
                     )
                     .await
@@ -1729,11 +1747,13 @@ impl AgentRuntime {
                             .skill_nudge_followup(
                                 tool_call_count,
                                 skills.is_some(),
-                                provider.as_ref(),
-                                &messages,
-                                &system,
-                                "",
-                                self.max_tokens.unwrap_or(4096),
+                                NudgeContext {
+                                    provider: provider.as_ref(),
+                                    messages: &messages,
+                                    system: &system,
+                                    model: "",
+                                    max_tokens: self.max_tokens.unwrap_or(4096),
+                                },
                                 session_id,
                             )
                             .await
@@ -1853,11 +1873,13 @@ impl AgentRuntime {
                             .skill_nudge_followup(
                                 tool_call_count,
                                 skills.is_some(),
-                                provider.as_ref(),
-                                &messages,
-                                &system,
-                                "",
-                                self.max_tokens.unwrap_or(4096),
+                                NudgeContext {
+                                    provider: provider.as_ref(),
+                                    messages: &messages,
+                                    system: &system,
+                                    model: "",
+                                    max_tokens: self.max_tokens.unwrap_or(4096),
+                                },
                                 session_id,
                             )
                             .await
@@ -2061,11 +2083,13 @@ impl AgentRuntime {
                     .skill_nudge_followup(
                         tool_call_count,
                         skills.is_some(),
-                        provider.as_ref(),
-                        &messages,
-                        &system,
-                        "",
-                        self.max_tokens.unwrap_or(4096),
+                        NudgeContext {
+                            provider: provider.as_ref(),
+                            messages: &messages,
+                            system: &system,
+                            model: "",
+                            max_tokens: self.max_tokens.unwrap_or(4096),
+                        },
                         session_id,
                     )
                     .await
@@ -2296,11 +2320,13 @@ impl AgentRuntime {
                             .skill_nudge_followup(
                                 tool_call_count,
                                 skills.is_some(),
-                                provider.as_ref(),
-                                &messages,
-                                &system,
-                                "",
-                                self.max_tokens.unwrap_or(4096),
+                                NudgeContext {
+                                    provider: provider.as_ref(),
+                                    messages: &messages,
+                                    system: &system,
+                                    model: "",
+                                    max_tokens: self.max_tokens.unwrap_or(4096),
+                                },
                                 session_id,
                             )
                             .await
@@ -2407,11 +2433,13 @@ impl AgentRuntime {
                             .skill_nudge_followup(
                                 tool_call_count,
                                 skills.is_some(),
-                                provider.as_ref(),
-                                &messages,
-                                &system,
-                                "",
-                                self.max_tokens.unwrap_or(4096),
+                                NudgeContext {
+                                    provider: provider.as_ref(),
+                                    messages: &messages,
+                                    system: &system,
+                                    model: "",
+                                    max_tokens: self.max_tokens.unwrap_or(4096),
+                                },
                                 session_id,
                             )
                             .await
@@ -4133,12 +4161,14 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD - 1,
-                false, // no skills injected
-                &provider,
-                &[],
-                &None,
-                "",
-                256,
+                false,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 256,
+                },
                 "sess",
             )
             .await;
@@ -4156,12 +4186,14 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
-                true, // skills were injected → suppress
-                &provider,
-                &[],
-                &None,
-                "",
-                256,
+                true,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 256,
+                },
                 "sess",
             )
             .await;
@@ -4180,12 +4212,14 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD + 5,
-                false, // no skills injected
-                &provider,
-                &[],
-                &None,
-                "",
-                256,
+                false,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 256,
+                },
                 "sess",
             )
             .await;
@@ -4205,12 +4239,14 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
-                false, // no skills injected
-                &provider,
-                &[make_msg(ChatRole::User, "help me with git rebase")],
-                &None,
-                "",
-                256,
+                false,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[make_msg(ChatRole::User, "help me with git rebase")],
+                    system: &None,
+                    model: "",
+                    max_tokens: 256,
+                },
                 "sess",
             )
             .await;
@@ -4256,12 +4292,14 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
-                false, // no skills injected
-                &provider,
-                &[],
-                &None,
-                "",
-                8192,
+                false,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 8192,
+                },
                 "sess",
             )
             .await;
@@ -4276,12 +4314,14 @@ mod tests {
         let result = runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
-                false, // no skills injected
-                &provider,
-                &[],
-                &None,
-                "",
-                256,
+                false,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 256,
+                },
                 "sess",
             )
             .await;
@@ -4332,12 +4372,14 @@ mod tests {
         runtime
             .skill_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
-                false, // no skills injected
-                &provider,
-                &history,
-                &None,
-                "",
-                256,
+                false,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &history,
+                    system: &None,
+                    model: "",
+                    max_tokens: 256,
+                },
                 "sess",
             )
             .await;

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -698,7 +698,7 @@ impl AgentRuntime {
                     );
                 }
                 let text = extract_text(&response.content);
-                if text.is_empty() { None } else { Some(text) }
+                strip_think_blocks(&text)
             }
             Err(e) => {
                 warn!("skill nudge follow-up LLM call failed: {}", e);
@@ -2947,6 +2947,37 @@ fn extract_text(content: &[ContentBlock]) -> String {
         .join("\n")
 }
 
+/// Strip `<think>…</think>` reasoning blocks emitted by Qwen3 and similar
+/// models running in thinking mode, then trim the remainder.
+/// Returns `None` if nothing is left after stripping.
+fn strip_think_blocks(text: &str) -> Option<String> {
+    let mut result = String::with_capacity(text.len());
+    let mut remaining = text;
+    loop {
+        match remaining.find("<think>") {
+            None => {
+                result.push_str(remaining);
+                break;
+            }
+            Some(start) => {
+                result.push_str(&remaining[..start]);
+                match remaining[start..].find("</think>") {
+                    None => break, // unclosed tag — discard the rest
+                    Some(end) => {
+                        remaining = &remaining[start + end + "</think>".len()..];
+                    }
+                }
+            }
+        }
+    }
+    let trimmed = result.trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
 /// Cosine similarity between two embedding vectors. Returns 0.0 when inputs are
 /// empty, different lengths, or either magnitude is zero.
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
@@ -3018,6 +3049,50 @@ mod tests {
             content: MessagePart::Text(text.to_string()),
         }
     }
+
+    // ── strip_think_blocks ────────────────────────────────────────────────────
+
+    #[test]
+    fn strip_think_blocks_no_tags() {
+        assert_eq!(
+            strip_think_blocks("Hello world"),
+            Some("Hello world".to_string())
+        );
+    }
+
+    #[test]
+    fn strip_think_blocks_only_thinking_returns_none() {
+        let input = "<think>I should ask the user</think>";
+        assert_eq!(strip_think_blocks(input), None);
+    }
+
+    #[test]
+    fn strip_think_blocks_thinking_then_answer() {
+        let input = "<think>Reason here</think>\nWould you like to save this?";
+        assert_eq!(
+            strip_think_blocks(input),
+            Some("Would you like to save this?".to_string())
+        );
+    }
+
+    #[test]
+    fn strip_think_blocks_multiple_blocks() {
+        let input = "<think>first</think> Answer <think>second</think> more";
+        assert_eq!(strip_think_blocks(input), Some("Answer  more".to_string()));
+    }
+
+    #[test]
+    fn strip_think_blocks_unclosed_tag_discards_rest() {
+        let input = "Before <think>unclosed";
+        assert_eq!(strip_think_blocks(input), Some("Before".to_string()));
+    }
+
+    #[test]
+    fn strip_think_blocks_empty_input() {
+        assert_eq!(strip_think_blocks(""), None);
+    }
+
+    // ── build_system_prompt ───────────────────────────────────────────────────
 
     #[test]
     fn build_system_prompt_all_parts() {

--- a/crates/opencrust-gateway/src/api.rs
+++ b/crates/opencrust-gateway/src/api.rs
@@ -144,6 +144,12 @@ pub async fn send_message(
     let agent_config = agent_router::resolve(&config, body.agent_id.as_deref(), None);
 
     let result = if let Some(ac) = agent_config {
+        // Apply per-agent tool whitelist (#300)
+        if !ac.tools.is_empty() {
+            state
+                .agents
+                .set_session_tool_config(&session_id, Some(ac.tools.clone()), None);
+        }
         state
             .agents
             .process_message_with_agent_config(
@@ -156,6 +162,7 @@ pub async fn send_message(
                 body.model.as_deref(),
                 ac.system_prompt.as_deref(),
                 ac.max_tokens,
+                ac.max_context_tokens, // #302
             )
             .await
     } else if body.model.is_some() {
@@ -169,6 +176,7 @@ pub async fn send_message(
                 None,
                 None,
                 body.model.as_deref(),
+                None,
                 None,
                 None,
             )

--- a/crates/opencrust-gateway/src/ws.rs
+++ b/crates/opencrust-gateway/src/ws.rs
@@ -12,6 +12,7 @@ use tracing::{info, warn};
 
 use opencrust_agents::ChatMessage;
 
+use crate::agent_router;
 use crate::state::SharedState;
 
 const MAX_WS_FRAME_BYTES: usize = 64 * 1024;
@@ -431,6 +432,31 @@ async fn process_text_message(
     let continuity_key = state.continuity_key(None);
     let summary = state.session_summary(session_id);
 
+    // Resolve named agent config for the web channel (#301)
+    let config = state.current_config();
+    let agent_config = agent_router::resolve(&config, None, Some("web"));
+
+    // Apply per-agent tool whitelist (#300) and resolve overrides
+    let (effective_provider, effective_system_prompt, effective_max_tokens, effective_max_ctx) =
+        if let Some(ac) = agent_config {
+            if !ac.tools.is_empty() {
+                state
+                    .agents
+                    .set_session_tool_config(session_id, Some(ac.tools.clone()), None);
+            }
+            (
+                ac.provider
+                    .as_deref()
+                    .or(provider_id.as_deref())
+                    .map(str::to_string),
+                ac.system_prompt.clone(),
+                ac.max_tokens,
+                ac.max_context_tokens,
+            )
+        } else {
+            (provider_id.clone(), None, None, None)
+        };
+
     // Route through agent runtime (with optional provider override)
     let reply = match state
         .agents
@@ -440,10 +466,11 @@ async fn process_text_message(
             &history,
             continuity_key.as_deref(),
             None,
-            provider_id.as_deref(),
+            effective_provider.as_deref(),
             model_override.as_deref(),
-            None,
-            None,
+            effective_system_prompt.as_deref(),
+            effective_max_tokens,
+            effective_max_ctx, // #302
             summary.as_deref(),
         )
         .await


### PR DESCRIPTION
## Summary

Wires three previously-ignored fields from `NamedAgentConfig` into the agent runtime. Closes #300, #301, #302.

- **#300** — `api.rs` + `ws.rs`: call `set_session_tool_config()` with `ac.tools` when the whitelist is non-empty, so per-agent tool restrictions are enforced
- **#301** — `ws.rs`: call `agent_router::resolve(&config, None, Some("web"))` so WebSocket sessions respect the named agent config (provider, system_prompt, max_tokens, max_context_tokens, tools) instead of always using hardcoded `None`
- **#302** — `runtime.rs`: add `max_context_tokens_override: Option<usize>` to `process_message_with_agent_config` and `process_message_with_agent_config_and_summary`; override takes priority over the global `self.max_context_tokens`

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — all 171 tests pass
- [x] `cargo clippy` — no new warnings
- [x] `cargo fmt --check` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)