### PR TITLE
fix(docs): correct guardrails rate_limit field names in all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,8 +407,8 @@ guardrails:
 
 gateway:
   rate_limit:
-    max_messages_per_minute: 10     # per-user message rate limit
-    cooldown_seconds: 30            # cooldown period after limit is exceeded
+    per_user_per_minute: 10         # per-user message rate limit
+    cooldown_secs: 30               # cooldown period after limit is exceeded
 
 memory:
   enabled: true

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -381,8 +381,8 @@ guardrails:
 
 gateway:
   rate_limit:
-    max_messages_per_minute: 10     # प्रति user message rate limit
-    cooldown_seconds: 30            # limit exceed होने पर cooldown
+    per_user_per_minute: 10         # प्रति user message rate limit
+    cooldown_secs: 30               # limit exceed होने पर cooldown
 
 memory:
   enabled: true

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -405,8 +405,8 @@ guardrails:
 
 gateway:
   rate_limit:
-    max_messages_per_minute: 10     # จำกัด message ต่อผู้ใช้ต่อนาที
-    cooldown_seconds: 30            # cooldown หลังเกินขีดจำกัด
+    per_user_per_minute: 10         # จำกัด message ต่อผู้ใช้ต่อนาที
+    cooldown_secs: 30               # cooldown หลังเกินขีดจำกัด
 
 memory:
   enabled: true

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -400,8 +400,8 @@ guardrails:
 
 gateway:
   rate_limit:
-    max_messages_per_minute: 10     # 每用户每分钟消息数限制
-    cooldown_seconds: 30            # 超限后的冷却时间
+    per_user_per_minute: 10         # 每用户每分钟消息数限制
+    cooldown_secs: 30               # 超限后的冷却时间
 
 memory:
   enabled: true


### PR DESCRIPTION
## Summary

- Fixes incorrect `rate_limit` field names in the guardrails config examples across all 4 READMEs
- `max_messages_per_minute` → `per_user_per_minute`
- `cooldown_seconds` → `cooldown_secs`

serde silently ignores unknown fields and falls back to defaults, so users who copied these examples had rate limiting silently disabled with no error.

Closes #321.

## Test plan

- [x] Verified no instances of `max_messages_per_minute` or `cooldown_seconds` remain in any README

🤖 Generated with [Claude Code](https://claude.com/claude-code)