### PR TITLE
feat(rag): resolve LINE group member display names in RAG context

### DIFF
--- a/crates/opencrust-channels/src/line/api.rs
+++ b/crates/opencrust-channels/src/line/api.rs
@@ -134,6 +134,41 @@ pub async fn get_bot_info(
     })
 }
 
+/// Fetch a group member's display name.
+///
+/// Uses `GET {base_url}/group/{group_id}/member/{user_id}`.
+/// Works even if the user has not added the bot as a friend.
+/// Falls back gracefully — callers should use `user_id` on error.
+pub async fn get_group_member_display_name(
+    client: &Client,
+    channel_access_token: &str,
+    group_id: &str,
+    user_id: &str,
+    base_url: &str,
+) -> Result<String, String> {
+    let resp = client
+        .get(format!("{base_url}/group/{group_id}/member/{user_id}"))
+        .bearer_auth(channel_access_token)
+        .send()
+        .await
+        .map_err(|e| format!("line get_group_member_display_name request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        return Err(format!("line get_group_member_display_name error {status}"));
+    }
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("line get_group_member_display_name parse failed: {e}"))?;
+
+    json.get("displayName")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| "line get_group_member_display_name: displayName missing".to_string())
+}
+
 /// Send a push message to a user ID (paid tier, works at any time).
 pub async fn push(
     client: &Client,

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3290,6 +3290,11 @@ pub fn build_line_channels(
                         let rag_provider = Arc::clone(&provider);
                         let rag_allowlist = Arc::clone(&allowlist);
                         let inner_on_message = Arc::clone(&on_message);
+                        // Lazy cache: user_id → display_name, populated on first query per user.
+                        let name_cache: Arc<Mutex<HashMap<String, String>>> =
+                            Arc::new(Mutex::new(HashMap::new()));
+                        let rag_client = reqwest::Client::new();
+                        let rag_token = channel_access_token.clone();
                         let rag_on_message: LineOnMessageFn = Arc::new(
                             move |user_id: String,
                                   context_id: String,
@@ -3302,6 +3307,9 @@ pub fn build_line_channels(
                                 let allowlist = Arc::clone(&rag_allowlist);
                                 let inner = Arc::clone(&inner_on_message);
                                 let top_k = rag_top_k;
+                                let name_cache = Arc::clone(&name_cache);
+                                let rag_client = rag_client.clone();
+                                let rag_token = rag_token.clone();
                                 Box::pin(async move {
                                     // RAG group commands (mention required, handled before agent).
                                     // Strip leading @mention token so "@bot !cmd" matches "!cmd".
@@ -3367,17 +3375,50 @@ pub fn build_line_channels(
                                                     top_k,
                                                 ) {
                                                     Ok(hits) if !hits.is_empty() => {
-                                                        let context_block = hits
-                                                            .iter()
-                                                            .map(|(uid, msg)| {
-                                                                format!("{uid}: {msg}")
-                                                            })
-                                                            .collect::<Vec<_>>()
-                                                            .join("\n");
+                                                        let mut lines =
+                                                            Vec::with_capacity(hits.len());
+                                                        for (uid, msg) in &hits {
+                                                            let display = {
+                                                                let cached = name_cache
+                                                                    .lock()
+                                                                    .unwrap()
+                                                                    .get(uid)
+                                                                    .cloned();
+                                                                if let Some(name) = cached {
+                                                                    name
+                                                                } else {
+                                                                    match opencrust_channels::line::api::get_group_member_display_name(
+                                                                        &rag_client,
+                                                                        &rag_token,
+                                                                        &context_id,
+                                                                        uid,
+                                                                        opencrust_channels::line::api::LINE_API_BASE,
+                                                                    )
+                                                                    .await
+                                                                    {
+                                                                        Ok(name) => {
+                                                                            name_cache
+                                                                                .lock()
+                                                                                .unwrap()
+                                                                                .insert(
+                                                                                    uid.clone(),
+                                                                                    name.clone(),
+                                                                                );
+                                                                            name
+                                                                        }
+                                                                        Err(_) => uid.clone(),
+                                                                    }
+                                                                }
+                                                            };
+                                                            lines.push(format!(
+                                                                "{display}: {msg}"
+                                                            ));
+                                                        }
+                                                        let context_block = lines.join("\n");
                                                         format!(
                                                             "[Recent group context — these are recent messages from this group chat. \
 Use them to answer the user's question if relevant. \
-Each line is formatted as <user_id>: <message>. \
+Each line is formatted as <display_name>: <message>. \
 If the answer is present here, answer directly without asking for more information.]\n\
 {context_block}\n---\n{text}"
                                                         )


### PR DESCRIPTION
## Summary

- Add `get_group_member_display_name()` in `api.rs` calling `GET /v2/bot/group/{groupId}/member/{userId}` — works even if the user has not added the bot as a friend
- Add a lazy name cache (`HashMap<user_id, display_name>`) in `bootstrap.rs` — populated on first encounter per user, cache hit on subsequent queries
- Replace raw `Uxxxxxxx: message` labels in RAG context with `display_name: message` so the AI can correctly answer "who" questions
- Fallback to `user_id` when the LINE API call fails

## Test plan

- [ ] Send messages in a LINE group from multiple users, then mention the bot and ask "who is studying AI agent"
- [ ] Verify logs show display names being resolved and cached
- [ ] Verify fallback: users whose profile API call fails should still appear as `user_id` in context rather than causing a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)