### PR TITLE
fix(channels): add channel_name() to prevent sender key collision (#320)

### DIFF
--- a/crates/opencrust-channels/src/discord/mod.rs
+++ b/crates/opencrust-channels/src/discord/mod.rs
@@ -73,6 +73,9 @@ pub struct DiscordChannel {
     /// Discord-specific configuration.
     config: DiscordConfig,
 
+    /// Config key name (e.g. `"discord-support"`).
+    name: String,
+
     /// Current connection status.
     status: ChannelStatus,
 
@@ -118,6 +121,7 @@ impl DiscordChannel {
         let (event_tx, _) = broadcast::channel(256);
         Self {
             config,
+            name: "discord".to_string(),
             status: ChannelStatus::Disconnected,
             on_message,
             group_filter,
@@ -126,6 +130,12 @@ impl DiscordChannel {
             client_handle: None,
             shard_manager: None,
         }
+    }
+
+    /// Override the config key name for this channel instance.
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
     }
 
     /// Create a `DiscordChannel` from the generic `ChannelConfig` settings.
@@ -205,12 +215,17 @@ impl DiscordChannel {
 /// Lightweight send-only handle for Discord. Holds a pre-built `Http` client.
 pub struct DiscordSender {
     http: std::sync::Arc<serenity_model::Http>,
+    name: String,
 }
 
 #[async_trait]
 impl ChannelSender for DiscordSender {
     fn channel_type(&self) -> &str {
         "discord"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {
@@ -227,6 +242,7 @@ impl ChannelLifecycle for DiscordChannel {
     fn create_sender(&self) -> Box<dyn ChannelSender> {
         Box::new(DiscordSender {
             http: std::sync::Arc::new(serenity_model::Http::new(&self.config.bot_token)),
+            name: self.name.clone(),
         })
     }
 
@@ -313,6 +329,10 @@ impl ChannelSender for DiscordChannel {
         "discord"
     }
 
+    fn channel_name(&self) -> &str {
+        &self.name
+    }
+
     async fn send_message(&self, message: &Message) -> Result<()> {
         let http = self
             .http
@@ -380,6 +400,41 @@ mod tests {
             });
         let channel = DiscordChannel::new(test_config(), on_msg);
         assert_eq!(channel.channel_type(), "discord");
+    }
+
+    #[test]
+    fn channel_name_defaults_to_channel_type() {
+        let on_msg: DiscordOnMessageFn =
+            Arc::new(|_ch, _uid, _user, _text, _is_group, _file, _delta_tx| {
+                Box::pin(async { Ok(ChannelResponse::Text("test".to_string())) })
+            });
+        let channel = DiscordChannel::new(test_config(), on_msg);
+        assert_eq!(channel.channel_name(), "discord");
+    }
+
+    #[test]
+    fn with_name_overrides_channel_name() {
+        let on_msg: DiscordOnMessageFn =
+            Arc::new(|_ch, _uid, _user, _text, _is_group, _file, _delta_tx| {
+                Box::pin(async { Ok(ChannelResponse::Text("test".to_string())) })
+            });
+        let channel =
+            DiscordChannel::new(test_config(), on_msg).with_name("discord-support".to_string());
+        assert_eq!(channel.channel_name(), "discord-support");
+        assert_eq!(channel.channel_type(), "discord");
+    }
+
+    #[test]
+    fn sender_channel_name_inherits_from_channel() {
+        let on_msg: DiscordOnMessageFn =
+            Arc::new(|_ch, _uid, _user, _text, _is_group, _file, _delta_tx| {
+                Box::pin(async { Ok(ChannelResponse::Text("test".to_string())) })
+            });
+        let channel =
+            DiscordChannel::new(test_config(), on_msg).with_name("discord-eng".to_string());
+        let sender = channel.create_sender();
+        assert_eq!(sender.channel_name(), "discord-eng");
+        assert_eq!(sender.channel_type(), "discord");
     }
 
     #[test]

--- a/crates/opencrust-channels/src/imessage/mod.rs
+++ b/crates/opencrust-channels/src/imessage/mod.rs
@@ -41,6 +41,7 @@ const MAX_BACKOFF: Duration = Duration::from_secs(30);
 
 pub struct IMessageChannel {
     poll_interval: Duration,
+    name: String,
     status: ChannelStatus,
     on_message: IMessageOnMessageFn,
     group_filter: IMessageGroupFilter,
@@ -59,21 +60,34 @@ impl IMessageChannel {
     ) -> Self {
         Self {
             poll_interval: Duration::from_secs(poll_interval_secs),
+            name: "imessage".to_string(),
             status: ChannelStatus::Disconnected,
             on_message,
             group_filter,
             shutdown_tx: None,
         }
     }
+
+    /// Override the config key name for this channel instance.
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
+    }
 }
 
-/// Lightweight send-only handle for iMessage. Stateless (uses osascript).
-pub struct IMessageSender;
+/// Lightweight send-only handle for iMessage. Uses osascript.
+pub struct IMessageSender {
+    name: String,
+}
 
 #[async_trait]
 impl ChannelSender for IMessageSender {
     fn channel_type(&self) -> &str {
         "imessage"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {
@@ -88,7 +102,9 @@ impl ChannelLifecycle for IMessageChannel {
     }
 
     fn create_sender(&self) -> Box<dyn ChannelSender> {
-        Box::new(IMessageSender)
+        Box::new(IMessageSender {
+            name: self.name.clone(),
+        })
     }
 
     async fn connect(&mut self) -> Result<()> {
@@ -258,6 +274,10 @@ impl ChannelLifecycle for IMessageChannel {
 impl ChannelSender for IMessageChannel {
     fn channel_type(&self) -> &str {
         "imessage"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {

--- a/crates/opencrust-channels/src/line/mod.rs
+++ b/crates/opencrust-channels/src/line/mod.rs
@@ -60,6 +60,7 @@ pub struct LineChannel {
     /// Base URL for the LINE data API (file/image/audio downloads).
     /// Defaults to `https://api-data.line.me/v2/bot`.
     data_api_base_url: String,
+    name: String,
     display: String,
     /// LINE user ID of this bot, resolved from `GET /v2/bot/info` on connect.
     /// Used to detect `@mention` in group messages.
@@ -95,12 +96,19 @@ impl LineChannel {
             channel_secret,
             api_base_url: api::LINE_API_BASE.to_string(),
             data_api_base_url: api::LINE_DATA_API_BASE.to_string(),
+            name: "line".to_string(),
             display: String::new(),
             bot_user_id: None,
             status: ChannelStatus::Disconnected,
             on_message,
             group_filter,
         }
+    }
+
+    /// Override the config key name for this channel instance.
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
     }
 
     /// Override the LINE messaging API base URL (e.g. to point at a mock server in tests).
@@ -174,12 +182,17 @@ pub struct LineSender {
     client: Client,
     channel_access_token: String,
     api_base_url: String,
+    name: String,
 }
 
 #[async_trait]
 impl ChannelSender for LineSender {
     fn channel_type(&self) -> &str {
         "line"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {
@@ -204,6 +217,7 @@ impl ChannelLifecycle for LineChannel {
             client: self.client.clone(),
             channel_access_token: self.channel_access_token.clone(),
             api_base_url: self.api_base_url.clone(),
+            name: self.name.clone(),
         })
     }
 
@@ -244,6 +258,10 @@ impl ChannelLifecycle for LineChannel {
 impl ChannelSender for LineChannel {
     fn channel_type(&self) -> &str {
         "line"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {

--- a/crates/opencrust-channels/src/mqtt/mod.rs
+++ b/crates/opencrust-channels/src/mqtt/mod.rs
@@ -79,6 +79,10 @@ impl ChannelSender for MqttSender {
         "mqtt"
     }
 
+    fn channel_name(&self) -> &str {
+        &self.channel_name
+    }
+
     async fn send_message(&self, message: &Message) -> Result<()> {
         let topic = message
             .metadata
@@ -178,6 +182,10 @@ impl ChannelLifecycle for MqttChannel {
 impl ChannelSender for MqttChannel {
     fn channel_type(&self) -> &str {
         "mqtt"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.config.channel_name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {

--- a/crates/opencrust-channels/src/slack/mod.rs
+++ b/crates/opencrust-channels/src/slack/mod.rs
@@ -59,6 +59,7 @@ pub type SlackOnMessageFn = Arc<
 pub struct SlackChannel {
     bot_token: String,
     app_token: String,
+    name: String,
     display: String,
     status: ChannelStatus,
     on_message: SlackOnMessageFn,
@@ -82,6 +83,7 @@ impl SlackChannel {
         Self {
             bot_token,
             app_token,
+            name: "slack".to_string(),
             display: "Slack".to_string(),
             status: ChannelStatus::Disconnected,
             on_message,
@@ -90,17 +92,28 @@ impl SlackChannel {
             shutdown_tx: None,
         }
     }
+
+    /// Override the config key name for this channel instance.
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
+    }
 }
 
 /// Lightweight send-only handle for Slack. Holds a bot token for API calls.
 pub struct SlackSender {
     bot_token: String,
+    name: String,
 }
 
 #[async_trait]
 impl ChannelSender for SlackSender {
     fn channel_type(&self) -> &str {
         "slack"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {
@@ -117,6 +130,7 @@ impl ChannelLifecycle for SlackChannel {
     fn create_sender(&self) -> Box<dyn ChannelSender> {
         Box::new(SlackSender {
             bot_token: self.bot_token.clone(),
+            name: self.name.clone(),
         })
     }
 
@@ -183,6 +197,10 @@ impl ChannelLifecycle for SlackChannel {
 impl ChannelSender for SlackChannel {
     fn channel_type(&self) -> &str {
         "slack"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {

--- a/crates/opencrust-channels/src/telegram.rs
+++ b/crates/opencrust-channels/src/telegram.rs
@@ -84,6 +84,7 @@ impl ErrorHandler<RequestError> for TelegramPollingErrorHandler {
 
 pub struct TelegramChannel {
     bot_token: String,
+    name: String,
     display: String,
     status: ChannelStatus,
     on_message: OnMessageFn,
@@ -105,6 +106,7 @@ impl TelegramChannel {
     ) -> Self {
         Self {
             bot_token,
+            name: "telegram".to_string(),
             display: "Telegram".to_string(),
             status: ChannelStatus::Disconnected,
             on_message,
@@ -113,6 +115,12 @@ impl TelegramChannel {
             bot: None,
             shutdown_tx: None,
         }
+    }
+
+    /// Override the config key name for this channel instance.
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
     }
 }
 
@@ -278,12 +286,17 @@ async fn extract_content(
 /// Lightweight send-only handle for Telegram. Holds a pre-built `Bot` instance.
 pub struct TelegramSender {
     bot: Bot,
+    name: String,
 }
 
 #[async_trait]
 impl ChannelSender for TelegramSender {
     fn channel_type(&self) -> &str {
         "telegram"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {
@@ -300,6 +313,7 @@ impl ChannelLifecycle for TelegramChannel {
     fn create_sender(&self) -> Box<dyn ChannelSender> {
         Box::new(TelegramSender {
             bot: Bot::new(&self.bot_token),
+            name: self.name.clone(),
         })
     }
 
@@ -584,6 +598,10 @@ impl ChannelSender for TelegramChannel {
         "telegram"
     }
 
+    fn channel_name(&self) -> &str {
+        &self.name
+    }
+
     async fn send_message(&self, message: &Message) -> Result<()> {
         let bot = self
             .bot
@@ -670,6 +688,44 @@ mod tests {
         assert_eq!(channel.channel_type(), "telegram");
         assert_eq!(channel.display_name(), "Telegram");
         assert_eq!(channel.status(), ChannelStatus::Disconnected);
+    }
+
+    #[test]
+    fn channel_name_defaults_to_telegram() {
+        let on_msg: OnMessageFn = Arc::new(
+            |_chat_id, _uid, _user, _text, _is_group, _attachment, _delta_tx| {
+                Box::pin(async { Ok(ChannelResponse::Text("test".to_string())) })
+            },
+        );
+        let channel = TelegramChannel::new("fake-token".to_string(), on_msg);
+        assert_eq!(channel.channel_name(), "telegram");
+    }
+
+    #[test]
+    fn with_name_overrides_channel_name() {
+        let on_msg: OnMessageFn = Arc::new(
+            |_chat_id, _uid, _user, _text, _is_group, _attachment, _delta_tx| {
+                Box::pin(async { Ok(ChannelResponse::Text("test".to_string())) })
+            },
+        );
+        let channel = TelegramChannel::new("fake-token".to_string(), on_msg)
+            .with_name("tg-support".to_string());
+        assert_eq!(channel.channel_name(), "tg-support");
+        assert_eq!(channel.channel_type(), "telegram");
+    }
+
+    #[test]
+    fn sender_channel_name_inherits_from_channel() {
+        let on_msg: OnMessageFn = Arc::new(
+            |_chat_id, _uid, _user, _text, _is_group, _attachment, _delta_tx| {
+                Box::pin(async { Ok(ChannelResponse::Text("test".to_string())) })
+            },
+        );
+        let channel =
+            TelegramChannel::new("fake-token".to_string(), on_msg).with_name("tg-ops".to_string());
+        let sender = channel.create_sender();
+        assert_eq!(sender.channel_name(), "tg-ops");
+        assert_eq!(sender.channel_type(), "telegram");
     }
 
     #[test]

--- a/crates/opencrust-channels/src/traits.rs
+++ b/crates/opencrust-channels/src/traits.rs
@@ -56,8 +56,19 @@ pub trait ChannelLifecycle: Send {
 /// Designed to be wrapped in `Arc` and shared across tasks (e.g. the scheduler).
 #[async_trait]
 pub trait ChannelSender: Send + Sync {
-    /// Unique identifier for this channel type.
+    /// Unique identifier for this channel type (e.g. `"discord"`, `"telegram"`).
     fn channel_type(&self) -> &str;
+
+    /// Config key name for this sender instance (e.g. `"discord-support"`).
+    ///
+    /// Used as the key when registering senders in the gateway's `channel_senders`
+    /// map, so multiple instances of the same channel type can coexist without
+    /// key collision.
+    ///
+    /// Defaults to [`channel_type()`][Self::channel_type] for backward compatibility.
+    fn channel_name(&self) -> &str {
+        self.channel_type()
+    }
 
     /// Send a message through this channel.
     async fn send_message(&self, message: &Message) -> Result<()>;
@@ -111,5 +122,25 @@ mod tests {
             audio: vec![],
         };
         assert_eq!(r.text(), "words");
+    }
+
+    /// Verify the default `channel_name()` falls back to `channel_type()`.
+    #[tokio::test]
+    async fn channel_name_default_returns_channel_type() {
+        struct MinimalSender;
+        #[async_trait::async_trait]
+        impl ChannelSender for MinimalSender {
+            fn channel_type(&self) -> &str {
+                "test-type"
+            }
+            async fn send_message(
+                &self,
+                _msg: &opencrust_common::Message,
+            ) -> opencrust_common::Result<()> {
+                Ok(())
+            }
+        }
+        let s = MinimalSender;
+        assert_eq!(s.channel_name(), "test-type");
     }
 }

--- a/crates/opencrust-channels/src/wechat/mod.rs
+++ b/crates/opencrust-channels/src/wechat/mod.rs
@@ -69,6 +69,7 @@ pub struct WeChatChannel {
     /// Verification token configured in the WeChat Official Account console.
     pub(crate) token: String,
     api_base_url: String,
+    name: String,
     display: String,
     status: ChannelStatus,
     on_message: WeChatOnMessageFn,
@@ -101,6 +102,7 @@ impl WeChatChannel {
             secret,
             token,
             api_base_url: api::WECHAT_API_BASE.to_string(),
+            name: "wechat".to_string(),
             display: "WeChat".to_string(),
             status: ChannelStatus::Disconnected,
             on_message,
@@ -108,6 +110,12 @@ impl WeChatChannel {
             token_cache: Arc::new(RwLock::new(None)),
             msg_id_cache: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Override the config key name for this channel instance.
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
     }
 
     /// Override the WeChat API base URL (e.g. to point at a mock server in tests).
@@ -198,12 +206,17 @@ pub struct WeChatSender {
     secret: String,
     api_base_url: String,
     token_cache: TokenCache,
+    name: String,
 }
 
 #[async_trait]
 impl ChannelSender for WeChatSender {
     fn channel_type(&self) -> &str {
         "wechat"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {
@@ -232,6 +245,7 @@ impl ChannelLifecycle for WeChatChannel {
             secret: self.secret.clone(),
             api_base_url: self.api_base_url.clone(),
             token_cache: Arc::clone(&self.token_cache),
+            name: self.name.clone(),
         })
     }
 
@@ -258,6 +272,10 @@ impl ChannelLifecycle for WeChatChannel {
 impl ChannelSender for WeChatChannel {
     fn channel_type(&self) -> &str {
         "wechat"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {

--- a/crates/opencrust-channels/src/whatsapp/mod.rs
+++ b/crates/opencrust-channels/src/whatsapp/mod.rs
@@ -55,6 +55,7 @@ pub struct WhatsAppChannel {
     access_token: String,
     phone_number_id: String,
     verify_token: String,
+    name: String,
     display: String,
     status: ChannelStatus,
     on_message: WhatsAppOnMessageFn,
@@ -72,10 +73,17 @@ impl WhatsAppChannel {
             access_token,
             phone_number_id,
             verify_token,
+            name: "whatsapp".to_string(),
             display: "WhatsApp".to_string(),
             status: ChannelStatus::Disconnected,
             on_message,
         }
+    }
+
+    /// Override the config key name for this channel instance.
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
     }
 
     /// Access token for the WhatsApp Cloud API.
@@ -123,12 +131,17 @@ pub struct WhatsAppSender {
     client: Client,
     access_token: String,
     phone_number_id: String,
+    name: String,
 }
 
 #[async_trait]
 impl ChannelSender for WhatsAppSender {
     fn channel_type(&self) -> &str {
         "whatsapp"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {
@@ -153,6 +166,7 @@ impl ChannelLifecycle for WhatsAppChannel {
             client: Client::new(),
             access_token: self.access_token.clone(),
             phone_number_id: self.phone_number_id.clone(),
+            name: self.name.clone(),
         })
     }
 
@@ -178,6 +192,10 @@ impl ChannelLifecycle for WhatsAppChannel {
 impl ChannelSender for WhatsAppChannel {
     fn channel_type(&self) -> &str {
         "whatsapp"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {

--- a/crates/opencrust-channels/src/whatsapp/web.rs
+++ b/crates/opencrust-channels/src/whatsapp/web.rs
@@ -24,12 +24,17 @@ type SharedStdinTx = Arc<tokio::sync::Mutex<Option<mpsc::Sender<String>>>>;
 /// Lightweight send-only handle for WhatsApp Web.
 pub struct WhatsAppWebSender {
     shared_stdin_tx: SharedStdinTx,
+    name: String,
 }
 
 #[async_trait]
 impl ChannelSender for WhatsAppWebSender {
     fn channel_type(&self) -> &str {
         "whatsapp-web"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {
@@ -47,6 +52,7 @@ pub struct WhatsAppWebChannel {
     stdin_tx: Option<mpsc::Sender<String>>,
     /// Shared sender handle exposed via `create_sender()`.
     shared_stdin_tx: SharedStdinTx,
+    name: String,
     status: ChannelStatus,
     display: String,
     on_message: WhatsAppOnMessageFn,
@@ -71,6 +77,7 @@ impl WhatsAppWebChannel {
             child: None,
             stdin_tx: None,
             shared_stdin_tx: Arc::new(tokio::sync::Mutex::new(None)),
+            name: "whatsapp-web".to_string(),
             status: ChannelStatus::Disconnected,
             display: "WhatsApp Web".to_string(),
             on_message,
@@ -78,6 +85,12 @@ impl WhatsAppWebChannel {
             auth_dir: config_dir.join("whatsapp-web-auth"),
             sidecar_dir: config_dir.join("sidecar").join("whatsapp-web"),
         }
+    }
+
+    /// Override the config key name for this channel instance.
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
+        self
     }
 
     // Embedded sidecar files - written to disk on first connect if not found elsewhere.
@@ -178,6 +191,7 @@ impl ChannelLifecycle for WhatsAppWebChannel {
     fn create_sender(&self) -> Box<dyn ChannelSender> {
         Box::new(WhatsAppWebSender {
             shared_stdin_tx: Arc::clone(&self.shared_stdin_tx),
+            name: self.name.clone(),
         })
     }
 
@@ -389,6 +403,10 @@ impl ChannelLifecycle for WhatsAppWebChannel {
 impl ChannelSender for WhatsAppWebChannel {
     fn channel_type(&self) -> &str {
         "whatsapp-web"
+    }
+
+    fn channel_name(&self) -> &str {
+        &self.name
     }
 
     async fn send_message(&self, message: &Message) -> Result<()> {

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -1166,7 +1166,8 @@ pub fn build_discord_channels(
                     discord_config,
                     on_message,
                     group_filter,
-                );
+                )
+                .with_name(name.clone());
                 channels.push(Box::new(channel) as Box<dyn opencrust_channels::Channel>);
                 info!("configured discord channel: {name}");
             }
@@ -1865,7 +1866,8 @@ pub fn build_telegram_channels(
             },
         );
 
-        let channel = TelegramChannel::with_group_filter(bot_token, on_message, group_filter);
+        let channel = TelegramChannel::with_group_filter(bot_token, on_message, group_filter)
+            .with_name(name.clone());
         channels.push(Box::new(channel) as Box<dyn opencrust_channels::Channel>);
         info!("configured telegram channel: {name}");
     }
@@ -2447,7 +2449,8 @@ pub fn build_slack_channels(
             on_message,
             group_filter,
             bot_user_id,
-        );
+        )
+        .with_name(name.clone());
         channels.push(Box::new(channel) as Box<dyn opencrust_channels::Channel>);
         info!("configured slack channel: {name}");
     }
@@ -2801,13 +2804,9 @@ pub fn build_whatsapp_channels(
             },
         );
 
-        let channel = Arc::new(WhatsAppChannel::new(
-            access_token,
-            phone_number_id,
-            verify_token,
-            on_message,
-        ));
-        channels.push(channel);
+        let channel = WhatsAppChannel::new(access_token, phone_number_id, verify_token, on_message)
+            .with_name(name.clone());
+        channels.push(Arc::new(channel));
         info!("configured whatsapp channel: {name}");
     }
 
@@ -3019,7 +3018,8 @@ pub fn build_whatsapp_web_channels(
             },
         );
 
-        let channel = WhatsAppWebChannel::with_group_filter(on_message, group_filter);
+        let channel =
+            WhatsAppWebChannel::with_group_filter(on_message, group_filter).with_name(name.clone());
         channels.push(channel);
         info!("configured whatsapp-web channel: {name}");
     }
@@ -3189,7 +3189,8 @@ pub fn build_imessage_channels(
         );
 
         let channel =
-            IMessageChannel::with_group_filter(poll_interval_secs, on_message, group_filter);
+            IMessageChannel::with_group_filter(poll_interval_secs, on_message, group_filter)
+                .with_name(name.clone());
         channels.push(Box::new(channel) as Box<dyn opencrust_channels::Channel>);
         info!("configured imessage channel: {name}");
     }
@@ -3490,7 +3491,8 @@ pub fn build_line_channels(
             channel_secret,
             on_message,
             group_filter,
-        );
+        )
+        .with_name(name.clone());
         channels.push(channel);
         info!("configured line channel: {name}");
     }
@@ -3786,14 +3788,10 @@ pub fn build_wechat_channels(
             },
         );
 
-        let channel = Arc::new(WeChatChannel::with_group_filter(
-            appid,
-            secret,
-            token,
-            on_message,
-            group_filter,
-        ));
-        channels.push(channel);
+        let channel =
+            WeChatChannel::with_group_filter(appid, secret, token, on_message, group_filter)
+                .with_name(name.clone());
+        channels.push(Arc::new(channel));
         info!("configured wechat channel: {name}");
     }
 

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -179,7 +179,7 @@ impl GatewayServer {
             let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
             state
                 .channel_senders
-                .insert(sender.channel_type().to_string(), sender);
+                .insert(sender.channel_name().to_string(), sender);
             tokio::spawn(async move {
                 if let Err(e) = channel.connect().await {
                     warn!("discord channel failed to connect: {e}");
@@ -225,7 +225,7 @@ impl GatewayServer {
             let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
             state
                 .channel_senders
-                .insert(sender.channel_type().to_string(), sender);
+                .insert(sender.channel_name().to_string(), sender);
             tokio::spawn(async move {
                 if let Err(e) = channel.connect().await {
                     warn!("telegram channel failed to connect: {e}");
@@ -242,7 +242,7 @@ impl GatewayServer {
             let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
             state
                 .channel_senders
-                .insert(sender.channel_type().to_string(), sender);
+                .insert(sender.channel_name().to_string(), sender);
             tokio::spawn(async move {
                 if let Err(e) = channel.connect().await {
                     warn!("slack channel failed to connect: {e}");
@@ -261,7 +261,7 @@ impl GatewayServer {
                 let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
                 state
                     .channel_senders
-                    .insert(sender.channel_type().to_string(), sender);
+                    .insert(sender.channel_name().to_string(), sender);
                 tokio::spawn(async move {
                     if let Err(e) = channel.connect().await {
                         warn!("imessage channel failed to connect: {e}");
@@ -279,7 +279,7 @@ impl GatewayServer {
             let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
             state
                 .channel_senders
-                .insert(sender.channel_type().to_string(), sender);
+                .insert(sender.channel_name().to_string(), sender);
             info!(
                 "whatsapp channel ready (webhook mode, phone_number_id={})",
                 channel.phone_number_id()
@@ -294,7 +294,7 @@ impl GatewayServer {
             let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
             state
                 .channel_senders
-                .insert(sender.channel_type().to_string(), sender);
+                .insert(sender.channel_name().to_string(), sender);
             tokio::spawn(async move {
                 if let Err(e) = channel.connect().await {
                     warn!("whatsapp-web channel failed to connect: {e}");
@@ -318,7 +318,7 @@ impl GatewayServer {
             let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
             state
                 .channel_senders
-                .insert(sender.channel_type().to_string(), sender);
+                .insert(sender.channel_name().to_string(), sender);
             info!("line channel ready (webhook mode)");
         }
         let line_state: opencrust_channels::line::webhook::LineWebhookState =
@@ -329,7 +329,7 @@ impl GatewayServer {
             let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
             state
                 .channel_senders
-                .insert(sender.channel_type().to_string(), sender);
+                .insert(sender.channel_name().to_string(), sender);
             info!("wechat channel ready (webhook mode)");
         }
         let wechat_state: opencrust_channels::wechat::webhook::WeChatWebhookState =
@@ -339,10 +339,9 @@ impl GatewayServer {
         let mut mqtt_channels = build_mqtt_channels(&state.config, &state);
         for mut channel in mqtt_channels.drain(..) {
             let sender: Arc<dyn ChannelSender> = Arc::from(channel.create_sender());
-            // Key by channel name to support multiple mqtt instances
             state
                 .channel_senders
-                .insert(format!("mqtt-{}", sender.channel_type()), sender);
+                .insert(sender.channel_name().to_string(), sender);
             tokio::spawn(async move {
                 if let Err(e) = channel.connect().await {
                     warn!("mqtt channel failed to connect: {e}");


### PR DESCRIPTION
## Summary

Fixes #320 — when multiple instances of the same channel type are configured (e.g. two Telegram bots, two Discord servers), all instances were registered in `channel_senders` under the same key (`channel_type()`), so the second instance silently overwrote the first.

Changes:

- **`ChannelSender` trait** — adds `channel_name() -> &str` with a default implementation that returns `channel_type()` (fully backward-compatible)
- **Every channel** (Discord, Telegram, Slack, LINE, WeChat, WhatsApp, WhatsApp Web, iMessage, MQTT) — adds a `name: String` field (default = channel type) and a `with_name(name) -> Self` builder; overrides `channel_name()` on both the Channel and its Sender
- **`bootstrap.rs`** — each `build_*` function calls `.with_name(name.clone())` so the config key name is carried through
- **`server.rs`** — all `channel_senders.insert()` calls changed from `sender.channel_type()` to `sender.channel_name()` as the map key; removes the special-case `format!("mqtt-{}", ...)` since MQTT's `channel_name()` now returns the config key directly

**Before:** two telegram channels keyed as `"telegram"` — second overwrote first.  
**After:** they key as `"tg-sales"` and `"tg-support"` (the config key names).

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test --all-features -p opencrust-channels` — 182 tests pass (0 failures)
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — passes
- [x] New unit tests added: `channel_name_defaults_to_channel_type`, `with_name_overrides_channel_name`, `sender_channel_name_inherits_from_channel` (Discord + Telegram), `channel_name_default_returns_channel_type` (traits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)