### PR TITLE
feat(line): add /clear and !clear commands for group sessions

### DIFF
--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3057,6 +3057,31 @@ pub fn build_line_channels(
                         }
                     }
 
+                    // Group /clear and !clear — strip @mention prefix then check command.
+                    if is_group {
+                        let raw = text.trim();
+                        let cmd = raw
+                            .strip_prefix(|c: char| c == '@')
+                            .and_then(|s| s.split_once(char::is_whitespace))
+                            .map(|(_, rest)| rest.trim())
+                            .unwrap_or(raw);
+                        if cmd == "/clear" || cmd == "!clear" {
+                            if !allowlist.lock().unwrap().is_allowed(&user_id) {
+                                return Err("__blocked__".to_string());
+                            }
+                            if let Some(mut session) = state.sessions.get_mut(&session_id) {
+                                session.history.clear();
+                            }
+                            state.update_session_summary(&session_id, "");
+                            if let Some(store) = &state.session_store {
+                                let _ = store.prune_old_messages(&session_id, 0);
+                            }
+                            return Ok(ChannelResponse::Text(
+                                "Conversation history cleared.".to_string(),
+                            ));
+                        }
+                    }
+
                     // /ingest — run pending file through the ingestion pipeline.
                     if matches!(text.trim(), "/ingest" | "!ingest")
                         || text.trim().starts_with("/ingest ")
@@ -3343,6 +3368,18 @@ pub fn build_line_channels(
                                             return Ok(ChannelResponse::Text(format!(
                                                 "Group context cleared. ({deleted} messages removed)"
                                             )));
+                                        }
+                                        // Route /clear and !clear through inner with stripped text.
+                                        if cmd == "/clear" || cmd == "!clear" {
+                                            return inner(
+                                                user_id,
+                                                context_id,
+                                                cmd.to_string(),
+                                                is_group,
+                                                file,
+                                                delta_tx,
+                                            )
+                                            .await;
                                         }
                                         // Route !ingest through inner with stripped text so the
                                         // pending file lookup uses the correct session key.


### PR DESCRIPTION
## Summary
- Add `@bot /clear` and `@bot !clear` support for LINE group sessions
- RAG wrapper routes stripped command through `inner()` before augmenting text
- `inner()` strips `@mention` prefix and handles the command for both RAG and non-RAG groups
- Only authorized users (allowlist) can clear the session history

## Test plan
- [ ] Send `@bot /clear` in a RAG-enabled LINE group → should reply "Conversation history cleared."
- [ ] Send `@bot !clear` in a RAG-enabled LINE group → same result
- [ ] Send `@bot /clear` in a non-RAG LINE group → same result
- [ ] Send `/clear` in LINE DM → still works as before
- [ ] Unauthorized user sends `@bot /clear` → silently blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)