### PR TITLE
fix(line): route ingest command through inner to preserve session key

### DIFF
--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3332,6 +3332,23 @@ pub fn build_line_channels(
                                                 "Group context cleared. ({deleted} messages removed)"
                                             )));
                                         }
+                                        // Route !ingest through inner with stripped text so the
+                                        // pending file lookup uses the correct session key.
+                                        if cmd == "!ingest"
+                                            || cmd.starts_with("!ingest ")
+                                            || cmd == "/ingest"
+                                            || cmd.starts_with("/ingest ")
+                                        {
+                                            return inner(
+                                                user_id,
+                                                context_id,
+                                                cmd.to_string(),
+                                                is_group,
+                                                file,
+                                                delta_tx,
+                                            )
+                                            .await;
+                                        }
                                     }
 
                                     let augmented_text = if is_group && file.is_none() {


### PR DESCRIPTION
## Summary

- `!ingest` / `/ingest` commands in LINE group context were not routing through `inner()` directly, causing the pending file lookup to use the wrong session key
- Added explicit routing for `!ingest`/`/ingest` (with and without arguments) to call `inner()` with the stripped command text after the group-command block

## Test plan

- [x] Send `!ingest` in a LINE group after uploading a file — verify the file is ingested correctly
- [x] Send `/ingest` variant — same verification
- [x] Confirm other group commands (`!clear`, RAG commands) are unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)