### PR TITLE
fix(rag): keyword fallback when no embedding provider and guide model to call doc_search when context incomplete

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -2756,8 +2756,7 @@ impl AgentRuntime {
 
         let query_embedding = self.embed_query(user_text).await;
         if query_embedding.is_none() {
-            warn!("auto_rag: no embedding provider, skipping");
-            return None;
+            info!("auto_rag: no embedding provider, falling back to keyword search");
         }
 
         let chunks = store
@@ -3095,8 +3094,10 @@ fn inject_rag_into_content(user_content: MessagePart, rag_context: Option<&str>)
         MessagePart::Text(text) => MessagePart::Text(format!(
             "{rag}\n\n\
              [Answer the question below using the document context above as your primary source. \
-             If the document context does not cover the question, fall back to memory or general knowledge \
-             and say so briefly.]\n\n\
+             If the context above seems incomplete or does not fully cover the question, \
+             call the doc_search tool to retrieve additional chunks before answering. \
+             If the document context does not cover the question at all, fall back to memory \
+             or general knowledge and say so briefly.]\n\n\
              ---\n\n\
              {text}"
         )),
@@ -3762,6 +3763,51 @@ mod tests {
         assert!(
             ctx.contains("relevance:"),
             "context should include relevance score"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_rag_keyword_fallback_when_no_embedding_provider() {
+        // No embedding provider set — should fall back to keyword search.
+        let store = Arc::new(resume_store());
+        let mut runtime = AgentRuntime::new();
+        runtime.doc_store = Some(store);
+        // Deliberately no embedding provider.
+
+        // Query contains "Rust" and "Engineer" which appear in the chunk text.
+        let ctx = runtime
+            .auto_rag_context("Rust Engineer experience")
+            .await;
+
+        assert!(
+            ctx.is_some(),
+            "keyword fallback should inject context when query terms match chunk text"
+        );
+        let ctx = ctx.unwrap();
+        assert!(
+            ctx.contains("resume.pdf"),
+            "context should name the source document"
+        );
+        assert!(
+            ctx.contains("Senior Rust Engineer"),
+            "context should include chunk text"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_rag_keyword_fallback_returns_none_when_no_terms_match() {
+        let store = Arc::new(resume_store());
+        let mut runtime = AgentRuntime::new();
+        runtime.doc_store = Some(store);
+
+        // Query has no terms present in the chunk.
+        let ctx = runtime
+            .auto_rag_context("weather Bangkok forecast")
+            .await;
+
+        assert!(
+            ctx.is_none(),
+            "keyword fallback should return None when no terms match"
         );
     }
 

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -3775,9 +3775,7 @@ mod tests {
         // Deliberately no embedding provider.
 
         // Query contains "Rust" and "Engineer" which appear in the chunk text.
-        let ctx = runtime
-            .auto_rag_context("Rust Engineer experience")
-            .await;
+        let ctx = runtime.auto_rag_context("Rust Engineer experience").await;
 
         assert!(
             ctx.is_some(),
@@ -3801,9 +3799,7 @@ mod tests {
         runtime.doc_store = Some(store);
 
         // Query has no terms present in the chunk.
-        let ctx = runtime
-            .auto_rag_context("weather Bangkok forecast")
-            .await;
+        let ctx = runtime.auto_rag_context("weather Bangkok forecast").await;
 
         assert!(
             ctx.is_none(),

--- a/crates/opencrust-agents/src/tools/doc_search_tool.rs
+++ b/crates/opencrust-agents/src/tools/doc_search_tool.rs
@@ -65,7 +65,9 @@ impl Tool for DocSearchTool {
              or reference material the user has shared. Also use when the user asks about a \
              specific file by name (e.g. 'what is in CLAUDE.md?') — pass the filename as the \
              query and the tool will find it by name if semantic search returns nothing. \
-             Do NOT use file_read for ingested documents.",
+             If document context was already provided above but seems incomplete or does not \
+             fully answer the question, call this tool with a more specific query to retrieve \
+             additional chunks. Do NOT use file_read for ingested documents.",
         )
     }
 

--- a/crates/opencrust-gateway/tests/line_doc_flow.rs
+++ b/crates/opencrust-gateway/tests/line_doc_flow.rs
@@ -68,9 +68,15 @@ async fn ingest_command_consumes_pending_file_and_stores_document() {
         .take_pending_file(session_id)
         .expect("pending file should exist");
 
-    let response = run_ingest(&state, data_dir.path(), "!ingest", &pending.filename, &pending.data)
-        .await
-        .expect("ingest should succeed");
+    let response = run_ingest(
+        &state,
+        data_dir.path(),
+        "!ingest",
+        &pending.filename,
+        &pending.data,
+    )
+    .await
+    .expect("ingest should succeed");
 
     let text = response.text();
     assert!(
@@ -121,7 +127,10 @@ async fn after_ingest_doc_search_finds_content() {
 
     // Ask about document content
     let output = tool
-        .execute(&ctx, serde_json::json!({"query": "quarterly sales revenue Q3"}))
+        .execute(
+            &ctx,
+            serde_json::json!({"query": "quarterly sales revenue Q3"}),
+        )
         .await
         .expect("doc_search should succeed");
 
@@ -193,8 +202,7 @@ fn pending_file_expires_after_ttl() {
         PendingFile {
             filename: "old.pdf".to_string(),
             data: vec![1, 2, 3],
-            received_at: std::time::Instant::now()
-                - std::time::Duration::from_secs(301), // just over 5-min TTL
+            received_at: std::time::Instant::now() - std::time::Duration::from_secs(301), // just over 5-min TTL
         },
     );
 
@@ -279,7 +287,10 @@ async fn doc_search_returns_empty_when_no_matching_content() {
 
     // Query about something completely unrelated
     let output = tool
-        .execute(&ctx, serde_json::json!({"query": "blockchain cryptocurrency defi"}))
+        .execute(
+            &ctx,
+            serde_json::json!({"query": "blockchain cryptocurrency defi"}),
+        )
         .await
         .expect("doc_search should not error");
 

--- a/crates/opencrust-gateway/tests/line_doc_flow.rs
+++ b/crates/opencrust-gateway/tests/line_doc_flow.rs
@@ -1,0 +1,295 @@
+/// Integration tests for the LINE document ingestion flow.
+///
+/// Simulates the full user journey through the AppState layer:
+///   1. File arrives via LINE webhook → stored as pending
+///   2. User sends `!ingest` → file ingested into document store
+///   3. User asks about the document → doc_search finds the content
+use std::sync::Arc;
+
+use opencrust_agents::AgentRuntime;
+use opencrust_channels::ChannelRegistry;
+use opencrust_config::AppConfig;
+use opencrust_db::DocumentStore;
+use opencrust_gateway::{
+    ingest::run_ingest,
+    state::{AppState, PendingFile},
+};
+
+fn test_state() -> AppState {
+    AppState::new(
+        AppConfig::default(),
+        Arc::new(AgentRuntime::new()),
+        ChannelRegistry::new(),
+    )
+}
+
+// ── Step 1: File received → stored as pending ─────────────────────────────
+
+#[test]
+fn file_received_stored_as_pending() {
+    let state = test_state();
+    let session_id = "line-Uabc123";
+
+    assert!(!state.has_pending_file(session_id));
+
+    state.set_pending_file(
+        session_id,
+        PendingFile {
+            filename: "report.pdf".to_string(),
+            data: b"PDF content about quarterly sales figures.".to_vec(),
+            received_at: std::time::Instant::now(),
+        },
+    );
+
+    assert!(state.has_pending_file(session_id));
+}
+
+// ── Step 2: !ingest consumes the pending file ─────────────────────────────
+
+#[tokio::test]
+async fn ingest_command_consumes_pending_file_and_stores_document() {
+    let state = test_state();
+    let session_id = "line-Uabc123";
+    let data_dir = tempfile::tempdir().expect("tempdir");
+
+    let content = b"This document explains the quarterly sales report for Q3 2024.";
+
+    state.set_pending_file(
+        session_id,
+        PendingFile {
+            filename: "q3_report.txt".to_string(),
+            data: content.to_vec(),
+            received_at: std::time::Instant::now(),
+        },
+    );
+
+    // Simulate `!ingest` command
+    let pending = state
+        .take_pending_file(session_id)
+        .expect("pending file should exist");
+
+    let response = run_ingest(&state, data_dir.path(), "!ingest", &pending.filename, &pending.data)
+        .await
+        .expect("ingest should succeed");
+
+    let text = response.text();
+    assert!(
+        text.contains("q3_report.txt"),
+        "response should mention filename, got: {text}"
+    );
+    assert!(
+        text.contains("chunk") || text.contains("Ingested"),
+        "response should confirm ingestion, got: {text}"
+    );
+
+    // File should now be gone from pending
+    assert!(
+        !state.has_pending_file(session_id),
+        "pending file should be consumed after !ingest"
+    );
+}
+
+// ── Step 3: After ingest, doc_search finds the content ────────────────────
+
+#[tokio::test]
+async fn after_ingest_doc_search_finds_content() {
+    use opencrust_agents::tools::{DocSearchTool, Tool, ToolContext};
+
+    let data_dir = tempfile::tempdir().expect("tempdir");
+    let db_path = data_dir.path().join("memory.db");
+
+    // Ingest a document directly into the store
+    let content = "The quarterly sales report shows revenue grew 15% year-over-year in Q3 2024.";
+    {
+        let store = DocumentStore::open(&db_path).expect("open store");
+        let doc_id = store
+            .add_document("q3_report.txt", None, "text/plain")
+            .expect("add document");
+        store
+            .add_chunk(&doc_id, 0, content, None, None, None, None)
+            .expect("add chunk");
+        store.update_chunk_count(&doc_id, 1).expect("update count");
+    }
+
+    let tool = DocSearchTool::new(db_path, None);
+    let ctx = ToolContext {
+        session_id: "line-Uabc123".to_string(),
+        user_id: None,
+        heartbeat_depth: 0,
+        allowed_tools: None,
+    };
+
+    // Ask about document content
+    let output = tool
+        .execute(&ctx, serde_json::json!({"query": "quarterly sales revenue Q3"}))
+        .await
+        .expect("doc_search should succeed");
+
+    assert!(
+        !output.is_error,
+        "doc_search returned error: {}",
+        output.content
+    );
+    assert!(
+        output.content.contains("q3_report.txt"),
+        "result should reference source document, got: {}",
+        output.content
+    );
+    assert!(
+        output.content.contains("revenue") || output.content.contains("sales"),
+        "result should contain relevant content, got: {}",
+        output.content
+    );
+}
+
+// ── Step 4: !ingest without a pending file returns a helpful message ───────
+
+#[tokio::test]
+async fn ingest_without_pending_file_returns_hint() {
+    let state = test_state();
+    let data_dir = tempfile::tempdir().expect("tempdir");
+    let session_id = "line-Uabc999";
+
+    // No file was set for this session
+    assert!(!state.has_pending_file(session_id));
+
+    // The on_message handler checks has_pending_file before calling take_pending_file.
+    // Simulate that check here: if no pending file, the bot returns a hint message.
+    let pending = state.take_pending_file(session_id);
+    assert!(
+        pending.is_none(),
+        "take_pending_file should return None when nothing is pending"
+    );
+
+    // Calling run_ingest with whitespace-only data returns Err (no extractable text)
+    let result = run_ingest(&state, data_dir.path(), "!ingest", "empty.txt", b"   ").await;
+    match result {
+        Ok(resp) => {
+            let text = resp.text().to_string();
+            assert!(
+                text.contains("no text") || text.contains("Failed"),
+                "ok-path should indicate no content, got: {text}"
+            );
+        }
+        Err(e) => {
+            assert!(
+                e.contains("no text content") || e.contains("Failed"),
+                "err-path should indicate no content, got: {e}"
+            );
+        }
+    }
+}
+
+// ── Step 5: Pending file expires after TTL ────────────────────────────────
+
+#[test]
+fn pending_file_expires_after_ttl() {
+    let state = test_state();
+    let session_id = "line-Uexpired";
+
+    // Inject a file that was received >5 minutes ago
+    state.set_pending_file(
+        session_id,
+        PendingFile {
+            filename: "old.pdf".to_string(),
+            data: vec![1, 2, 3],
+            received_at: std::time::Instant::now()
+                - std::time::Duration::from_secs(301), // just over 5-min TTL
+        },
+    );
+
+    // take_pending_file should filter out expired files
+    let result = state.take_pending_file(session_id);
+    assert!(
+        result.is_none(),
+        "expired pending file should not be returned"
+    );
+}
+
+// ── Step 6: !ingest replace overwrites an existing document ───────────────
+
+#[tokio::test]
+async fn ingest_replace_overwrites_existing_document() {
+    let state = test_state();
+    let data_dir = tempfile::tempdir().expect("tempdir");
+
+    let original = b"Original content from first upload.";
+    let updated = b"Updated content after revision.";
+
+    // First ingest
+    run_ingest(&state, data_dir.path(), "!ingest", "notes.txt", original)
+        .await
+        .expect("first ingest should succeed");
+
+    // Second ingest without replace → should indicate already ingested
+    let resp2 = run_ingest(&state, data_dir.path(), "!ingest", "notes.txt", original)
+        .await
+        .expect("second ingest should return Ok with hint");
+    assert!(
+        resp2.text().contains("already ingested"),
+        "should mention already ingested: {}",
+        resp2.text()
+    );
+
+    // Third ingest with replace keyword → should succeed
+    let resp3 = run_ingest(
+        &state,
+        data_dir.path(),
+        "!ingest replace",
+        "notes.txt",
+        updated,
+    )
+    .await
+    .expect("replace ingest should succeed");
+    assert!(
+        resp3.text().contains("Replaced") || resp3.text().contains("notes.txt"),
+        "should confirm replacement: {}",
+        resp3.text()
+    );
+}
+
+// ── Step 7: doc_search returns empty for unknown content ──────────────────
+
+#[tokio::test]
+async fn doc_search_returns_empty_when_no_matching_content() {
+    use opencrust_agents::tools::{DocSearchTool, Tool, ToolContext};
+
+    let data_dir = tempfile::tempdir().expect("tempdir");
+    let db_path = data_dir.path().join("memory.db");
+
+    // Initialize the store with one unrelated document
+    {
+        let store = DocumentStore::open(&db_path).expect("open store");
+        let doc_id = store
+            .add_document("cats.txt", None, "text/plain")
+            .expect("add document");
+        store
+            .add_chunk(&doc_id, 0, "Cats are great pets.", None, None, None, None)
+            .expect("add chunk");
+        store.update_chunk_count(&doc_id, 1).expect("update count");
+    }
+
+    let tool = DocSearchTool::new(db_path, None);
+    let ctx = ToolContext {
+        session_id: "line-Uabc123".to_string(),
+        user_id: None,
+        heartbeat_depth: 0,
+        allowed_tools: None,
+    };
+
+    // Query about something completely unrelated
+    let output = tool
+        .execute(&ctx, serde_json::json!({"query": "blockchain cryptocurrency defi"}))
+        .await
+        .expect("doc_search should not error");
+
+    assert!(
+        !output.is_error,
+        "doc_search should not error on empty results"
+    );
+    assert!(
+        output.content.contains("No relevant"),
+        "should indicate no results found, got: {}",
+        output.content
+    );
+}


### PR DESCRIPTION
## Summary

- **auto_rag keyword fallback**: When no embedding provider is configured, `auto_rag` previously bailed out with `warn! + return None`, leaving the model with zero document context. Now it falls through to `hybrid_search_chunks(embedding=None)` which already performs keyword (LIKE) search — so deployments without Cohere/OpenAI embeddings still get RAG.

- **doc_search tool conflict resolved**: The `inject_rag_into_content` instruction previously told the model to "answer from this context", causing it to skip calling `doc_search` for additional chunks. Updated the instruction to explicitly tell the model to call `doc_search` if the injected context is incomplete. Updated `doc_search`'s `system_hint` to match.

- **Integration tests**: Added 7 tests in `crates/opencrust-gateway/tests/line_doc_flow.rs` covering the full LINE document flow: file received → pending → `!ingest` → `doc_search` finds content → TTL expiry → `!ingest replace` → empty results.

## Root cause

Observed in production logs (LINE channel):
```
WARN auto_rag: no embedding provider, skipping
```
Model received no document context → answered from general knowledge → wrong answer about ingested documents.

## Test plan

- [x] `cargo test -p opencrust-agents` — unit tests for keyword fallback (2 new tests)
- [x] `cargo test -p opencrust-gateway` — all 7 LINE flow integration tests pass
- [x] Live test on running service: after deploying new binary, `auto_rag: found 3 chunks above threshold` confirms keyword search active

🤖 Generated with [Claude Code](https://claude.com/claude-code)