### PR TITLE
feat(line): add group RAG management commands (!context-stats, !clear-context)

### DIFF
--- a/crates/opencrust-db/src/vector_store.rs
+++ b/crates/opencrust-db/src/vector_store.rs
@@ -207,6 +207,31 @@ impl VectorStore {
             .map_err(|e| Error::Database(format!("failed to collect keyword results: {e}")))
     }
 
+    /// Count stored messages for a group.
+    pub fn count_group_messages(&self, channel: &str, group_id: &str) -> Result<usize> {
+        let conn = self.connection()?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM group_chat_messages WHERE channel = ? AND group_id = ?",
+                params![channel, group_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(format!("failed to count group messages: {e}")))?;
+        Ok(count as usize)
+    }
+
+    /// Delete all stored messages for a group. Returns the number of rows deleted.
+    pub fn clear_group_messages(&self, channel: &str, group_id: &str) -> Result<usize> {
+        let conn = self.connection()?;
+        let deleted = conn
+            .execute(
+                "DELETE FROM group_chat_messages WHERE channel = ? AND group_id = ?",
+                params![channel, group_id],
+            )
+            .map_err(|e| Error::Database(format!("failed to clear group messages: {e}")))?;
+        Ok(deleted)
+    }
+
     /// Create or verify that a `vec0` virtual table exists for the given dimensionality.
     /// This is a no-op if sqlite-vec is not loaded.
     pub fn ensure_vec_table(&self, dimensions: usize) -> Result<()> {

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3281,9 +3281,10 @@ pub fn build_line_channels(
                                 })
                             });
 
-                        // Wrap on_message to prepend retrieved context when the bot is mentioned.
+                        // Wrap on_message to handle RAG commands and prepend retrieved context.
                         let rag_store = Arc::clone(&store);
                         let rag_provider = Arc::clone(&provider);
+                        let rag_allowlist = Arc::clone(&allowlist);
                         let inner_on_message = Arc::clone(&on_message);
                         let rag_on_message: LineOnMessageFn = Arc::new(
                             move |user_id: String,
@@ -3294,9 +3295,39 @@ pub fn build_line_channels(
                                   delta_tx: Option<tokio::sync::mpsc::Sender<String>>| {
                                 let store = Arc::clone(&rag_store);
                                 let provider = Arc::clone(&rag_provider);
+                                let allowlist = Arc::clone(&rag_allowlist);
                                 let inner = Arc::clone(&inner_on_message);
                                 let top_k = rag_top_k;
                                 Box::pin(async move {
+                                    // RAG group commands (mention required, handled before agent).
+                                    if is_group {
+                                        let cmd = text.trim();
+                                        if cmd == "!context-stats" {
+                                            let count = store
+                                                .count_group_messages("line", &context_id)
+                                                .unwrap_or(0);
+                                            return Ok(ChannelResponse::Text(format!(
+                                                "Group context: {count} messages stored"
+                                            )));
+                                        }
+                                        if cmd == "!clear-context" {
+                                            let is_allowed =
+                                                allowlist.lock().unwrap().is_allowed(&user_id);
+                                            if !is_allowed {
+                                                return Ok(ChannelResponse::Text(
+                                                    "Only authorized users can clear group context."
+                                                        .to_string(),
+                                                ));
+                                            }
+                                            let deleted = store
+                                                .clear_group_messages("line", &context_id)
+                                                .unwrap_or(0);
+                                            return Ok(ChannelResponse::Text(format!(
+                                                "Group context cleared. ({deleted} messages removed)"
+                                            )));
+                                        }
+                                    }
+
                                     let augmented_text = if is_group && file.is_none() {
                                         match provider.embed_query(&text).await {
                                             Ok(query_embedding) => {
@@ -3311,7 +3342,9 @@ pub fn build_line_channels(
                                                     Ok(hits) if !hits.is_empty() => {
                                                         let context_block = hits
                                                             .iter()
-                                                            .map(|(uid, msg)| format!("{uid}: {msg}"))
+                                                            .map(|(uid, msg)| {
+                                                                format!("{uid}: {msg}")
+                                                            })
                                                             .collect::<Vec<_>>()
                                                             .join("\n");
                                                         format!(


### PR DESCRIPTION
## Summary

Follows #337 — adds management commands for group RAG context.

- **VectorStore**: add `count_group_messages` and `clear_group_messages` methods
- **bootstrap**: handle `!context-stats` and `!clear-context` when @mentioned in a LINE group

## Commands

| Command | Response | Permission |
|---------|----------|------------|
| `!context-stats` | `Group context: 127 messages stored` | anyone |
| `!clear-context` | `Group context cleared. (127 messages removed)` | allowlist only |

Permission for `!clear-context` is based on the global allowlist — any authorized user across any channel can clear the group context.

## Test plan

- [x] @mention `!context-stats` → shows correct message count
- [x] @mention `!clear-context` as allowlisted user → clears and reports count
- [x] @mention `!clear-context` as non-allowlisted user → rejected with error message
- [x] After `!clear-context`, subsequent mentions have no RAG context

🤖 Generated with [Claude Code](https://claude.com/claude-code)