### PR TITLE
feat(cli): interactive terminal chat command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3791,9 +3791,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/opencrust-cli/src/banner.rs
+++ b/crates/opencrust-cli/src/banner.rs
@@ -3,6 +3,38 @@ use std::path::Path;
 use colored::Colorize;
 use opencrust_config::AppConfig;
 
+/// Print the chat-mode banner shown when `opencrust chat` starts.
+pub fn print_chat_banner(url: &str, agent_id: Option<&str>) {
+    let version = env!("CARGO_PKG_VERSION");
+    let width = 50usize;
+
+    let title = format!("OpenCrust Chat v{version}");
+    let title_dashes = width.saturating_sub(2 + 5 + title.len()); // 2 ╭╮, 5 "─── " + " "
+    let top = format!("╭─── {title} {}╮", "─".repeat(title_dashes));
+    let bottom = format!("╰{}╯", "─".repeat(width - 2));
+    let inner_w = width - 4; // 4 = "│ " + " │"
+    let row = |s: &str| format!("│ {:<inner_w$} │", s);
+    let blank = row("");
+
+    let o = |s: String| s.truecolor(255, 140, 0).to_string();
+
+    println!("{}", o(top));
+    println!("{}", o(blank.clone()));
+    println!("{}", o(row("        _~^~^~_                 ")));
+    println!("{}", o(row("    \\) /  o o  \\ (/             ")));
+    println!("{}", o(row("      '_   -   _'               ")));
+    println!("{}", o(row("      / '-----' \\               ")));
+    println!("{}", o(blank.clone()));
+    println!("{}", o(row(&format!("  Gateway  {url}"))));
+    let agent_label = agent_id.unwrap_or("default");
+    println!("{}", o(row(&format!("  Agent    {agent_label}"))));
+    println!("{}", o(blank.clone()));
+    println!("{}", o(row("  Type /help for commands")));
+    println!("{}", o(blank));
+    println!("{}", o(bottom));
+    println!();
+}
+
 /// Print the startup banner with Ferris and config summary.
 pub fn print_banner(host: &str, port: u16, config: &AppConfig, config_dir: &Path) {
     let version = env!("CARGO_PKG_VERSION");

--- a/crates/opencrust-cli/src/chat.rs
+++ b/crates/opencrust-cli/src/chat.rs
@@ -1,0 +1,146 @@
+use anyhow::{Context, Result};
+use colored::Colorize;
+use reqwest::Client;
+use std::io::{self, BufRead, Write};
+
+use crate::banner;
+
+struct ChatSession {
+    client: Client,
+    base_url: String,
+    agent_id: Option<String>,
+    session_id: Option<String>,
+}
+
+impl ChatSession {
+    fn new(base_url: String, agent_id: Option<String>) -> Self {
+        Self {
+            client: Client::new(),
+            base_url,
+            agent_id,
+            session_id: None,
+        }
+    }
+
+    async fn create_session(&mut self) -> Result<()> {
+        let body = serde_json::json!({ "agent_id": self.agent_id });
+        let resp = self
+            .client
+            .post(format!("{}/api/sessions", self.base_url))
+            .json(&body)
+            .send()
+            .await
+            .context("failed to connect to gateway — is `opencrust start` running?")?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("gateway returned {}", resp.status());
+        }
+
+        let json: serde_json::Value = resp.json().await.context("invalid session response")?;
+        self.session_id = json["session_id"].as_str().map(str::to_string);
+        Ok(())
+    }
+
+    async fn send(&self, text: &str) -> Result<String> {
+        let session_id = self.session_id.as_deref().context("no active session")?;
+        let resp = self
+            .client
+            .post(format!(
+                "{}/api/sessions/{}/messages",
+                self.base_url, session_id
+            ))
+            .json(&serde_json::json!({ "content": text }))
+            .send()
+            .await
+            .context("failed to send message")?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("gateway returned {}", resp.status());
+        }
+
+        let json: serde_json::Value = resp.json().await.context("invalid message response")?;
+        Ok(json["content"].as_str().unwrap_or("").to_string())
+    }
+}
+
+pub async fn run(base_url: String, agent_id: Option<String>) -> Result<()> {
+    let mut session = ChatSession::new(base_url.clone(), agent_id.clone());
+
+    banner::print_chat_banner(&base_url, agent_id.as_deref());
+
+    session
+        .create_session()
+        .await
+        .context("could not start chat session")?;
+
+    let stdin = io::stdin();
+    loop {
+        print!("{} ", "you ›".cyan().bold());
+        io::stdout().flush()?;
+
+        let mut line = String::new();
+        match stdin.lock().read_line(&mut line) {
+            Ok(0) => break, // EOF (Ctrl-D)
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("read error: {e}");
+                break;
+            }
+        }
+
+        let text = line.trim();
+        if text.is_empty() {
+            continue;
+        }
+
+        match text {
+            "/exit" | "/quit" => {
+                println!("{}", "Goodbye!".dimmed());
+                break;
+            }
+            "/help" => {
+                println!("{}", "Commands:".bold());
+                println!("  /exit, /quit     — end the session");
+                println!("  /new             — start a fresh conversation");
+                println!("  /agent <id>      — switch to a different agent");
+                println!("  /clear           — clear the screen");
+                println!("  /help            — show this message");
+            }
+            "/new" => {
+                session.create_session().await?;
+                println!("{}", "New session started.".dimmed());
+            }
+            "/clear" => {
+                print!("\x1b[2J\x1b[1;1H");
+                io::stdout().flush()?;
+            }
+            _ if text.starts_with("/agent ") => {
+                let id = text[7..].trim().to_string();
+                if id.is_empty() {
+                    println!("{}", "Usage: /agent <agent-id>".yellow());
+                } else {
+                    session.agent_id = Some(id.clone());
+                    session.create_session().await?;
+                    println!("{}", format!("Switched to agent: {id}").dimmed());
+                }
+            }
+            _ if text.starts_with('/') => {
+                println!(
+                    "{}",
+                    format!("Unknown command: {text}  (type /help for help)").yellow()
+                );
+            }
+            _ => match session.send(text).await {
+                Ok(reply) => {
+                    println!("{} {}", "bot ›".green().bold(), reply);
+                    println!();
+                }
+                Err(e) => {
+                    println!("{} {e}", "error ›".red().bold());
+                }
+            },
+        }
+    }
+
+    Ok(())
+}

--- a/crates/opencrust-cli/src/main.rs
+++ b/crates/opencrust-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod banner;
+mod chat;
 mod doctor;
 mod mcp_registry;
 mod migrate;
@@ -72,6 +73,17 @@ enum Commands {
 
     /// Run the onboarding wizard
     Init,
+
+    /// Interactive terminal chat with the gateway
+    Chat {
+        /// Gateway URL
+        #[arg(long, default_value = "http://127.0.0.1:3888")]
+        url: String,
+
+        /// Named agent to use (defaults to gateway default)
+        #[arg(long)]
+        agent: Option<String>,
+    },
 
     /// Manage channels
     Channel {
@@ -763,6 +775,9 @@ async fn async_main(
         Commands::Init => {
             init_tracing(&cli.log_level);
             wizard::run_wizard(config_loader.config_dir()).await?;
+        }
+        Commands::Chat { url, agent } => {
+            chat::run(url, agent).await?;
         }
         Commands::Channel { action } => {
             init_tracing(&cli.log_level);


### PR DESCRIPTION
## Summary

- Adds \`opencrust chat\` subcommand — a readline-style terminal chat client that connects to a running gateway over REST
- Displays an ASCII Ferris banner (same orange truecolor palette as \`opencrust start\`) showing gateway URL and active agent
- Colored prompts: \`you ›\` (cyan), \`bot ›\` (green), \`error ›\` (red)
- Built-in slash commands: \`/help\`, \`/new\`, \`/agent <id>\`, \`/clear\`, \`/exit\` / \`/quit\`

## Usage

\`\`\`bash
# Connect to local gateway (default)
opencrust chat

# Use a specific named agent
opencrust chat --agent triage

# Connect to a remote gateway
opencrust chat --url http://192.168.1.10:3888
\`\`\`

## Design rationale

CLI chat is a **client**, not a channel. It connects to the already-running gateway via \`POST /api/sessions\` + \`POST /api/sessions/:id/messages\` — the same REST path as the web client. It lives in \`opencrust-cli\` as a thin \`chat.rs\` module; no new dependencies were added (\`reqwest\` and \`colored\` were already present).

## Test plan

- [x] \`opencrust start\` then \`opencrust chat\` — banner renders, messages round-trip to bot and back
- [x] \`opencrust chat --agent <name>\` — \`Agent\` line in banner shows the correct name
- [x] \`/new\` resets session (history cleared)
- [x] \`/agent <id>\` mid-session switches agent and creates a new session
- [x] \`/clear\` clears the screen
- [x] \`/exit\` and Ctrl-D both exit cleanly
- [x] \`opencrust chat\` when gateway is not running — prints a clear "is \`opencrust start\` running?" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)