### PR TITLE
feat(cli): always attempt to backup config before write

### DIFF
--- a/crates/opencrust-cli/src/migrate.rs
+++ b/crates/opencrust-cli/src/migrate.rs
@@ -408,14 +408,15 @@ fn import_channels(source_dir: &Path, opencrust_dir: &Path, report: &mut Migrati
         report.channels_imported += 1;
     }
 
-    if !report.dry_run
-        && report.channels_imported > 0
-        && let Ok(yaml_str) = serde_yaml::to_string(&opencrust_config)
-        && let Err(e) = std::fs::write(&opencrust_config_path, yaml_str)
-    {
-        report
-            .errors
-            .push(format!("failed to write updated config: {e}"));
+    if !report.dry_run && report.channels_imported > 0 {
+        opencrust_config::try_backup_file(&opencrust_config_path);
+        if let Ok(yaml_str) = serde_yaml::to_string(&opencrust_config)
+            && let Err(e) = std::fs::write(&opencrust_config_path, yaml_str)
+        {
+            report
+                .errors
+                .push(format!("failed to write updated config: {e}"));
+        }
     }
 }
 

--- a/crates/opencrust-cli/src/wizard.rs
+++ b/crates/opencrust-cli/src/wizard.rs
@@ -1800,6 +1800,7 @@ pub async fn run_wizard(config_dir: &Path) -> Result<()> {
 
     // Write config
     let config_path = config_dir.join("config.yml");
+    opencrust_config::try_backup_file(&config_path);
     let yaml = serde_yaml::to_string(&config).context("failed to serialize config")?;
     std::fs::write(&config_path, &yaml)
         .context(format!("failed to write {}", config_path.display()))?;
@@ -2119,6 +2120,7 @@ pub async fn run_mcp_add_wizard(config_dir: &Path, pre_selected: Option<&str>) -
 
     // --- Save config ---
     config.mcp.insert(server_name.clone(), mcp_config);
+    opencrust_config::try_backup_file(&config_path);
     let yaml = serde_yaml::to_string(&config).context("failed to serialize config")?;
     std::fs::write(&config_path, &yaml)
         .context(format!("failed to write {}", config_path.display()))?;
@@ -2399,6 +2401,7 @@ pub fn run_mcp_remove(config_dir: &Path, config: &AppConfig, name: &str) -> Resu
         }
     }
 
+    opencrust_config::try_backup_file(&config_path);
     let yaml = serde_yaml::to_string(&config).context("failed to serialize config")?;
     std::fs::write(&config_path, &yaml)
         .context(format!("failed to write {}", config_path.display()))?;

--- a/crates/opencrust-config/src/lib.rs
+++ b/crates/opencrust-config/src/lib.rs
@@ -3,7 +3,7 @@ pub mod model;
 pub mod providers;
 pub mod watcher;
 
-pub use loader::ConfigLoader;
+pub use loader::{ConfigLoader, backup_file, backup_file_with_limit, try_backup_file};
 pub use model::{
     AgentConfig, AppConfig, ChannelConfig, EmbeddingProviderConfig, GatewayConfig,
     LlmProviderConfig, McpServerConfig, MemoryConfig, NamedAgentConfig, ToolsConfig,

--- a/crates/opencrust-config/src/loader.rs
+++ b/crates/opencrust-config/src/loader.rs
@@ -2,9 +2,62 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use opencrust_common::{Error, Result};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::model::{AppConfig, McpServerConfig};
+
+/// Maximum number of backup copies to keep per config file.
+const MAX_BACKUPS: u32 = 3;
+
+/// Create a rotated backup of `path` before it is overwritten.
+///
+/// Backup chain: `file.bak.3` is removed, `file.bak.2` becomes
+/// `file.bak.3`, `file.bak.1` becomes `file.bak.2`, and the current file is
+/// copied to `file.bak.1`.
+///
+/// Does nothing when `path` does not exist yet.
+pub fn backup_file(path: &Path) -> std::io::Result<()> {
+    backup_file_with_limit(path, MAX_BACKUPS)
+}
+
+/// Like [`backup_file`] but with a configurable retention limit.
+pub fn backup_file_with_limit(path: &Path, max_backups: u32) -> std::io::Result<()> {
+    if !path.exists() || max_backups == 0 {
+        return Ok(());
+    }
+
+    let oldest = backup_path(path, max_backups);
+    if oldest.exists() {
+        std::fs::remove_file(&oldest)?;
+    }
+
+    for i in (1..max_backups).rev() {
+        let from = backup_path(path, i);
+        let to = backup_path(path, i + 1);
+        if from.exists() {
+            std::fs::rename(&from, &to)?;
+        }
+    }
+
+    let dest = backup_path(path, 1);
+    std::fs::copy(path, &dest)?;
+    info!("backed up {} -> {}", path.display(), dest.display());
+
+    Ok(())
+}
+
+/// Convenience wrapper that warns instead of failing the caller.
+pub fn try_backup_file(path: &Path) {
+    if let Err(e) = backup_file(path) {
+        warn!("failed to back up {}: {e}", path.display());
+    }
+}
+
+fn backup_path(original: &Path, n: u32) -> PathBuf {
+    let mut name = original.as_os_str().to_os_string();
+    name.push(format!(".bak.{n}"));
+    PathBuf::from(name)
+}
 
 pub struct ConfigLoader {
     config_dir: PathBuf,
@@ -295,6 +348,47 @@ mod tests {
         assert!(dir.join("plugins").exists());
         assert!(dir.join("skills").exists());
         assert!(dir.join("data").exists());
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn backup_file_rotates_existing_config_backups() {
+        let dir = temp_dir("backup-rotation");
+        fs::create_dir_all(&dir).expect("failed to create temp dir");
+        let config = dir.join("config.yml");
+
+        for version in 1..=4 {
+            fs::write(&config, format!("v{version}")).expect("failed to write config");
+            super::backup_file(&config).expect("backup should succeed");
+        }
+
+        assert_eq!(
+            fs::read_to_string(dir.join("config.yml.bak.1")).unwrap(),
+            "v4"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.join("config.yml.bak.2")).unwrap(),
+            "v3"
+        );
+        assert_eq!(
+            fs::read_to_string(dir.join("config.yml.bak.3")).unwrap(),
+            "v2"
+        );
+        assert!(!dir.join("config.yml.bak.4").exists());
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn try_backup_file_does_not_create_backup_for_missing_config() {
+        let dir = temp_dir("backup-missing");
+        fs::create_dir_all(&dir).expect("failed to create temp dir");
+        let config = dir.join("config.yml");
+
+        super::try_backup_file(&config);
+
+        assert!(!dir.join("config.yml.bak.1").exists());
 
         let _ = fs::remove_dir_all(dir);
     }


### PR DESCRIPTION
## Summary

- Attempts to back up the config.yml file before any writes to it.
- Issues a warning and proceeds to write if the backup was not successful.

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Manual testing: Installed a separate opencrust-dev build and tested the different paths triggering the write.

## Related Issues
Closes #158.
