### PR TITLE
docs: add Web Chat quick start section to all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ Goodbye!
 
 **Chat commands:** `/help` · `/new` (fresh session) · `/agent <id>` · `/clear` · `/exit`
 
+### Web Chat
+
+Once the gateway is running, open your browser at:
+
+```
+http://127.0.0.1:3888
+```
+
+The built-in web UI lets you chat with your agent, switch LLM providers on the fly, manage MCP servers, and monitor connected channels — all without restarting.
+
+> **Authentication** — if `api_key` is set in `config.yml`, the UI will prompt for the gateway key before connecting.
+
 Pre-compiled binaries for Linux (x86_64, aarch64), macOS (Intel, Apple Silicon), and Windows (x86_64) are available on [GitHub Releases](https://github.com/opencrust-org/opencrust/releases).
 
 ## Why OpenCrust?

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -125,6 +125,18 @@ Goodbye!
 
 **Chat commands:** `/help` · `/new` (नया session) · `/agent <id>` · `/clear` · `/exit`
 
+### Web Chat
+
+Gateway चालू होने के बाद, browser में खोलें:
+
+```
+http://127.0.0.1:3888
+```
+
+Built-in Web UI से आप agent से chat कर सकते हैं, LLM provider बदल सकते हैं, MCP server manage कर सकते हैं और connected channels देख सकते हैं — बिना restart किए।
+
+> **Authentication** — अगर `config.yml` में `api_key` सेट है, तो UI connect करने से पहले gateway key मांगेगा।
+
 Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) और Windows (x86_64) के लिए binary [GitHub Releases](https://github.com/opencrust-org/opencrust/releases) पर उपलब्ध हैं।
 
 ## OpenCrust क्यों?

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -125,6 +125,18 @@ Goodbye!
 
 **คำสั่งใน chat:** `/help` · `/new` (เริ่ม session ใหม่) · `/agent <id>` · `/clear` · `/exit`
 
+### Web Chat
+
+เมื่อ gateway รันแล้ว เปิดเบราว์เซอร์ที่:
+
+```
+http://127.0.0.1:3888
+```
+
+Web UI ในตัวช่วยให้คุณแชทกับ agent สลับ LLM provider, จัดการ MCP server และตรวจสอบ channel ที่เชื่อมต่ออยู่ — โดยไม่ต้องรีสตาร์ท
+
+> **Authentication** — ถ้าตั้งค่า `api_key` ไว้ใน `config.yml` UI จะขอ gateway key ก่อนเชื่อมต่อ
+
 binary สำหรับ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) และ Windows (x86_64) ดาวน์โหลดได้ที่ [GitHub Releases](https://github.com/opencrust-org/opencrust/releases)
 
 ## ทำไมต้อง OpenCrust?

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -125,6 +125,18 @@ Goodbye!
 
 **聊天命令：** `/help` · `/new`（新建会话）· `/agent <id>` · `/clear` · `/exit`
 
+### 网页聊天
+
+Gateway 启动后，在浏览器中打开：
+
+```
+http://127.0.0.1:3888
+```
+
+内置 Web UI 让你与 agent 对话、实时切换 LLM provider、管理 MCP server 并监控已连接的 channel — 无需重启。
+
+> **身份验证** — 若 `config.yml` 中设置了 `api_key`，UI 将在连接前提示输入 gateway key。
+
 适用于 Linux (x86_64, aarch64)、macOS (Intel, Apple Silicon) 和 Windows (x86_64) 的预编译二进制文件。可在 [GitHub Releases](https://github.com/opencrust-org/opencrust/releases) 下载。
 
 ## 为什么选择 OpenCrust?


### PR DESCRIPTION
## Summary

Adds a **Web Chat** subsection to the Quick Start section in all four READMEs, documenting the built-in browser UI that ships with the gateway.

| File | Language |
|---|---|
| `README.md` | English |
| `i18n/README.th.md` | Thai |
| `i18n/README.zh.md` | Chinese |
| `i18n/README.hi.md` | Hindi |

Each section covers:
- Browser URL (`http://127.0.0.1:3888`)
- What the UI provides: chat, live LLM provider switching, MCP server management, channel monitoring
- Authentication note for `api_key`-protected gateways

## Test plan

- [x] Web Chat section appears after Terminal Chat in all four READMEs
- [x] URL, feature list, and auth note are consistent across all languages
- [x] Renders correctly on GitHub (blockquote, code block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)