### PR TITLE
fix(rag): always register doc_search tool regardless of memory.db existence

### DIFF
--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -541,10 +541,11 @@ pub async fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
             .unwrap_or_else(|| opencrust_config::ConfigLoader::default_config_dir().join("data"));
         let memory_db_path = data_dir.join("memory.db");
 
-        // Register doc_search whenever the memory DB exists — documents ingested
-        // after startup are visible because the tool opens the DB fresh per call.
+        // Always register doc_search — the tool opens the DB fresh on every call,
+        // so documents ingested after startup (including the very first ingest) are
+        // immediately visible without a server restart.
         // Embedding is optional: falls back to keyword search when unavailable.
-        if memory_db_path.exists() {
+        {
             let embed_fn: Option<opencrust_agents::tools::doc_search_tool::EmbedFn> =
                 runtime.embedding_provider().map(|embed| {
                     let embed_clone = embed.clone();

--- a/crates/opencrust-gateway/src/ingest.rs
+++ b/crates/opencrust-gateway/src/ingest.rs
@@ -36,6 +36,7 @@ pub async fn run_ingest(
 
     match ingest_from_bytes(filename, data, &doc_store, embed.as_deref(), replace).await {
         Ok(result) => {
+            state.agents.notify_document_ingested();
             let action = if result.replaced {
                 "Replaced"
             } else {


### PR DESCRIPTION
## Summary

- `doc_search` tool was only registered at startup if `memory.db` already existed — first-time users (fresh install, no prior ingests) never got the tool registered, so the agent could not query documents ingested via `!ingest`
- Bug affected **all channels** (LINE, Discord, Slack, WhatsApp, Telegram, iMessage, WeChat) since tool registration is global
- Fix: remove the `if memory_db_path.exists()` guard — `DocSearchTool` opens the DB fresh on every call and handles a missing/empty DB gracefully
- Also call `notify_document_ingested()` after a successful `run_ingest` so auto-RAG `has_documents` flag updates immediately without waiting for the next lazy DB check

## Test plan

- [x] Build passes: `cargo build -p opencrust-gateway`
- [x] All tests pass: `cargo test -p opencrust-gateway`
- [x] Delete `memory.db`, start server, send file → `!ingest` → ask question about file content → agent answers correctly
- [x] Existing installs with `memory.db` already present continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)