### PR TITLE
fix(channels): enforce 10 MiB download limit on all channel file downloads

### DIFF
--- a/crates/opencrust-channels/src/discord/handler.rs
+++ b/crates/opencrust-channels/src/discord/handler.rs
@@ -303,15 +303,25 @@ impl EventHandler for DiscordHandler {
                 size = attachment.size,
                 "discord: downloading attachment"
             );
-            match attachment.download().await {
-                Ok(data) => Some(DiscordFile {
-                    filename: attachment.filename.clone(),
-                    data,
-                    content_type: attachment.content_type.clone(),
-                }),
-                Err(e) => {
-                    warn!("discord: failed to download attachment: {e}");
-                    None
+            if attachment.size as usize > crate::MAX_DOWNLOAD_BYTES {
+                warn!(
+                    filename = %attachment.filename,
+                    size = attachment.size,
+                    limit = crate::MAX_DOWNLOAD_BYTES,
+                    "discord: attachment too large, skipping download"
+                );
+                None
+            } else {
+                match attachment.download().await {
+                    Ok(data) => Some(DiscordFile {
+                        filename: attachment.filename.clone(),
+                        data,
+                        content_type: attachment.content_type.clone(),
+                    }),
+                    Err(e) => {
+                        warn!("discord: failed to download attachment: {e}");
+                        None
+                    }
                 }
             }
         } else {

--- a/crates/opencrust-channels/src/lib.rs
+++ b/crates/opencrust-channels/src/lib.rs
@@ -1,5 +1,12 @@
 pub mod protocol;
 pub mod registry;
+
+/// Maximum file size accepted when downloading attachments from any channel (10 MiB).
+///
+/// Applied as both a `Content-Length` pre-check (where the header is available)
+/// and a post-download `bytes.len()` check as a safety net.  This matches the
+/// limit already in use by the Slack channel (`SLACK_MAX_FILE_BYTES`).
+pub const MAX_DOWNLOAD_BYTES: usize = 10 * 1024 * 1024;
 #[cfg(feature = "telegram")]
 pub mod telegram;
 #[cfg(feature = "telegram")]

--- a/crates/opencrust-channels/src/line/api.rs
+++ b/crates/opencrust-channels/src/line/api.rs
@@ -27,10 +27,29 @@ pub async fn download_content(
         return Err(format!("line download_content error {status}: {body}"));
     }
 
-    resp.bytes()
+    if let Some(len) = resp.content_length()
+        && len > crate::MAX_DOWNLOAD_BYTES as u64
+    {
+        return Err(format!(
+            "line file too large: {len} bytes exceeds {} byte limit",
+            crate::MAX_DOWNLOAD_BYTES
+        ));
+    }
+
+    let bytes = resp
+        .bytes()
         .await
-        .map(|b| b.to_vec())
-        .map_err(|e| format!("line download_content read failed: {e}"))
+        .map_err(|e| format!("line download_content read failed: {e}"))?;
+
+    if bytes.len() > crate::MAX_DOWNLOAD_BYTES {
+        return Err(format!(
+            "line file too large: {} bytes exceeds {} byte limit",
+            bytes.len(),
+            crate::MAX_DOWNLOAD_BYTES
+        ));
+    }
+
+    Ok(bytes.to_vec())
 }
 
 /// Send a reply using a reply token (free, expires in 30 seconds, one use).
@@ -142,5 +161,13 @@ pub async fn push(
         let status = resp.status();
         let body_text = resp.text().await.unwrap_or_default();
         Err(format!("line push failed ({status}): {body_text}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn download_size_limit_constant_is_10_mib() {
+        assert_eq!(crate::MAX_DOWNLOAD_BYTES, 10 * 1024 * 1024);
     }
 }

--- a/crates/opencrust-channels/src/telegram.rs
+++ b/crates/opencrust-channels/src/telegram.rs
@@ -144,10 +144,27 @@ async fn download_telegram_file(
         .await
         .map_err(|e| format!("telegram file download failed: {e}"))?;
 
+    if let Some(len) = response.content_length()
+        && len > crate::MAX_DOWNLOAD_BYTES as u64
+    {
+        return Err(format!(
+            "telegram file too large: {len} bytes exceeds {} byte limit",
+            crate::MAX_DOWNLOAD_BYTES
+        ));
+    }
+
     let bytes = response
         .bytes()
         .await
         .map_err(|e| format!("telegram file read failed: {e}"))?;
+
+    if bytes.len() > crate::MAX_DOWNLOAD_BYTES {
+        return Err(format!(
+            "telegram file too large: {} bytes exceeds {} byte limit",
+            bytes.len(),
+            crate::MAX_DOWNLOAD_BYTES
+        ));
+    }
 
     Ok(bytes.to_vec())
 }
@@ -931,5 +948,12 @@ mod tests {
         let filter: GroupFilter = Arc::new(|_mentioned| true);
         assert!(filter(false));
         assert!(filter(true));
+    }
+
+    // --- download size-limit tests ---
+
+    #[test]
+    fn download_size_limit_constant_is_10_mib() {
+        assert_eq!(crate::MAX_DOWNLOAD_BYTES, 10 * 1024 * 1024);
     }
 }

--- a/crates/opencrust-channels/src/wechat/api.rs
+++ b/crates/opencrust-channels/src/wechat/api.rs
@@ -249,10 +249,29 @@ pub async fn download_pic(client: &Client, url: &str) -> Result<Vec<u8>, String>
         return Err(format!("wechat download_pic error {status}: {body}"));
     }
 
-    resp.bytes()
+    if let Some(len) = resp.content_length()
+        && len > crate::MAX_DOWNLOAD_BYTES as u64
+    {
+        return Err(format!(
+            "wechat file too large: {len} bytes exceeds {} byte limit",
+            crate::MAX_DOWNLOAD_BYTES
+        ));
+    }
+
+    let bytes = resp
+        .bytes()
         .await
-        .map(|b| b.to_vec())
-        .map_err(|e| format!("wechat download_pic read failed: {e}"))
+        .map_err(|e| format!("wechat download_pic read failed: {e}"))?;
+
+    if bytes.len() > crate::MAX_DOWNLOAD_BYTES {
+        return Err(format!(
+            "wechat file too large: {} bytes exceeds {} byte limit",
+            bytes.len(),
+            crate::MAX_DOWNLOAD_BYTES
+        ));
+    }
+
+    Ok(bytes.to_vec())
 }
 
 /// Push a voice message to a user via the Customer Service API.
@@ -271,4 +290,12 @@ pub async fn push_voice_msg(
         "voice": { "media_id": media_id }
     });
     send_custom(client, access_token, base_url, body).await
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn download_size_limit_constant_is_10_mib() {
+        assert_eq!(crate::MAX_DOWNLOAD_BYTES, 10 * 1024 * 1024);
+    }
 }

--- a/crates/opencrust-channels/src/whatsapp/api.rs
+++ b/crates/opencrust-channels/src/whatsapp/api.rs
@@ -112,11 +112,29 @@ pub async fn download_media(
         return Err(format!("WhatsApp media download error {status}: {body}"));
     }
 
-    file_resp
+    if let Some(len) = file_resp.content_length()
+        && len > crate::MAX_DOWNLOAD_BYTES as u64
+    {
+        return Err(format!(
+            "WhatsApp file too large: {len} bytes exceeds {} byte limit",
+            crate::MAX_DOWNLOAD_BYTES
+        ));
+    }
+
+    let bytes = file_resp
         .bytes()
         .await
-        .map(|b| b.to_vec())
-        .map_err(|e| format!("WhatsApp download_media read failed: {e}"))
+        .map_err(|e| format!("WhatsApp download_media read failed: {e}"))?;
+
+    if bytes.len() > crate::MAX_DOWNLOAD_BYTES {
+        return Err(format!(
+            "WhatsApp file too large: {} bytes exceeds {} byte limit",
+            bytes.len(),
+            crate::MAX_DOWNLOAD_BYTES
+        ));
+    }
+
+    Ok(bytes.to_vec())
 }
 
 /// Mark a message as read.
@@ -146,4 +164,12 @@ pub async fn mark_as_read(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn download_size_limit_constant_is_10_mib() {
+        assert_eq!(crate::MAX_DOWNLOAD_BYTES, 10 * 1024 * 1024);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a shared `MAX_DOWNLOAD_BYTES` constant (10 MiB) to `opencrust-channels/src/lib.rs`, reusing the same value already present in the Slack channel
- Applies a two-layer size guard to every channel that downloads user-sent files:
  - **Telegram** (`download_telegram_file`): Content-Length pre-check + post-download `bytes.len()` check
  - **LINE** (`download_content`): same pattern
  - **WeChat** (`download_pic`): same pattern
  - **WhatsApp** (`download_media`): same pattern on Step 2 (the actual file fetch)
  - **Discord** (`handler.rs`): pre-check `attachment.size` (provided by serenity in the event payload) before calling `attachment.download()`, skipping oversized attachments with a `warn!` log entry

Closes #317.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — all 186+ channel tests pass, including new `download_size_limit_constant_is_10_mib` tests in LINE, WeChat, WhatsApp, and Telegram
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)