### PR TITLE
fix(rag): improve LINE group RAG context quality

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -2754,13 +2754,22 @@ impl AgentRuntime {
         const THRESHOLD: f64 = 0.42;
         const TOP_K: usize = 3;
 
-        let query_embedding = self.embed_query(user_text).await;
+        // When memory_text contains a group-context header (LINE group RAG injects
+        // "[Recent group context]\n...\n---\n<current message>"), use only the
+        // current message as the search query so the long history doesn't dilute
+        // keyword/vector matching against document chunks.
+        let query = match user_text.rfind("\n---\n") {
+            Some(pos) => user_text[pos + 5..].trim(),
+            None => user_text.trim(),
+        };
+
+        let query_embedding = self.embed_query(query).await;
         if query_embedding.is_none() {
             info!("auto_rag: no embedding provider, falling back to keyword search");
         }
 
         let chunks = store
-            .hybrid_search_chunks(user_text, query_embedding.as_deref(), TOP_K, THRESHOLD)
+            .hybrid_search_chunks(query, query_embedding.as_deref(), TOP_K, THRESHOLD)
             .unwrap_or_default();
 
         info!("auto_rag: found {} chunks above threshold", chunks.len());

--- a/crates/opencrust-db/src/vector_store.rs
+++ b/crates/opencrust-db/src/vector_store.rs
@@ -155,7 +155,17 @@ impl VectorStore {
             return self.keyword_search_group_messages(channel, group_id, limit);
         }
 
-        let ids: Vec<String> = candidates.into_iter().map(|(id, _)| id).collect();
+        // Filter by cosine similarity threshold before group_id scoping.
+        // Cosine distance from sqlite-vec = 1 - cosine_similarity, so
+        // similarity >= MIN_SIMILARITY  ↔  distance <= 1.0 - MIN_SIMILARITY.
+        // 0.3 is intentionally lower than doc RAG (0.42) because chat messages
+        // are short and produce lower absolute similarity scores.
+        const MIN_SIMILARITY: f64 = 0.3;
+        let ids: Vec<String> = candidates
+            .into_iter()
+            .filter(|(_, dist)| *dist <= 1.0 - MIN_SIMILARITY)
+            .map(|(id, _)| id)
+            .collect();
         let conn = self.connection()?;
 
         let mut results = Vec::new();
@@ -359,6 +369,110 @@ fn embedding_to_blob(embedding: &[f32]) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Insert a group message with a synthetic embedding and return the store.
+    fn store_with_group_messages() -> VectorStore {
+        let store = VectorStore::in_memory().expect("in-memory store");
+        // dim=3 for simplicity
+        // msg A: "ประชุมทีม dev 10 คน" → embedding points toward [1,0,0]
+        // msg B: "สวัสดีครับ" → embedding points toward [0,1,0] (unrelated)
+        store
+            .insert_group_message(
+                "line",
+                "group-1",
+                "user-A",
+                "ประชุมทีม dev 10 คน",
+                &[1.0, 0.0, 0.0],
+                3,
+            )
+            .expect("insert A");
+        store
+            .insert_group_message("line", "group-1", "user-B", "สวัสดีครับ", &[0.0, 1.0, 0.0], 3)
+            .expect("insert B");
+        store
+    }
+
+    #[test]
+    fn search_group_messages_returns_relevant_only() {
+        let store = store_with_group_messages();
+        if !store.vec_enabled() {
+            eprintln!("sqlite-vec not available, skipping");
+            return;
+        }
+
+        // Query similar to "ประชุม" (close to [1,0,0])
+        let query = [0.99, 0.1, 0.0];
+        let results = store
+            .search_group_messages("line", "group-1", &query, 3, 5)
+            .expect("search");
+
+        // Should return msg A (high similarity), not msg B (low similarity / filtered by threshold)
+        assert!(!results.is_empty(), "should return at least one result");
+        let texts: Vec<&str> = results.iter().map(|(_, t)| t.as_str()).collect();
+        assert!(
+            texts.contains(&"ประชุมทีม dev 10 คน"),
+            "relevant message should be returned: {texts:?}"
+        );
+        assert!(
+            !texts.contains(&"สวัสดีครับ"),
+            "unrelated message should be filtered out: {texts:?}"
+        );
+    }
+
+    #[test]
+    fn search_group_messages_falls_back_to_keyword_when_all_filtered() {
+        let store = store_with_group_messages();
+        if !store.vec_enabled() {
+            eprintln!("sqlite-vec not available, skipping");
+            return;
+        }
+
+        // Query orthogonal to everything stored → all below threshold → keyword fallback
+        // keyword fallback returns by recency so both messages should come back
+        let query = [0.0, 0.0, 1.0];
+        let results = store
+            .search_group_messages("line", "group-1", &query, 3, 5)
+            .expect("search orthogonal");
+
+        // Keyword fallback returns recent messages regardless of relevance
+        assert!(
+            !results.is_empty(),
+            "keyword fallback should return results"
+        );
+    }
+
+    #[test]
+    fn search_group_messages_scoped_to_group() {
+        let store = store_with_group_messages();
+        if !store.vec_enabled() {
+            eprintln!("sqlite-vec not available, skipping");
+            return;
+        }
+
+        // Insert message into a different group
+        store
+            .insert_group_message(
+                "line",
+                "group-2",
+                "user-C",
+                "ข้อมูลลับกลุ่ม 2",
+                &[1.0, 0.0, 0.0],
+                3,
+            )
+            .expect("insert group-2");
+
+        // Query group-1 should NOT return group-2's message
+        let query = [1.0, 0.0, 0.0];
+        let results = store
+            .search_group_messages("line", "group-1", &query, 3, 5)
+            .expect("search group-1");
+
+        let texts: Vec<&str> = results.iter().map(|(_, t)| t.as_str()).collect();
+        assert!(
+            !texts.contains(&"ข้อมูลลับกลุ่ม 2"),
+            "group-2 message must not leak into group-1 results"
+        );
+    }
 
     #[test]
     fn in_memory_creates_embeddings_table() {

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3375,7 +3375,11 @@ pub fn build_line_channels(
                                                             .collect::<Vec<_>>()
                                                             .join("\n");
                                                         format!(
-                                                            "[Recent group context]\n{context_block}\n---\n{text}"
+                                                            "[Recent group context — these are recent messages from this group chat. \
+Use them to answer the user's question if relevant. \
+Each line is formatted as <user_id>: <message>. \
+If the answer is present here, answer directly without asking for more information.]\n\
+{context_block}\n---\n{text}"
                                                         )
                                                     }
                                                     _ => text,


### PR DESCRIPTION
## Summary

- **Add instruction to group context header** — agent now knows the `[Recent group context]` block contains historical group messages and should use them to answer directly, fixing the pattern where it replied "ไม่มีข้อมูล" despite the answer being present in context
- **Add cosine similarity threshold (≥0.3) to `search_group_messages`** — prevents unrelated messages from being injected into the context window; mirrors doc RAG's threshold pattern but lower (0.3 vs 0.42) to account for short chat messages producing lower absolute similarity scores
- **Strip group context header before doc RAG query** — `auto_rag_context` now uses only the current message (after `\n---\n`) as the search query, preventing the full injected history from diluting document chunk retrieval

## Root cause

`search_group_messages` discarded similarity scores entirely and had no threshold, so all top-K candidates regardless of relevance were injected. The `[Recent group context]` label also carried no instruction, so the agent had no guidance on how to use the retrieved messages.

## Test plan

- [x] `search_group_messages_returns_relevant_only` — threshold filters orthogonal messages
- [x] `search_group_messages_falls_back_to_keyword_when_all_filtered` — keyword fallback still works when all candidates are below threshold
- [x] `search_group_messages_scoped_to_group` — no cross-group message leakage
- [x] `cargo test -p opencrust-db` — all 40 tests pass
- [x] `cargo check -p opencrust-db -p opencrust-gateway` — compiles clean
- [ ] Manual: send group message then query agent via LINE to verify answer is drawn from context

🤖 Generated with [Claude Code](https://claude.com/claude-code)