### PR TITLE
fix(line): strip @mention prefix before matching RAG group commands

### DIFF
--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3300,8 +3300,14 @@ pub fn build_line_channels(
                                 let top_k = rag_top_k;
                                 Box::pin(async move {
                                     // RAG group commands (mention required, handled before agent).
+                                    // Strip leading @mention token so "@bot !cmd" matches "!cmd".
                                     if is_group {
-                                        let cmd = text.trim();
+                                        let stripped = text.trim();
+                                        let cmd = stripped
+                                            .strip_prefix(|c: char| c == '@')
+                                            .and_then(|s| s.split_once(char::is_whitespace))
+                                            .map(|(_, rest)| rest.trim())
+                                            .unwrap_or(stripped);
                                         if cmd == "!context-stats" {
                                             let count = store
                                                 .count_group_messages("line", &context_id)


### PR DESCRIPTION
## Summary

Fixes RAG group commands (`!context-stats`, `!clear-context`) not working when @mentioned in a LINE group.

## Root cause

LINE includes the `@botname` token in the message text. When a user types `@chat-bot-ai !context-stats`, the raw text received is `"@chat-bot-ai !context-stats"` — so the exact match against `"!context-stats"` always failed.

## Fix

Strip the leading `@mention` token before comparing commands:

```rust
let cmd = stripped
    .strip_prefix(|c: char| c == '@')
    .and_then(|s| s.split_once(char::is_whitespace))
    .map(|(_, rest)| rest.trim())
    .unwrap_or(stripped);
```

## Test plan

- [x] `@bot !context-stats` in group → returns stored message count
- [x] `@bot !clear-context` in group → clears context and reports count
- [x] Plain `!context-stats` without @mention still works (fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)