### PR TITLE
refactor(gateway): share PairingManager globally across all channels

### DIFF
--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -849,9 +849,7 @@ pub fn build_discord_channels(
         let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
             &default_allowlist_path(),
         )));
-        let pairing = Arc::new(Mutex::new(PairingManager::new(
-            std::time::Duration::from_secs(300),
-        )));
+        let pairing = Arc::clone(&state.pairing);
 
         let policy = Arc::new(ChannelPolicy::from_settings(&settings));
 
@@ -1247,9 +1245,7 @@ pub fn build_telegram_channels(
             &default_allowlist_path(),
         )));
 
-        let pairing = Arc::new(Mutex::new(PairingManager::new(
-            std::time::Duration::from_secs(300),
-        )));
+        let pairing = Arc::clone(&state.pairing);
 
         let policy = Arc::new(ChannelPolicy::from_settings(&channel_config.settings));
 
@@ -2002,9 +1998,7 @@ pub fn build_slack_channels(
             &default_allowlist_path(),
         )));
 
-        let pairing = Arc::new(Mutex::new(PairingManager::new(
-            std::time::Duration::from_secs(300),
-        )));
+        let pairing = Arc::clone(&state.pairing);
 
         let policy = Arc::new(ChannelPolicy::from_settings(&channel_config.settings));
 
@@ -2308,9 +2302,7 @@ pub fn build_whatsapp_channels(
             &default_allowlist_path(),
         )));
 
-        let pairing = Arc::new(Mutex::new(PairingManager::new(
-            std::time::Duration::from_secs(300),
-        )));
+        let pairing = Arc::clone(&state.pairing);
 
         let policy = Arc::new(ChannelPolicy::from_settings(&channel_config.settings));
 
@@ -2559,9 +2551,7 @@ pub fn build_whatsapp_web_channels(
             &default_allowlist_path(),
         )));
 
-        let pairing = Arc::new(Mutex::new(PairingManager::new(
-            std::time::Duration::from_secs(300),
-        )));
+        let pairing = Arc::clone(&state.pairing);
 
         let policy = Arc::new(ChannelPolicy::from_settings(&channel_config.settings));
 
@@ -2758,9 +2748,7 @@ pub fn build_imessage_channels(
             &default_allowlist_path(),
         )));
 
-        let pairing = Arc::new(Mutex::new(PairingManager::new(
-            std::time::Duration::from_secs(300),
-        )));
+        let pairing = Arc::clone(&state.pairing);
 
         let policy = Arc::new(ChannelPolicy::from_settings(&channel_config.settings));
 
@@ -2964,9 +2952,7 @@ pub fn build_line_channels(
         let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
             &default_allowlist_path(),
         )));
-        let pairing = Arc::new(Mutex::new(PairingManager::new(
-            std::time::Duration::from_secs(300),
-        )));
+        let pairing = Arc::clone(&state.pairing);
         let policy = Arc::new(ChannelPolicy::from_settings(&channel_config.settings));
 
         let state_for_cb = Arc::clone(state);
@@ -3306,9 +3292,7 @@ pub fn build_wechat_channels(
         let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
             &default_allowlist_path(),
         )));
-        let pairing = Arc::new(Mutex::new(PairingManager::new(
-            std::time::Duration::from_secs(300),
-        )));
+        let pairing = Arc::clone(&state.pairing);
         let policy = Arc::new(ChannelPolicy::from_settings(&channel_config.settings));
 
         let state_for_cb = Arc::clone(state);

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -31,10 +31,6 @@ pub(crate) fn default_vault_path() -> Option<PathBuf> {
     )
 }
 
-fn default_allowlist_path() -> PathBuf {
-    opencrust_config::ConfigLoader::default_config_dir().join("allowlist.json")
-}
-
 /// Resolve an API key using the priority chain: vault -> config -> env var.
 pub(crate) fn resolve_api_key(
     config_key: Option<&str>,
@@ -846,9 +842,7 @@ pub fn build_discord_channels(
             settings.insert("application_id".to_string(), serde_json::json!(id));
         }
 
-        let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
-            &default_allowlist_path(),
-        )));
+        let allowlist = Arc::clone(&state.allowlist);
         let pairing = Arc::clone(&state.pairing);
 
         let policy = Arc::new(ChannelPolicy::from_settings(&settings));
@@ -1241,9 +1235,7 @@ pub fn build_telegram_channels(
             continue;
         };
 
-        let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
-            &default_allowlist_path(),
-        )));
+        let allowlist = Arc::clone(&state.allowlist);
 
         let pairing = Arc::clone(&state.pairing);
 
@@ -1994,9 +1986,7 @@ pub fn build_slack_channels(
             continue;
         };
 
-        let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
-            &default_allowlist_path(),
-        )));
+        let allowlist = Arc::clone(&state.allowlist);
 
         let pairing = Arc::clone(&state.pairing);
 
@@ -2298,9 +2288,7 @@ pub fn build_whatsapp_channels(
             .or_else(|| std::env::var("WHATSAPP_VERIFY_TOKEN").ok())
             .unwrap_or_else(|| "opencrust-verify".to_string());
 
-        let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
-            &default_allowlist_path(),
-        )));
+        let allowlist = Arc::clone(&state.allowlist);
 
         let pairing = Arc::clone(&state.pairing);
 
@@ -2547,9 +2535,7 @@ pub fn build_whatsapp_web_channels(
             continue;
         }
 
-        let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
-            &default_allowlist_path(),
-        )));
+        let allowlist = Arc::clone(&state.allowlist);
 
         let pairing = Arc::clone(&state.pairing);
 
@@ -2744,9 +2730,7 @@ pub fn build_imessage_channels(
             .and_then(|v| v.as_u64())
             .unwrap_or(2);
 
-        let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
-            &default_allowlist_path(),
-        )));
+        let allowlist = Arc::clone(&state.allowlist);
 
         let pairing = Arc::clone(&state.pairing);
 
@@ -2949,9 +2933,7 @@ pub fn build_line_channels(
             _ => Arc::new(|_| true), // "open" — process all group messages
         };
 
-        let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
-            &default_allowlist_path(),
-        )));
+        let allowlist = Arc::clone(&state.allowlist);
         let pairing = Arc::clone(&state.pairing);
         let policy = Arc::new(ChannelPolicy::from_settings(&channel_config.settings));
 
@@ -3289,9 +3271,7 @@ pub fn build_wechat_channels(
             _ => Arc::new(|_| true),
         };
 
-        let allowlist = Arc::new(Mutex::new(Allowlist::load_or_create(
-            &default_allowlist_path(),
-        )));
+        let allowlist = Arc::clone(&state.allowlist);
         let pairing = Arc::clone(&state.pairing);
         let policy = Arc::new(ChannelPolicy::from_settings(&channel_config.settings));
 

--- a/crates/opencrust-gateway/src/state.rs
+++ b/crates/opencrust-gateway/src/state.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
@@ -13,6 +14,7 @@ use opencrust_config::{
 };
 use opencrust_db::SessionStore;
 use opencrust_media::TtsProvider;
+use opencrust_security::PairingManager;
 use tokio::sync::watch;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -74,6 +76,9 @@ pub struct AppState {
     /// These are injected into the HTML instead of the real gateway API key so
     /// the real key is never exposed in the page source.
     webchat_tokens: DashMap<String, Instant>,
+    /// Global pairing manager shared across all channels.
+    /// Codes generated in any channel can be claimed from any other channel.
+    pub pairing: Arc<Mutex<PairingManager>>,
 }
 
 /// A file received in chat waiting for the user to confirm ingestion.
@@ -127,6 +132,7 @@ impl AppState {
             session_token_counts: DashMap::new(),
             pending_files: DashMap::new(),
             webchat_tokens: DashMap::new(),
+            pairing: Arc::new(Mutex::new(PairingManager::new(Duration::from_secs(300)))),
         }
     }
 

--- a/crates/opencrust-gateway/src/state.rs
+++ b/crates/opencrust-gateway/src/state.rs
@@ -14,7 +14,7 @@ use opencrust_config::{
 };
 use opencrust_db::SessionStore;
 use opencrust_media::TtsProvider;
-use opencrust_security::PairingManager;
+use opencrust_security::{Allowlist, PairingManager};
 use tokio::sync::watch;
 use tracing::{info, warn};
 use uuid::Uuid;
@@ -79,6 +79,10 @@ pub struct AppState {
     /// Global pairing manager shared across all channels.
     /// Codes generated in any channel can be claimed from any other channel.
     pub pairing: Arc<Mutex<PairingManager>>,
+    /// Global allowlist shared across all channels.
+    /// A user authorized on any channel is authorized on all channels,
+    /// matching the multi-agent cross-channel identity model.
+    pub allowlist: Arc<Mutex<Allowlist>>,
 }
 
 /// A file received in chat waiting for the user to confirm ingestion.
@@ -133,6 +137,9 @@ impl AppState {
             pending_files: DashMap::new(),
             webchat_tokens: DashMap::new(),
             pairing: Arc::new(Mutex::new(PairingManager::new(Duration::from_secs(300)))),
+            allowlist: Arc::new(Mutex::new(Allowlist::load_or_create(
+                &opencrust_config::ConfigLoader::default_config_dir().join("allowlist.json"),
+            ))),
         }
     }
 


### PR DESCRIPTION
## Summary

Previously each channel created its own `PairingManager` and `Allowlist` instance, causing two bugs:

1. **PairingManager**: codes generated in Telegram could not be claimed in LINE — each channel had its own code pool
2. **Allowlist**: a user paired in Telegram was written to `allowlist.json` on disk but other channels' in-memory instances would not see the change until restart

Both objects are moved into `AppState` as global shared instances. This matches OpenCrust's multi-agent cross-channel identity model — a user authorized on one channel is authorized on all channels (shared continuity, cross-channel agent routing, scheduled heartbeats).

Per-channel access control is still available via `dm_policy: allowlist` in channel config for cases requiring isolation.

## Changes

- `state.rs`: add `pub pairing: Arc<Mutex<PairingManager>>` and `pub allowlist: Arc<Mutex<Allowlist>>` initialized at startup
- `bootstrap.rs`: replace all 8 per-channel `PairingManager::new(...)` and `Allowlist::load_or_create(...)` with `Arc::clone(&state.pairing)` / `Arc::clone(&state.allowlist)`
- Remove unused `default_allowlist_path()` function

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p opencrust-gateway` — 10/10 tests pass
- [x] `cargo clippy -p opencrust-gateway` clean
- [x] `cargo fmt --check` clean
- [ ] Generate `/pair` from Telegram → claim code in LINE DM → user added to allowlist on both channels instantly
- [ ] User paired via Telegram can immediately use LINE without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)