### PR TITLE
fix(agents): preserve call_count when updating session tool config (#318)

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -331,20 +331,27 @@ impl AgentRuntime {
     /// Set the tool configuration for a session before processing a message.
     /// `allowed_tools = None` means all tools are permitted.
     /// `budget = None` means no per-session call-count cap.
+    ///
+    /// Preserves the existing `call_count` so the budget is enforced across
+    /// the whole session, not reset on every incoming message.
     pub fn set_session_tool_config(
         &self,
         session_id: &str,
         allowed_tools: Option<Vec<String>>,
         budget: Option<u32>,
     ) {
-        self.session_tool_config.insert(
-            session_id.to_string(),
-            SessionToolConfig {
+        self.session_tool_config
+            .entry(session_id.to_string())
+            .and_modify(|cfg| {
+                cfg.allowed_tools = allowed_tools.clone();
+                cfg.budget = budget;
+                // call_count is intentionally preserved
+            })
+            .or_insert(SessionToolConfig {
                 allowed_tools,
                 call_count: 0,
                 budget,
-            },
-        );
+            });
     }
 
     /// Remove the tool configuration for a session (called during cleanup).
@@ -3562,6 +3569,26 @@ mod tests {
         assert!(runtime.check_tool_allowed("sess", "bash").is_ok()); // call 2
         let err = runtime.check_tool_allowed("sess", "bash"); // call 3 → blocked
         assert!(err.is_err());
+        assert!(err.unwrap_err().to_string().contains("budget"));
+    }
+
+    #[test]
+    fn set_session_tool_config_preserves_call_count_across_messages() {
+        // Regression test for issue #318: call_count must not reset when
+        // set_session_tool_config is called again (as happens on every message).
+        let runtime = AgentRuntime::new();
+
+        // First message: configure budget of 3, use 2 calls
+        runtime.set_session_tool_config("sess", None, Some(3));
+        assert!(runtime.check_tool_allowed("sess", "bash").is_ok()); // call 1
+        assert!(runtime.check_tool_allowed("sess", "bash").is_ok()); // call 2
+
+        // Second message: set_session_tool_config is called again (simulating
+        // a new incoming message). call_count must still be 2, not reset to 0.
+        runtime.set_session_tool_config("sess", None, Some(3));
+        assert!(runtime.check_tool_allowed("sess", "bash").is_ok()); // call 3
+        let err = runtime.check_tool_allowed("sess", "bash"); // call 4 → blocked
+        assert!(err.is_err(), "budget should be exhausted across messages");
         assert!(err.unwrap_err().to_string().contains("budget"));
     }
 

--- a/crates/opencrust-channels/src/telegram.rs
+++ b/crates/opencrust-channels/src/telegram.rs
@@ -184,16 +184,15 @@ fn is_bot_mentioned(msg: &teloxide::types::Message, bot_username: &str) -> bool 
                         }
                     }
                 }
-                teloxide::types::MessageEntityKind::TextMention { user } => {
+                teloxide::types::MessageEntityKind::TextMention { user }
                     if user.is_bot
                         && user
                             .username
                             .as_deref()
                             .map(|u| u.eq_ignore_ascii_case(bot_username))
-                            .unwrap_or(false)
-                    {
-                        return true;
-                    }
+                            .unwrap_or(false) =>
+                {
+                    return true;
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Problem

`set_session_tool_config()` was calling `DashMap::insert()` unconditionally on every incoming message, resetting `call_count` to `0` each time. The per-session tool call budget was therefore only enforced within a single message, not across the session lifetime.

Fixes #318.

## Fix

Replace `insert()` with `entry().and_modify().or_insert()` so `allowed_tools` and `budget` are updated while `call_count` is preserved:

```rust
self.session_tool_config
    .entry(session_id.to_string())
    .and_modify(|cfg| {
        cfg.allowed_tools = allowed_tools.clone();
        cfg.budget = budget;
        // call_count is intentionally preserved
    })
    .or_insert(SessionToolConfig {
        allowed_tools,
        call_count: 0,
        budget,
    });
```

## Test plan

- [x] Existing tests pass (`set_session_tool_config_and_check_allowed_tool`, `budget_exhaustion_blocks_tool_call`)
- [x] New regression test `set_session_tool_config_preserves_call_count_across_messages` — calls `set_session_tool_config` twice (simulating two messages), verifies budget is exhausted across both calls, not reset on the second call
- [x] Full test suite: 148 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)