### PR TITLE
docs: move Web Chat before Terminal Chat in all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ cargo build --release --features plugins
 ```
 </details>
 
+### Web Chat
+
+Once the gateway is running, open your browser at:
+
+```
+http://127.0.0.1:3888
+```
+
+The built-in web UI lets you chat with your agent, switch LLM providers on the fly, manage MCP servers, and monitor connected channels — all without restarting.
+
+> **Authentication** — if `api_key` is set in `config.yml`, the UI will prompt for the gateway key before connecting.
+
 ### Terminal Chat
 
 Chat with your agent directly from the terminal — no browser needed.
@@ -125,18 +137,6 @@ Goodbye!
 ```
 
 **Chat commands:** `/help` · `/new` (fresh session) · `/agent <id>` · `/clear` · `/exit`
-
-### Web Chat
-
-Once the gateway is running, open your browser at:
-
-```
-http://127.0.0.1:3888
-```
-
-The built-in web UI lets you chat with your agent, switch LLM providers on the fly, manage MCP servers, and monitor connected channels — all without restarting.
-
-> **Authentication** — if `api_key` is set in `config.yml`, the UI will prompt for the gateway key before connecting.
 
 Pre-compiled binaries for Linux (x86_64, aarch64), macOS (Intel, Apple Silicon), and Windows (x86_64) are available on [GitHub Releases](https://github.com/opencrust-org/opencrust/releases).
 

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -68,6 +68,18 @@ cargo build --release --features plugins
 ```
 </details>
 
+### Web Chat
+
+Gateway चालू होने के बाद, browser में खोलें:
+
+```
+http://127.0.0.1:3888
+```
+
+Built-in Web UI से आप agent से chat कर सकते हैं, LLM provider बदल सकते हैं, MCP server manage कर सकते हैं और connected channels देख सकते हैं — बिना restart किए।
+
+> **Authentication** — अगर `config.yml` में `api_key` सेट है, तो UI connect करने से पहले gateway key मांगेगा।
+
 ### Terminal Chat
 
 Browser खोले बिना सीधे terminal से agent से बात करें।
@@ -124,18 +136,6 @@ Goodbye!
 ```
 
 **Chat commands:** `/help` · `/new` (नया session) · `/agent <id>` · `/clear` · `/exit`
-
-### Web Chat
-
-Gateway चालू होने के बाद, browser में खोलें:
-
-```
-http://127.0.0.1:3888
-```
-
-Built-in Web UI से आप agent से chat कर सकते हैं, LLM provider बदल सकते हैं, MCP server manage कर सकते हैं और connected channels देख सकते हैं — बिना restart किए।
-
-> **Authentication** — अगर `config.yml` में `api_key` सेट है, तो UI connect करने से पहले gateway key मांगेगा।
 
 Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) और Windows (x86_64) के लिए binary [GitHub Releases](https://github.com/opencrust-org/opencrust/releases) पर उपलब्ध हैं।
 

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -68,6 +68,18 @@ cargo build --release --features plugins
 ```
 </details>
 
+### Web Chat
+
+เมื่อ gateway รันแล้ว เปิดเบราว์เซอร์ที่:
+
+```
+http://127.0.0.1:3888
+```
+
+Web UI ในตัวช่วยให้คุณแชทกับ agent สลับ LLM provider, จัดการ MCP server และตรวจสอบ channel ที่เชื่อมต่ออยู่ — โดยไม่ต้องรีสตาร์ท
+
+> **Authentication** — ถ้าตั้งค่า `api_key` ไว้ใน `config.yml` UI จะขอ gateway key ก่อนเชื่อมต่อ
+
 ### แชทผ่าน Terminal
 
 คุยกับ agent โดยตรงจาก terminal โดยไม่ต้องเปิดเบราว์เซอร์
@@ -124,18 +136,6 @@ Goodbye!
 ```
 
 **คำสั่งใน chat:** `/help` · `/new` (เริ่ม session ใหม่) · `/agent <id>` · `/clear` · `/exit`
-
-### Web Chat
-
-เมื่อ gateway รันแล้ว เปิดเบราว์เซอร์ที่:
-
-```
-http://127.0.0.1:3888
-```
-
-Web UI ในตัวช่วยให้คุณแชทกับ agent สลับ LLM provider, จัดการ MCP server และตรวจสอบ channel ที่เชื่อมต่ออยู่ — โดยไม่ต้องรีสตาร์ท
-
-> **Authentication** — ถ้าตั้งค่า `api_key` ไว้ใน `config.yml` UI จะขอ gateway key ก่อนเชื่อมต่อ
 
 binary สำหรับ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) และ Windows (x86_64) ดาวน์โหลดได้ที่ [GitHub Releases](https://github.com/opencrust-org/opencrust/releases)
 

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -68,6 +68,18 @@ cargo build --release --features plugins
 ```
 </details>
 
+### 网页聊天
+
+Gateway 启动后，在浏览器中打开：
+
+```
+http://127.0.0.1:3888
+```
+
+内置 Web UI 让你与 agent 对话、实时切换 LLM provider、管理 MCP server 并监控已连接的 channel — 无需重启。
+
+> **身份验证** — 若 `config.yml` 中设置了 `api_key`，UI 将在连接前提示输入 gateway key。
+
 ### 终端聊天
 
 直接在终端与 agent 对话，无需打开浏览器。
@@ -124,18 +136,6 @@ Goodbye!
 ```
 
 **聊天命令：** `/help` · `/new`（新建会话）· `/agent <id>` · `/clear` · `/exit`
-
-### 网页聊天
-
-Gateway 启动后，在浏览器中打开：
-
-```
-http://127.0.0.1:3888
-```
-
-内置 Web UI 让你与 agent 对话、实时切换 LLM provider、管理 MCP server 并监控已连接的 channel — 无需重启。
-
-> **身份验证** — 若 `config.yml` 中设置了 `api_key`，UI 将在连接前提示输入 gateway key。
 
 适用于 Linux (x86_64, aarch64)、macOS (Intel, Apple Silicon) 和 Windows (x86_64) 的预编译二进制文件。可在 [GitHub Releases](https://github.com/opencrust-org/opencrust/releases) 下载。
 


### PR DESCRIPTION
## Summary

Reorders the Quick Start subsections so **Web Chat** appears before **Terminal Chat** in all four READMEs — the browser UI at `http://127.0.0.1:3888` is the more accessible entry point for new users, while the terminal chat is for power users who prefer the CLI.

Affected files: `README.md`, `i18n/README.th.md`, `i18n/README.zh.md`, `i18n/README.hi.md`

No content changes — reorder only.

## Test plan

- [x] Web Chat section appears before Terminal Chat in all four READMEs
- [x] No content was added or removed, only order changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)