### PR TITLE
fix(line): remove directive instructions from group RAG context header

### DIFF
--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3417,9 +3417,8 @@ pub fn build_line_channels(
                                                         let context_block = lines.join("\n");
                                                         format!(
                                                             "[Recent group context — these are recent messages from this group chat. \
-Use them to answer the user's question if relevant. \
-Each line is formatted as <display_name>: <message>. \
-If the answer is present here, answer directly without asking for more information.]\n\
+Use them if relevant to the user's question. \
+Each line is formatted as <display_name>: <message>.]\n\
 {context_block}\n---\n{text}"
                                                         )
                                                     }


### PR DESCRIPTION
## Summary

- The group RAG context header added in #347 included the instruction _"answer directly without asking for more information"_, which caused local models (vllm) to skip tool calls even when the question required real-time data (e.g. disk usage via `bash`)
- Tool-use decisions should be governed by the system prompt / `dna.md`, not by the injected RAG context header
- Removed the directive sentences; kept only the factual description of what the context block contains

## Test plan

- [ ] Ask the LINE bot a question that requires a tool (e.g. "ตรวจสอบพื้นที่ว่างใน disk") in a group with RAG enabled — confirm `bash` tool is called
- [ ] Ask a question answerable from group chat history — confirm the RAG context is still used correctly
- [ ] Confirm no regression in group RAG retrieval behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)