### PR TITLE
fix(gateway): clean up session DNA/skills overrides and stale pending files (#319)

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -388,6 +388,34 @@ impl AgentRuntime {
         self.session_user_name.retain(|id, _| f(id));
     }
 
+    /// Retain only DNA overrides whose session IDs satisfy the predicate.
+    pub fn retain_session_dna_overrides<F>(&self, f: F)
+    where
+        F: Fn(&str) -> bool,
+    {
+        self.session_dna_override.retain(|id, _| f(id));
+    }
+
+    /// Retain only skills overrides whose session IDs satisfy the predicate.
+    pub fn retain_session_skills_overrides<F>(&self, f: F)
+    where
+        F: Fn(&str) -> bool,
+    {
+        self.session_skills_override.retain(|id, _| f(id));
+    }
+
+    /// Returns `true` if a DNA override is stored for the session.
+    /// Intended for use in tests and diagnostics.
+    pub fn has_session_dna_override(&self, session_id: &str) -> bool {
+        self.session_dna_override.contains_key(session_id)
+    }
+
+    /// Returns `true` if a skills override is stored for the session.
+    /// Intended for use in tests and diagnostics.
+    pub fn has_session_skills_override(&self, session_id: &str) -> bool {
+        self.session_skills_override.contains_key(session_id)
+    }
+
     /// Get the user display name for a session.
     fn session_user_name(&self, session_id: &str) -> Option<String> {
         self.session_user_name.get(session_id).map(|v| v.clone())
@@ -3601,6 +3629,26 @@ mod tests {
         assert!(runtime.check_tool_allowed("keep", "bash").is_ok());
         // "drop" has no config → passes through (None config = all allowed)
         assert!(runtime.check_tool_allowed("drop", "bash").is_ok());
+    }
+
+    #[test]
+    fn retain_session_dna_overrides_removes_evicted_sessions() {
+        let runtime = AgentRuntime::new();
+        runtime.set_session_dna_override("keep", Some("you are helpful".to_string()));
+        runtime.set_session_dna_override("drop", Some("you are a pirate".to_string()));
+        runtime.retain_session_dna_overrides(|id| id == "keep");
+        assert!(runtime.session_dna_override.contains_key("keep"));
+        assert!(!runtime.session_dna_override.contains_key("drop"));
+    }
+
+    #[test]
+    fn retain_session_skills_overrides_removes_evicted_sessions() {
+        let runtime = AgentRuntime::new();
+        runtime.set_session_skills_override("keep", Some("skill: greet".to_string()));
+        runtime.set_session_skills_override("drop", Some("skill: farewell".to_string()));
+        runtime.retain_session_skills_overrides(|id| id == "keep");
+        assert!(runtime.session_skills_override.contains_key("keep"));
+        assert!(!runtime.session_skills_override.contains_key("drop"));
     }
 
     #[test]

--- a/crates/opencrust-gateway/src/state.rs
+++ b/crates/opencrust-gateway/src/state.rs
@@ -23,6 +23,8 @@ const SESSION_TTL: Duration = Duration::from_secs(3600); // 1 hour
 const CLEANUP_INTERVAL: Duration = Duration::from_secs(300); // 5 minutes
 /// Sliding window for per-user rate limiting.
 const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+/// How long an unconfirmed pending file is kept before being dropped.
+const PENDING_FILE_TTL: Duration = Duration::from_secs(300); // 5 minutes
 
 /// Per-user rate limit tracking entry.
 struct UserRateLimitEntry {
@@ -680,6 +682,14 @@ impl AppState {
             .retain_session_tool_configs(|session_id| self.sessions.contains_key(session_id));
         self.agents
             .retain_session_user_names(|session_id| self.sessions.contains_key(session_id));
+        self.agents
+            .retain_session_dna_overrides(|session_id| self.sessions.contains_key(session_id));
+        self.agents
+            .retain_session_skills_overrides(|session_id| self.sessions.contains_key(session_id));
+
+        // Drop pending files that were never confirmed within PENDING_FILE_TTL.
+        self.pending_files
+            .retain(|_, f| f.received_at.elapsed() < PENDING_FILE_TTL);
 
         // Evict rate-limit entries whose sliding window has fully expired and
         // whose cooldown (if any) has also elapsed. Without this, the DashMap
@@ -1039,6 +1049,89 @@ mod tests {
         assert!(
             state.user_rate_limits.contains_key("user_b"),
             "active rate-limit entry should NOT be evicted"
+        );
+    }
+
+    #[test]
+    fn cleanup_drops_stale_pending_files() {
+        let state = test_state();
+
+        // Fresh file — received just now.
+        state.set_pending_file(
+            "fresh",
+            PendingFile {
+                filename: "fresh.pdf".to_string(),
+                data: vec![1, 2, 3],
+                received_at: Instant::now(),
+            },
+        );
+
+        // Stale file — received more than PENDING_FILE_TTL ago.
+        state.set_pending_file(
+            "stale",
+            PendingFile {
+                filename: "stale.pdf".to_string(),
+                data: vec![4, 5, 6],
+                received_at: Instant::now() - PENDING_FILE_TTL - Duration::from_secs(1),
+            },
+        );
+
+        state.cleanup_expired_sessions();
+
+        assert!(
+            state.pending_files.contains_key("fresh"),
+            "fresh pending file should be retained"
+        );
+        assert!(
+            !state.pending_files.contains_key("stale"),
+            "stale pending file should be evicted"
+        );
+    }
+
+    #[test]
+    fn cleanup_drops_dna_and_skills_overrides_for_evicted_sessions() {
+        let state = test_state();
+
+        // Active session.
+        let active_id = state.create_session();
+
+        // Expired session — simulate by back-dating last_active.
+        let expired_id = state.create_session();
+        if let Some(mut s) = state.sessions.get_mut(&expired_id) {
+            s.connected = false;
+            s.last_active = Instant::now() - Duration::from_secs(7200);
+        }
+
+        state
+            .agents
+            .set_session_dna_override(&active_id, Some("active dna".to_string()));
+        state
+            .agents
+            .set_session_dna_override(&expired_id, Some("expired dna".to_string()));
+        state
+            .agents
+            .set_session_skills_override(&active_id, Some("active skills".to_string()));
+        state
+            .agents
+            .set_session_skills_override(&expired_id, Some("expired skills".to_string()));
+
+        state.cleanup_expired_sessions();
+
+        assert!(
+            state.agents.has_session_dna_override(&active_id),
+            "active session DNA should be retained"
+        );
+        assert!(
+            !state.agents.has_session_dna_override(&expired_id),
+            "expired session DNA should be evicted"
+        );
+        assert!(
+            state.agents.has_session_skills_override(&active_id),
+            "active session skills should be retained"
+        );
+        assert!(
+            !state.agents.has_session_skills_override(&expired_id),
+            "expired session skills should be evicted"
         );
     }
 }


### PR DESCRIPTION
## Problem

`cleanup_expired_sessions()` in `state.rs` was missing two `DashMap`s added in PR #306, causing a slow memory leak:

- `session_dna_override` — never cleaned up
- `session_skills_override` — never cleaned up

Additionally, `pending_files` entries were never evicted when users did not confirm file ingestion, leaking heap memory proportional to file size (up to `SLACK_MAX_FILE_BYTES` = 10 MiB per unanswered file prompt).

Fixes #319.

## Changes

**`crates/opencrust-agents/src/runtime.rs`**
- Add `retain_session_dna_overrides()` — same pattern as existing `retain_session_tool_configs()`
- Add `retain_session_skills_overrides()` — same pattern
- Add `has_session_dna_override()` and `has_session_skills_override()` public helpers for tests/diagnostics

**`crates/opencrust-gateway/src/state.rs`**
- Call `retain_session_dna_overrides()` and `retain_session_skills_overrides()` from `cleanup_expired_sessions()`
- Evict `pending_files` entries older than `PENDING_FILE_TTL` (5 min) in `cleanup_expired_sessions()`
- Add `PENDING_FILE_TTL` constant

## Test plan

- [x] `retain_session_dna_overrides_removes_evicted_sessions` — evicted session DNA is dropped, active session DNA is kept
- [x] `retain_session_skills_overrides_removes_evicted_sessions` — same for skills
- [x] `cleanup_drops_stale_pending_files` — files older than 5 min are evicted; fresh files are kept
- [x] `cleanup_drops_dna_and_skills_overrides_for_evicted_sessions` — end-to-end through `cleanup_expired_sessions()`
- [x] All existing tests pass: 150 (agents) + 50 (gateway) = 200 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)