### PR TITLE
feat(gateway): add /pair, /users, /help, /clear commands to LINE DM

### DIFF
--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3006,6 +3006,35 @@ pub fn build_line_channels(
                 let data_dir = data_dir_line.clone();
                 Box::pin(async move {
                     if !is_group {
+                        // Owner-only commands handled before auth so the owner can
+                        // use /pair before their user ID is in the allowlist.
+                        let cmd = text.trim();
+                        if cmd == "/pair" || cmd == "/users" {
+                            let list = allowlist.lock().unwrap();
+                            let is_owner = list.is_owner(&user_id);
+                            drop(list);
+                            if !is_owner {
+                                return Ok(ChannelResponse::Text(
+                                    "Only the bot owner can use this command.".to_string(),
+                                ));
+                            }
+                            if cmd == "/pair" {
+                                let code = pairing.lock().unwrap().generate("line");
+                                return Ok(ChannelResponse::Text(format!(
+                                    "Pairing code: {code}\n\nShare this with the person you want to invite. Valid for 5 minutes."
+                                )));
+                            }
+                            // /users
+                            let list = allowlist.lock().unwrap();
+                            let owner = list.owner().unwrap_or("none").to_string();
+                            let users = list.list_users();
+                            return Ok(ChannelResponse::Text(format!(
+                                "Owner: {owner}\nAllowed users ({}):\n{}",
+                                users.len(),
+                                users.join("\n")
+                            )));
+                        }
+
                         let mut list = allowlist.lock().unwrap();
                         match check_dm_auth(
                             &policy, &mut list, &pairing, &user_id, &user_id, &text, "line",
@@ -3022,6 +3051,39 @@ pub fn build_line_channels(
                     } else {
                         format!("line-{user_id}")
                     };
+
+                    // Post-auth commands available to all allowed users (DM only).
+                    if !is_group {
+                        let cmd = text.trim();
+                        if cmd == "/help" {
+                            let list = allowlist.lock().unwrap();
+                            let is_owner = list.is_owner(&user_id);
+                            drop(list);
+                            let mut help = "OpenCrust Commands:\n\
+                                /help - show this help\n\
+                                /clear - reset conversation history\n\
+                                !ingest - store a sent document for future reference"
+                                .to_string();
+                            if is_owner {
+                                help.push_str(
+                                    "\n/pair - generate a 6-digit invite code\n/users - list allowed users",
+                                );
+                            }
+                            return Ok(ChannelResponse::Text(help));
+                        }
+                        if cmd == "/clear" {
+                            if let Some(mut session) = state.sessions.get_mut(&session_id) {
+                                session.history.clear();
+                            }
+                            state.update_session_summary(&session_id, "");
+                            if let Some(store) = &state.session_store {
+                                let _ = store.prune_old_messages(&session_id, 0);
+                            }
+                            return Ok(ChannelResponse::Text(
+                                "Conversation history cleared.".to_string(),
+                            ));
+                        }
+                    }
 
                     // /ingest — run pending file through the ingestion pipeline.
                     if matches!(text.trim(), "/ingest" | "!ingest")


### PR DESCRIPTION
## Summary

- LINE DM previously had no command handler — users had to pair via Telegram or manually edit `allowlist.json`
- Adds the same command surface that Telegram and Discord already have
- `/pair` and `/users` run **before** auth so the owner can invite users even before their LINE user ID is in the allowlist
- `/help` and `/clear` are available to all allowed users after auth

## Commands added

| Command | Access | Description |
|---------|--------|-------------|
| `/pair` | owner only | Generate a 6-digit invite code (valid 5 min) |
| `/users` | owner only | List owner and allowed users |
| `/help` | allowed users | Show available commands |
| `/clear` | allowed users | Reset conversation history |

## Test plan

- [x] Send first DM to LINE bot → auto-claimed as owner, bot responds
- [x] Send `/pair` as owner → receive 6-digit code
- [x] Send code as a different LINE user → paired and allowed
- [x] Send `/users` → see owner and allowed user list
- [x] Send `/help` as allowed user → see command list (with /pair and /users shown only to owner)
- [x] Send `/clear` → history cleared, bot starts fresh
- [x] `cargo test -p opencrust-gateway` passes
- [x] `cargo clippy -p opencrust-gateway` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)