### PR TITLE
docs(i18n): add Terminal Chat section to Thai, Chinese, Hindi READMEs

### DIFF
--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -68,6 +68,63 @@ cargo build --release --features plugins
 ```
 </details>
 
+### Terminal Chat
+
+Browser खोले बिना सीधे terminal से agent से बात करें।
+
+> **Gateway चालू होना ज़रूरी है।** पहली बार `opencrust init` चलाएं, फिर `opencrust start`, उसके बाद `opencrust chat` उपयोग करें।
+
+```bash
+# पहली बार setup
+opencrust init
+opencrust start           # या: opencrust start -d  (daemon mode)
+
+# Terminal chat खोलें
+opencrust chat
+opencrust chat --agent coder           # किसी agent के साथ शुरू करें
+opencrust chat --url http://host:3888  # दूसरे gateway से जुड़ें
+```
+
+```
+╭─── OpenCrust Chat v0.2.9 ──────────────────────╮
+│                                                │
+│         _~^~^~_                                │
+│     \) /  o o  \ (/                            │
+│       '_   -   _'                              │
+│       / '-----' \                              │
+│                                                │
+│   Gateway  http://127.0.0.1:3888               │
+│   Agent    default                             │
+│                                                │
+│   Type /help for commands                      │
+│                                                │
+╰────────────────────────────────────────────────╯
+
+you › Go channel और Rust async में क्या अंतर है?
+bot › Go channel भाषा में built-in है — goroutine typed channel
+      (make(chan int, 5)) से data भेजते हैं। Rust async में
+      Future + tokio::sync::mpsc use होता है, लेकिन ownership
+      system compile time पर data race रोकता है, unsafe के बिना।
+
+you › /agent coder
+Switched to agent: coder.
+
+you › rust mpsc का example दिखाओ
+bot › use tokio::sync::mpsc;
+
+      #[tokio::main]
+      async fn main() {
+          let (tx, mut rx) = mpsc::channel(8);
+          tokio::spawn(async move { tx.send(42).await.unwrap(); });
+          println!("{}", rx.recv().await.unwrap()); // 42
+      }
+
+you › /exit
+Goodbye!
+```
+
+**Chat commands:** `/help` · `/new` (नया session) · `/agent <id>` · `/clear` · `/exit`
+
 Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) और Windows (x86_64) के लिए binary [GitHub Releases](https://github.com/opencrust-org/opencrust/releases) पर उपलब्ध हैं।
 
 ## OpenCrust क्यों?

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -68,6 +68,63 @@ cargo build --release --features plugins
 ```
 </details>
 
+### แชทผ่าน Terminal
+
+คุยกับ agent โดยตรงจาก terminal โดยไม่ต้องเปิดเบราว์เซอร์
+
+> **ต้องเปิด gateway ก่อน** รัน `opencrust init` (ครั้งแรกเท่านั้น) จากนั้น `opencrust start` ก่อนใช้ `opencrust chat`
+
+```bash
+# ตั้งค่าครั้งแรก
+opencrust init
+opencrust start           # หรือ: opencrust start -d  (daemon mode)
+
+# เปิด terminal chat
+opencrust chat
+opencrust chat --agent coder           # เริ่มด้วย agent ที่กำหนด
+opencrust chat --url http://host:3888  # เชื่อมกับ gateway อื่น
+```
+
+```
+╭─── OpenCrust Chat v0.2.9 ──────────────────────╮
+│                                                │
+│         _~^~^~_                                │
+│     \) /  o o  \ (/                            │
+│       '_   -   _'                              │
+│       / '-----' \                              │
+│                                                │
+│   Gateway  http://127.0.0.1:3888               │
+│   Agent    default                             │
+│                                                │
+│   Type /help for commands                      │
+│                                                │
+╰────────────────────────────────────────────────╯
+
+you › Go channel กับ Rust async ต่างกันอย่างไร?
+bot › Go channel เป็น feature ในตัวภาษา — goroutine สื่อสารกันผ่าน
+      typed channel (make(chan int, 5)) ส่วน Rust async ใช้
+      Future + tokio::sync::mpsc แต่ระบบ ownership ป้องกัน
+      data race ได้ตั้งแต่ compile time โดยไม่ต้องใช้ unsafe
+
+you › /agent coder
+Switched to agent: coder.
+
+you › ขอตัวอย่าง rust mpsc
+bot › use tokio::sync::mpsc;
+
+      #[tokio::main]
+      async fn main() {
+          let (tx, mut rx) = mpsc::channel(8);
+          tokio::spawn(async move { tx.send(42).await.unwrap(); });
+          println!("{}", rx.recv().await.unwrap()); // 42
+      }
+
+you › /exit
+Goodbye!
+```
+
+**คำสั่งใน chat:** `/help` · `/new` (เริ่ม session ใหม่) · `/agent <id>` · `/clear` · `/exit`
+
 binary สำหรับ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) และ Windows (x86_64) ดาวน์โหลดได้ที่ [GitHub Releases](https://github.com/opencrust-org/opencrust/releases)
 
 ## ทำไมต้อง OpenCrust?

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -68,6 +68,63 @@ cargo build --release --features plugins
 ```
 </details>
 
+### 终端聊天
+
+直接在终端与 agent 对话，无需打开浏览器。
+
+> **需要先启动 gateway。** 首次使用请运行 `opencrust init`，然后运行 `opencrust start`，再使用 `opencrust chat`。
+
+```bash
+# 首次设置
+opencrust init
+opencrust start           # 或：opencrust start -d  (后台模式)
+
+# 启动终端聊天
+opencrust chat
+opencrust chat --agent coder           # 使用指定 agent
+opencrust chat --url http://host:3888  # 连接远程 gateway
+```
+
+```
+╭─── OpenCrust Chat v0.2.9 ──────────────────────╮
+│                                                │
+│         _~^~^~_                                │
+│     \) /  o o  \ (/                            │
+│       '_   -   _'                              │
+│       / '-----' \                              │
+│                                                │
+│   Gateway  http://127.0.0.1:3888               │
+│   Agent    default                             │
+│                                                │
+│   Type /help for commands                      │
+│                                                │
+╰────────────────────────────────────────────────╯
+
+you › Go channel 和 Rust async 有什么区别？
+bot › Go channel 是语言内置功能 — goroutine 通过类型化 channel
+      (make(chan int, 5)) 传递数据。Rust async 使用
+      Future + tokio::sync::mpsc 实现类似模式，但所有权系统
+      在编译期就能防止数据竞争，无需 unsafe。
+
+you › /agent coder
+Switched to agent: coder.
+
+you › 给我一个 rust mpsc 示例
+bot › use tokio::sync::mpsc;
+
+      #[tokio::main]
+      async fn main() {
+          let (tx, mut rx) = mpsc::channel(8);
+          tokio::spawn(async move { tx.send(42).await.unwrap(); });
+          println!("{}", rx.recv().await.unwrap()); // 42
+      }
+
+you › /exit
+Goodbye!
+```
+
+**聊天命令：** `/help` · `/new`（新建会话）· `/agent <id>` · `/clear` · `/exit`
+
 适用于 Linux (x86_64, aarch64)、macOS (Intel, Apple Silicon) 和 Windows (x86_64) 的预编译二进制文件。可在 [GitHub Releases](https://github.com/opencrust-org/opencrust/releases) 下载。
 
 ## 为什么选择 OpenCrust?


### PR DESCRIPTION
## Summary

Adds the `opencrust chat` Terminal Chat quick start section to all three i18n READMEs, matching the English README updated in #312.

| File | Language | Section added |
|---|---|---|
| `i18n/README.th.md` | Thai | `### แชทผ่าน Terminal` |
| `i18n/README.zh.md` | Chinese | `### 终端聊天` |
| `i18n/README.hi.md` | Hindi | `### Terminal Chat` |

Each translation includes:
- Prerequisite note (gateway must be running)
- Usage examples (`--agent`, `--url` flags)
- Terminal UI banner + conversation demo
- Slash command list

## Test plan

- [x] All three i18n files contain the Terminal Chat section
- [x] Commands (`opencrust chat`, `--agent`, `--url`, `/new`, `/agent`, `/clear`, `/exit`) match English README exactly
- [x] Prerequisite flow explained in each language before the usage example

🤖 Generated with [Claude Code](https://claude.com/claude-code)