### PR TITLE
fix(gateway): replace gateway key injection with short-lived webchat tokens

### DIFF
--- a/crates/opencrust-gateway/src/router.rs
+++ b/crates/opencrust-gateway/src/router.rs
@@ -145,12 +145,14 @@ async fn web_chat(axum::extract::State(state): axum::extract::State<SharedState>
             include_str!("webchat.html").to_string()
         };
 
-    // Inject the gateway key (if configured) so the webchat frontend can
-    // authenticate without requiring the user to enter it manually.
-    let inject = if let Some(key) = state.config.gateway.api_key.as_deref() {
+    // Issue a short-lived webchat token and inject it instead of the real
+    // gateway API key.  The token is validated server-side on WebSocket
+    // upgrade so the real key is never exposed in the page source.
+    let inject = if state.config.gateway.api_key.is_some() {
+        let token = state.issue_webchat_token();
         format!(
             "<script>window.__OPENCRUST_GATEWAY_KEY__={:?};</script>",
-            key
+            token
         )
     } else {
         String::new()

--- a/crates/opencrust-gateway/src/state.rs
+++ b/crates/opencrust-gateway/src/state.rs
@@ -25,6 +25,8 @@ const CLEANUP_INTERVAL: Duration = Duration::from_secs(300); // 5 minutes
 const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
 /// How long an unconfirmed pending file is kept before being dropped.
 const PENDING_FILE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+/// How long a webchat session token remains valid after issuance.
+const WEBCHAT_TOKEN_TTL: Duration = Duration::from_secs(86400); // 24 hours
 
 /// Per-user rate limit tracking entry.
 struct UserRateLimitEntry {
@@ -68,6 +70,10 @@ pub struct AppState {
     session_token_counts: DashMap<String, u32>,
     /// Pending files awaiting ingestion confirmation, keyed by session_id.
     pending_files: DashMap<String, PendingFile>,
+    /// Short-lived tokens issued to webchat page-loads, keyed by token value.
+    /// These are injected into the HTML instead of the real gateway API key so
+    /// the real key is never exposed in the page source.
+    webchat_tokens: DashMap<String, Instant>,
 }
 
 /// A file received in chat waiting for the user to confirm ingestion.
@@ -120,6 +126,7 @@ impl AppState {
             user_rate_limits: DashMap::new(),
             session_token_counts: DashMap::new(),
             pending_files: DashMap::new(),
+            webchat_tokens: DashMap::new(),
         }
     }
 
@@ -198,6 +205,27 @@ impl AppState {
         if let Ok(mut slot) = self.google_workspace_email.write() {
             *slot = email;
         }
+    }
+
+    /// Issue a short-lived webchat token tied to a single page-load.
+    ///
+    /// The token is stored server-side and expires after [`WEBCHAT_TOKEN_TTL`].
+    /// It is injected into the webchat HTML **instead of** the real gateway API
+    /// key so the real key is never visible in the page source.
+    pub fn issue_webchat_token(&self) -> String {
+        let token = Uuid::new_v4().simple().to_string();
+        self.webchat_tokens.insert(token.clone(), Instant::now());
+        token
+    }
+
+    /// Validate a webchat token, returning `true` if it exists and has not expired.
+    ///
+    /// Expired tokens are pruned from the map on each call.
+    pub fn validate_webchat_token(&self, token: &str) -> bool {
+        // Prune all expired tokens while we have the map open.
+        self.webchat_tokens
+            .retain(|_, issued_at| issued_at.elapsed() < WEBCHAT_TOKEN_TTL);
+        self.webchat_tokens.contains_key(token)
     }
 
     /// Create and track a one-time OAuth state token.
@@ -691,6 +719,10 @@ impl AppState {
         self.pending_files
             .retain(|_, f| f.received_at.elapsed() < PENDING_FILE_TTL);
 
+        // Evict expired webchat tokens.
+        self.webchat_tokens
+            .retain(|_, issued_at| issued_at.elapsed() < WEBCHAT_TOKEN_TTL);
+
         // Evict rate-limit entries whose sliding window has fully expired and
         // whose cooldown (if any) has also elapsed. Without this, the DashMap
         // grows unboundedly on public bots with many unique users.
@@ -1085,6 +1117,77 @@ mod tests {
         assert!(
             !state.pending_files.contains_key("stale"),
             "stale pending file should be evicted"
+        );
+    }
+
+    // ── webchat token tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn issue_webchat_token_returns_unique_tokens() {
+        let state = test_state();
+        let t1 = state.issue_webchat_token();
+        let t2 = state.issue_webchat_token();
+        assert_ne!(t1, t2);
+        assert_eq!(state.webchat_tokens.len(), 2);
+    }
+
+    #[test]
+    fn validate_webchat_token_accepts_freshly_issued_token() {
+        let state = test_state();
+        let token = state.issue_webchat_token();
+        assert!(state.validate_webchat_token(&token));
+    }
+
+    #[test]
+    fn validate_webchat_token_rejects_unknown_token() {
+        let state = test_state();
+        assert!(!state.validate_webchat_token("not-a-real-token"));
+    }
+
+    #[test]
+    fn validate_webchat_token_prunes_expired_tokens() {
+        let state = test_state();
+        let token = state.issue_webchat_token();
+
+        // Backdate the issued_at so the token is considered expired.
+        if let Some(mut entry) = state.webchat_tokens.get_mut(&token) {
+            *entry = Instant::now() - WEBCHAT_TOKEN_TTL - Duration::from_secs(1);
+        }
+
+        // validate_webchat_token should prune the expired entry and return false.
+        assert!(!state.validate_webchat_token(&token));
+        assert!(
+            state.webchat_tokens.is_empty(),
+            "expired token should have been pruned"
+        );
+    }
+
+    #[test]
+    fn cleanup_evicts_expired_webchat_tokens() {
+        let state = test_state();
+        let token = state.issue_webchat_token();
+
+        // Backdate so token appears expired.
+        if let Some(mut entry) = state.webchat_tokens.get_mut(&token) {
+            *entry = Instant::now() - WEBCHAT_TOKEN_TTL - Duration::from_secs(1);
+        }
+
+        state.cleanup_expired_sessions();
+        assert!(
+            state.webchat_tokens.is_empty(),
+            "cleanup should evict expired webchat tokens"
+        );
+    }
+
+    #[test]
+    fn cleanup_retains_valid_webchat_tokens() {
+        let state = test_state();
+        let _token = state.issue_webchat_token();
+        state.cleanup_expired_sessions();
+        assert_eq!(
+            state.webchat_tokens.len(),
+            1,
+            "fresh webchat token should not be evicted by cleanup"
         );
     }
 

--- a/crates/opencrust-gateway/src/state.rs
+++ b/crates/opencrust-gateway/src/state.rs
@@ -209,7 +209,7 @@ impl AppState {
 
     /// Issue a short-lived webchat token tied to a single page-load.
     ///
-    /// The token is stored server-side and expires after [`WEBCHAT_TOKEN_TTL`].
+    /// The token is stored server-side and expires after 24 hours.
     /// It is injected into the webchat HTML **instead of** the real gateway API
     /// key so the real key is never visible in the page source.
     pub fn issue_webchat_token(&self) -> String {

--- a/crates/opencrust-gateway/src/ws.rs
+++ b/crates/opencrust-gateway/src/ws.rs
@@ -46,15 +46,18 @@ pub async fn ws_handler(
 
         let token = token_from_query.map(|s| s.as_str()).or(token_from_header);
 
-        // Constant-time comparison
         let valid = match token {
-            Some(t) if t.len() == configured_key.len() => {
-                t.bytes()
-                    .zip(configured_key.bytes())
-                    .fold(0, |acc, (a, b)| acc | (a ^ b))
-                    == 0
+            Some(t) => {
+                // Accept the real gateway key (constant-time) or a valid
+                // short-lived webchat token issued on page-load.
+                let key_match = t.len() == configured_key.len()
+                    && t.bytes()
+                        .zip(configured_key.bytes())
+                        .fold(0, |acc, (a, b)| acc | (a ^ b))
+                        == 0;
+                key_match || state.validate_webchat_token(t)
             }
-            _ => false,
+            None => false,
         };
 
         if !valid {


### PR DESCRIPTION
## Summary

- `web_chat()` was injecting the real gateway API key into every HTML response via `window.__OPENCRUST_GATEWAY_KEY__`, exposing it to anyone who could reach the gateway port and view-source
- Fix uses **option 1** from the issue: issue a short-lived per-page-load token instead of the real key
- The frontend variable name (`window.__OPENCRUST_GATEWAY_KEY__`) is unchanged — no frontend changes needed
- Existing API clients that send the real key are unaffected

### Changes

**`state.rs`**
- `webchat_tokens: DashMap<String, Instant>` field + `WEBCHAT_TOKEN_TTL = 24 h` constant
- `issue_webchat_token()` — generates a UUID-based token, stores it server-side, returns it
- `validate_webchat_token()` — checks existence + TTL, prunes expired entries on each call
- `cleanup_expired_sessions()` — also evicts expired webchat tokens

**`router.rs`**
- `web_chat()` calls `issue_webchat_token()` and injects the ephemeral token instead of the real key

**`ws.rs`**
- `ws_handler()` accepts either the real gateway key (constant-time compare) **or** a valid webchat token

Closes #316.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo test` — all tests pass (6 new webchat token tests in `state.rs`)
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)