### PR TITLE
feat(line): add group RAG — embed messages, retrieve context on mention

### DIFF
--- a/crates/opencrust-channels/Cargo.toml
+++ b/crates/opencrust-channels/Cargo.toml
@@ -43,7 +43,7 @@ slack = ["dep:tokio-tungstenite", "dep:futures"]
 whatsapp = ["dep:axum"]
 whatsapp-web = ["dep:dirs"]
 imessage = ["dep:rusqlite", "dep:dirs"]
-line = ["dep:axum", "dep:ring", "dep:base64"]
+line = ["dep:axum", "dep:ring", "dep:base64", "dep:futures"]
 wechat = ["dep:axum", "dep:ring", "dep:subtle"]
 mqtt = ["dep:rumqttc"]
 

--- a/crates/opencrust-channels/src/line/mod.rs
+++ b/crates/opencrust-channels/src/line/mod.rs
@@ -36,7 +36,11 @@ pub struct LineFile {
 /// Arguments: `(group_id, user_id, text)`.
 /// Used to embed and store messages for RAG without blocking the webhook response.
 pub type GroupObserveFn = Arc<
-    dyn Fn(String, String, String) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+    dyn Fn(
+            String,
+            String,
+            String,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
         + Send
         + Sync,
 >;

--- a/crates/opencrust-channels/src/line/mod.rs
+++ b/crates/opencrust-channels/src/line/mod.rs
@@ -32,6 +32,15 @@ pub struct LineFile {
     pub mime_type: Option<String>,
 }
 
+/// Fire-and-forget callback invoked for every group text message (before reply filtering).
+/// Arguments: `(group_id, user_id, text)`.
+/// Used to embed and store messages for RAG without blocking the webhook response.
+pub type GroupObserveFn = Arc<
+    dyn Fn(String, String, String) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>
+        + Send
+        + Sync,
+>;
+
 /// Callback invoked when the bot receives a message from LINE.
 ///
 /// Arguments: `(user_id, context_id, text, is_group, file, delta_tx)`.
@@ -68,6 +77,8 @@ pub struct LineChannel {
     status: ChannelStatus,
     on_message: LineOnMessageFn,
     group_filter: LineGroupFilter,
+    /// Optional RAG observer: called for every group text message before reply filtering.
+    group_observe_fn: Option<GroupObserveFn>,
 }
 
 impl LineChannel {
@@ -102,7 +113,18 @@ impl LineChannel {
             status: ChannelStatus::Disconnected,
             on_message,
             group_filter,
+            group_observe_fn: None,
         }
+    }
+
+    /// Attach a RAG observer that embeds every group message for later retrieval.
+    pub fn with_group_observe(mut self, observe_fn: GroupObserveFn) -> Self {
+        self.group_observe_fn = Some(observe_fn);
+        self
+    }
+
+    pub fn group_observe_fn(&self) -> Option<&GroupObserveFn> {
+        self.group_observe_fn.as_ref()
     }
 
     /// Override the config key name for this channel instance.

--- a/crates/opencrust-channels/src/line/webhook.rs
+++ b/crates/opencrust-channels/src/line/webhook.rs
@@ -163,7 +163,22 @@ pub async fn line_webhook(
             false
         };
 
-        if is_group && !channel.group_filter()(is_mentioned) {
+        // Embed every group text message for RAG (fire-and-forget, skips bot's own messages).
+        let is_bot_message = channel.bot_user_id() == Some(user_id.as_str());
+        if is_group && !text.is_empty() && !is_bot_message {
+            if let Some(observe_fn) = channel.group_observe_fn().cloned() {
+                let gid = context_id.clone();
+                let uid = user_id.clone();
+                let msg = text.clone();
+                tokio::spawn(observe_fn(gid, uid, msg));
+            }
+        }
+
+        // File messages bypass the mention filter when group RAG is enabled,
+        // so the bot can prompt for !ingest regardless of mention.
+        let has_file = file_info.is_some();
+        let rag_enabled = channel.group_observe_fn().is_some();
+        if is_group && !(has_file && rag_enabled) && !channel.group_filter()(is_mentioned) {
             continue;
         }
 

--- a/crates/opencrust-channels/src/line/webhook.rs
+++ b/crates/opencrust-channels/src/line/webhook.rs
@@ -165,13 +165,15 @@ pub async fn line_webhook(
 
         // Embed every group text message for RAG (fire-and-forget, skips bot's own messages).
         let is_bot_message = channel.bot_user_id() == Some(user_id.as_str());
-        if is_group && !text.is_empty() && !is_bot_message {
-            if let Some(observe_fn) = channel.group_observe_fn().cloned() {
-                let gid = context_id.clone();
-                let uid = user_id.clone();
-                let msg = text.clone();
-                tokio::spawn(observe_fn(gid, uid, msg));
-            }
+        if is_group
+            && !text.is_empty()
+            && !is_bot_message
+            && let Some(observe_fn) = channel.group_observe_fn().cloned()
+        {
+            let gid = context_id.clone();
+            let uid = user_id.clone();
+            let msg = text.clone();
+            tokio::spawn(observe_fn(gid, uid, msg));
         }
 
         // File messages bypass the mention filter when group RAG is enabled,

--- a/crates/opencrust-db/src/vector_store.rs
+++ b/crates/opencrust-db/src/vector_store.rs
@@ -97,11 +97,114 @@ impl VectorStore {
             CREATE TABLE IF NOT EXISTS vec_id_map (
                 rowid INTEGER PRIMARY KEY AUTOINCREMENT,
                 entry_id TEXT NOT NULL UNIQUE
-            );",
+            );
+            CREATE TABLE IF NOT EXISTS group_chat_messages (
+                id TEXT PRIMARY KEY,
+                channel TEXT NOT NULL,
+                group_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                text TEXT NOT NULL,
+                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE INDEX IF NOT EXISTS idx_group_chat_lookup ON group_chat_messages(channel, group_id);",
         )
         .map_err(|e| Error::Database(format!("vector store migration failed: {e}")))?;
 
         Ok(())
+    }
+
+    /// Insert a group chat message and its embedding into the store.
+    /// The embedding is stored in the shared vec0 table keyed by `id`.
+    pub fn insert_group_message(
+        &self,
+        channel: &str,
+        group_id: &str,
+        user_id: &str,
+        text: &str,
+        embedding: &[f32],
+        dimensions: usize,
+    ) -> Result<()> {
+        let id = format!("gchat:{channel}:{group_id}:{}", uuid::Uuid::new_v4());
+
+        let conn = self.connection()?;
+        conn.execute(
+            "INSERT INTO group_chat_messages (id, channel, group_id, user_id, text) VALUES (?, ?, ?, ?, ?)",
+            params![id, channel, group_id, user_id, text],
+        )
+        .map_err(|e| Error::Database(format!("failed to insert group chat message: {e}")))?;
+        drop(conn);
+
+        self.ensure_vec_table(dimensions)?;
+        self.insert_embedding(&id, embedding, dimensions)?;
+        Ok(())
+    }
+
+    /// Search group chat messages by semantic similarity to `query_embedding`.
+    /// Returns `(user_id, text)` pairs for the given `channel` + `group_id`, ordered by relevance.
+    /// Falls back to recency-ordered keyword search when vec is unavailable or returns no results.
+    pub fn search_group_messages(
+        &self,
+        channel: &str,
+        group_id: &str,
+        query_embedding: &[f32],
+        dimensions: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, String)>> {
+        let candidates = self.search_nearest(query_embedding, dimensions, limit * 10)?;
+        if candidates.is_empty() {
+            return self.keyword_search_group_messages(channel, group_id, limit);
+        }
+
+        let ids: Vec<String> = candidates.into_iter().map(|(id, _)| id).collect();
+        let conn = self.connection()?;
+
+        let mut results = Vec::new();
+        for id in &ids {
+            if results.len() >= limit {
+                break;
+            }
+            let row = conn.query_row(
+                "SELECT user_id, text FROM group_chat_messages WHERE id = ? AND channel = ? AND group_id = ?",
+                params![id, channel, group_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            );
+            if let Ok(pair) = row {
+                results.push(pair);
+            }
+        }
+
+        if results.is_empty() {
+            drop(conn);
+            return self.keyword_search_group_messages(channel, group_id, limit);
+        }
+
+        Ok(results)
+    }
+
+    fn keyword_search_group_messages(
+        &self,
+        channel: &str,
+        group_id: &str,
+        limit: usize,
+    ) -> Result<Vec<(String, String)>> {
+        let conn = self.connection()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT user_id, text FROM group_chat_messages
+                 WHERE channel = ? AND group_id = ?
+                 ORDER BY created_at DESC
+                 LIMIT ?",
+            )
+            .map_err(|e| Error::Database(format!("failed to prepare keyword search: {e}")))?;
+
+        let rows = stmt
+            .query_map(params![channel, group_id, limit as i64], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|e| Error::Database(format!("keyword search failed: {e}")))?;
+
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| Error::Database(format!("failed to collect keyword results: {e}")))
     }
 
     /// Create or verify that a `vec0` virtual table exists for the given dimensionality.

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3225,11 +3225,14 @@ pub fn build_line_channels(
                                 key,
                                 embed_config.and_then(|c| c.model.clone()),
                                 embed_config.and_then(|c| c.base_url.clone()),
-                            )) as Arc<dyn opencrust_agents::EmbeddingProvider>
+                            ))
+                                as Arc<dyn opencrust_agents::EmbeddingProvider>
                         })
                     }
                     _ => {
-                        warn!("line channel '{name}': group_rag_enabled=true but no valid embedding_provider configured, skipping RAG");
+                        warn!(
+                            "line channel '{name}': group_rag_enabled=true but no valid embedding_provider configured, skipping RAG"
+                        );
                         None
                     }
                 };
@@ -3241,10 +3244,9 @@ pub fn build_line_channels(
                     .and_then(|v| v.as_u64())
                     .unwrap_or(5) as usize;
 
-                let data_dir = config
-                    .data_dir
-                    .clone()
-                    .unwrap_or_else(|| opencrust_config::ConfigLoader::default_config_dir().join("data"));
+                let data_dir = config.data_dir.clone().unwrap_or_else(|| {
+                    opencrust_config::ConfigLoader::default_config_dir().join("data")
+                });
                 let rag_db_path = data_dir.join("group_rag.db");
 
                 match VectorStore::open(&rag_db_path) {
@@ -3259,13 +3261,16 @@ pub fn build_line_channels(
                                 let store = Arc::clone(&observe_store);
                                 let provider = Arc::clone(&observe_provider);
                                 Box::pin(async move {
-                                    match provider.embed_documents(&[text.clone()]).await {
+                                    match provider
+                                        .embed_documents(std::slice::from_ref(&text))
+                                        .await
+                                    {
                                         Ok(mut embeddings) => {
                                             if let Some(embedding) = embeddings.pop() {
                                                 let dims = embedding.len();
                                                 if let Err(e) = store.insert_group_message(
-                                                    "line", &group_id, &user_id, &text,
-                                                    &embedding, dims,
+                                                    "line", &group_id, &user_id, &text, &embedding,
+                                                    dims,
                                                 ) {
                                                     warn!("group RAG: insert failed: {e}");
                                                 }
@@ -3339,7 +3344,9 @@ pub fn build_line_channels(
                         continue;
                     }
                     Err(e) => {
-                        warn!("line channel '{name}': failed to open group RAG store: {e}, disabling RAG");
+                        warn!(
+                            "line channel '{name}': failed to open group RAG store: {e}, disabling RAG"
+                        );
                     }
                 }
             }

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -16,7 +16,7 @@ use opencrust_channels::{
 #[cfg(target_os = "macos")]
 use opencrust_channels::{IMessageChannel, IMessageGroupFilter, IMessageOnMessageFn};
 use opencrust_config::AppConfig;
-use opencrust_db::MemoryStore;
+use opencrust_db::{MemoryStore, VectorStore};
 use opencrust_security::{Allowlist, ChannelPolicy, DmAuthResult, PairingManager, check_dm_auth};
 use tracing::{info, warn};
 
@@ -3194,6 +3194,156 @@ pub fn build_line_channels(
                 })
             },
         );
+
+        // --- Group RAG setup ---
+        // If group_rag_enabled=true and setup succeeds, build a RAG-augmented channel and continue.
+        // On any failure, fall through to build a plain channel without RAG.
+        let group_rag_enabled = channel_config
+            .settings
+            .get("group_rag_enabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        if group_rag_enabled {
+            let embed_provider_name = channel_config
+                .settings
+                .get("embedding_provider")
+                .and_then(|v| v.as_str())
+                .unwrap_or("default");
+            let embed_config = config.embeddings.get(embed_provider_name);
+
+            let embed_provider: Option<Arc<dyn opencrust_agents::EmbeddingProvider>> =
+                match embed_config.map(|c| c.provider.as_str()) {
+                    Some("cohere") => {
+                        let api_key = resolve_api_key(
+                            embed_config.and_then(|c| c.api_key.as_deref()),
+                            "COHERE_API_KEY",
+                            "COHERE_API_KEY",
+                        );
+                        api_key.map(|key| {
+                            Arc::new(CohereEmbeddingProvider::new(
+                                key,
+                                embed_config.and_then(|c| c.model.clone()),
+                                embed_config.and_then(|c| c.base_url.clone()),
+                            )) as Arc<dyn opencrust_agents::EmbeddingProvider>
+                        })
+                    }
+                    _ => {
+                        warn!("line channel '{name}': group_rag_enabled=true but no valid embedding_provider configured, skipping RAG");
+                        None
+                    }
+                };
+
+            if let Some(provider) = embed_provider {
+                let rag_top_k = channel_config
+                    .settings
+                    .get("rag_top_k")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(5) as usize;
+
+                let data_dir = config
+                    .data_dir
+                    .clone()
+                    .unwrap_or_else(|| opencrust_config::ConfigLoader::default_config_dir().join("data"));
+                let rag_db_path = data_dir.join("group_rag.db");
+
+                match VectorStore::open(&rag_db_path) {
+                    Ok(store) => {
+                        let store = Arc::new(store);
+                        info!("line channel '{name}': group RAG enabled (top_k={rag_top_k})");
+
+                        let observe_store = Arc::clone(&store);
+                        let observe_provider = Arc::clone(&provider);
+                        let observe_fn: opencrust_channels::line::GroupObserveFn =
+                            Arc::new(move |group_id: String, user_id: String, text: String| {
+                                let store = Arc::clone(&observe_store);
+                                let provider = Arc::clone(&observe_provider);
+                                Box::pin(async move {
+                                    match provider.embed_documents(&[text.clone()]).await {
+                                        Ok(mut embeddings) => {
+                                            if let Some(embedding) = embeddings.pop() {
+                                                let dims = embedding.len();
+                                                if let Err(e) = store.insert_group_message(
+                                                    "line", &group_id, &user_id, &text,
+                                                    &embedding, dims,
+                                                ) {
+                                                    warn!("group RAG: insert failed: {e}");
+                                                }
+                                            }
+                                        }
+                                        Err(e) => warn!("group RAG: embed failed: {e}"),
+                                    }
+                                })
+                            });
+
+                        // Wrap on_message to prepend retrieved context when the bot is mentioned.
+                        let rag_store = Arc::clone(&store);
+                        let rag_provider = Arc::clone(&provider);
+                        let inner_on_message = Arc::clone(&on_message);
+                        let rag_on_message: LineOnMessageFn = Arc::new(
+                            move |user_id: String,
+                                  context_id: String,
+                                  text: String,
+                                  is_group: bool,
+                                  file: Option<LineFile>,
+                                  delta_tx: Option<tokio::sync::mpsc::Sender<String>>| {
+                                let store = Arc::clone(&rag_store);
+                                let provider = Arc::clone(&rag_provider);
+                                let inner = Arc::clone(&inner_on_message);
+                                let top_k = rag_top_k;
+                                Box::pin(async move {
+                                    let augmented_text = if is_group && file.is_none() {
+                                        match provider.embed_query(&text).await {
+                                            Ok(query_embedding) => {
+                                                let dims = query_embedding.len();
+                                                match store.search_group_messages(
+                                                    "line",
+                                                    &context_id,
+                                                    &query_embedding,
+                                                    dims,
+                                                    top_k,
+                                                ) {
+                                                    Ok(hits) if !hits.is_empty() => {
+                                                        let context_block = hits
+                                                            .iter()
+                                                            .map(|(uid, msg)| format!("{uid}: {msg}"))
+                                                            .collect::<Vec<_>>()
+                                                            .join("\n");
+                                                        format!(
+                                                            "[Recent group context]\n{context_block}\n---\n{text}"
+                                                        )
+                                                    }
+                                                    _ => text,
+                                                }
+                                            }
+                                            Err(_) => text,
+                                        }
+                                    } else {
+                                        text
+                                    };
+                                    inner(user_id, context_id, augmented_text, is_group, file, delta_tx).await
+                                })
+                            },
+                        );
+
+                        let channel = LineChannel::with_group_filter(
+                            channel_access_token,
+                            channel_secret,
+                            rag_on_message,
+                            group_filter,
+                        )
+                        .with_group_observe(observe_fn)
+                        .with_name(name.clone());
+                        channels.push(channel);
+                        info!("configured line channel: {name}");
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!("line channel '{name}': failed to open group RAG store: {e}, disabling RAG");
+                    }
+                }
+            }
+        }
 
         let channel = LineChannel::with_group_filter(
             channel_access_token,


### PR DESCRIPTION
## Summary

- **VectorStore**: add `group_chat_messages` table scoped by `channel` + `group_id` with `insert_group_message` / `search_group_messages` and keyword fallback when vec is unavailable
- **LineChannel**: add `GroupObserveFn` type and `group_observe_fn` field with `with_group_observe` builder for fire-and-forget embedding
- **webhook**: call `observe_fn` for every group text message before reply filter; file messages bypass mention filter when RAG is enabled so the bot can prompt for `!ingest` without being @mentioned
- **bootstrap**: wire Cohere embedding + VectorStore when `group_rag_enabled=true`; wrap `on_message` to prepend retrieved context on mention; falls back gracefully when setup fails

## Config

```yaml
channels:
  line-bot:
    group_policy: mention
    group_rag_enabled: true
    embedding_provider: cohere_embed
    rag_top_k: 5          # optional, default 5

embeddings:
  cohere_embed:
    provider: cohere
    model: embed-multilingual-v3.0
```

## Design notes

- `group_chat_messages` has a `channel` column so future channels (Telegram, Discord, etc.) can reuse the same table without schema changes
- `group_policy: mention` + `group_rag_enabled: true` is the intended combination — bot passively embeds all messages but only replies when mentioned
- `group_policy: open` + RAG is intentionally not recommended until de-duplication between session history and RAG context is implemented

## Test plan

- [x] Text sent in group without mention → silently embedded (verify `group_rag.db`)
- [x] @mention bot → response includes context retrieved from prior messages
- [x] Send PDF without mention (RAG enabled) → bot prompts for `!ingest`
- [x] Send PDF without mention (RAG disabled) → bot does not respond
- [x] Startup log shows `line channel 'xxx': group RAG enabled (top_k=5)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)