### PR TITLE
feat(agents): skill self-improvement loop with production hardening

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -947,38 +947,37 @@ impl AgentRuntime {
         }
         // Look for a patch tool call in the response.
         for block in &response.content {
-            if let ContentBlock::ToolUse { name, input, .. } = block {
-                if name == "create_skill"
-                    && input.get("action").and_then(|v| v.as_str()) == Some("patch")
-                {
-                    let skill_name = input
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("unknown")
-                        .to_string();
-                    let ctx = ToolContext {
-                        session_id: session_id.to_string(),
-                        user_id: None,
-                        heartbeat_depth: 0,
-                        allowed_tools: None,
-                    };
-                    if let Some(tool) = self.find_tool("create_skill") {
-                        match tool.execute(&ctx, input.clone()).await {
-                            Ok(out) if !out.is_error => {
-                                return Some(format!(
-                                    "_(Skill '{skill_name}' updated based on this session.)_"
-                                ));
-                            }
-                            Ok(out) => {
-                                warn!("skill refine patch failed: {}", out.content);
-                            }
-                            Err(e) => {
-                                warn!("skill refine patch error: {}", e);
-                            }
+            if let ContentBlock::ToolUse { name, input, .. } = block
+                && name == "create_skill"
+                && input.get("action").and_then(|v| v.as_str()) == Some("patch")
+            {
+                let skill_name = input
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                let ctx = ToolContext {
+                    session_id: session_id.to_string(),
+                    user_id: None,
+                    heartbeat_depth: 0,
+                    allowed_tools: None,
+                };
+                if let Some(tool) = self.find_tool("create_skill") {
+                    match tool.execute(&ctx, input.clone()).await {
+                        Ok(out) if !out.is_error => {
+                            return Some(format!(
+                                "_(Skill '{skill_name}' updated based on this session.)_"
+                            ));
+                        }
+                        Ok(out) => {
+                            warn!("skill refine patch failed: {}", out.content);
+                        }
+                        Err(e) => {
+                            warn!("skill refine patch error: {}", e);
                         }
                     }
-                    return None;
                 }
+                return None;
             }
         }
         None

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -29,6 +29,8 @@ const SKILL_REFLECTION_THRESHOLD: usize = 3;
 const DEFAULT_SKILL_RECALL_LIMIT: usize = 5;
 /// Minimum cosine similarity for a skill to be considered relevant (0–1).
 const SKILL_SIMILARITY_THRESHOLD: f64 = 0.25;
+/// Minimum confidence (0–1) required before the refine nudge applies a patch.
+const SKILL_REFINE_CONFIDENCE_THRESHOLD: f64 = 0.7;
 
 /// Default base system prompt when none is configured.
 const DEFAULT_BASE_SYSTEM_PROMPT: &str = "\
@@ -102,6 +104,9 @@ struct NudgeContext<'a> {
     system: &'a Option<String>,
     model: &'a str,
     max_tokens: u32,
+    /// The raw skill block injected into the system prompt for this turn.
+    /// Used by `skill_refine_nudge_followup` to locate skill CHANGELOG files.
+    skills_content: Option<&'a str>,
 }
 
 impl AgentRuntime {
@@ -736,6 +741,15 @@ impl AgentRuntime {
             .map(|t| t.as_ref())
     }
 
+    /// Return the skills directory from the registered `create_skill` tool, if any.
+    fn skills_dir(&self) -> std::path::PathBuf {
+        self.tools
+            .iter()
+            .find(|t| t.name() == "create_skill")
+            .and_then(|t| t.skills_dir_hint())
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+    }
+
     /// Return a reflection nudge when the agent has completed a complex multi-tool workflow
     /// and the `create_skill` tool is available. Returns `None` when below threshold or
     /// when self-learning is disabled (tool not registered).
@@ -757,6 +771,7 @@ impl AgentRuntime {
             system,
             model,
             max_tokens,
+            skills_content: _,
         } = ctx;
         if tool_call_count < SKILL_REFLECTION_THRESHOLD {
             return None;
@@ -821,6 +836,7 @@ impl AgentRuntime {
             system,
             model,
             max_tokens,
+            skills_content,
         } = ctx;
         if tool_call_count < SKILL_REFLECTION_THRESHOLD {
             return None;
@@ -834,16 +850,74 @@ impl AgentRuntime {
                 description: t.description().to_string(),
                 input_schema: t.input_schema(),
             })?;
+        // Build patch history context from CHANGELOG files of injected skills.
+        let changelog_context = skills_content
+            .map(|sc| build_changelog_context(sc, &self.skills_dir()))
+            .unwrap_or_default();
+        let history_note = if changelog_context.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "\n\nRecent patch history for the skill(s) used:\n{changelog_context}\
+                 Only patch if you found a NEW gap not already addressed by recent changes."
+            )
+        };
+        // ── Round 1: confidence assessment (no tools, JSON reply) ────────────
         let mut msgs = messages.to_vec();
         msgs.push(ChatMessage {
             role: ChatRole::User,
-            content: MessagePart::Text(
+            content: MessagePart::Text(format!(
                 "[internal] You just completed a task using an existing skill. \
-                 Silently self-assess: were any steps in the skill unclear, outdated, \
-                 or improvable based on what you just did? \
-                 If yes, call create_skill with action='patch' to improve it now — \
-                 no need to ask the user. \
-                 If the skill worked well and needs no changes, reply with an empty string."
+                 Assess whether the skill needs improvement. \
+                 Reply with a JSON object only — no other text:\n\
+                 {{\"should_patch\": <true|false>, \"confidence\": <0.0–1.0>, \
+                 \"reason\": \"<one line>\", \"skill_name\": \"<name>\"}}\n\
+                 confidence = how certain you are that a gap exists (not how bad the gap is). \
+                 If the skill worked well, set should_patch=false.{history_note}"
+            )),
+        });
+        let assess_request = LlmRequest {
+            model: model.to_string(),
+            messages: msgs.clone(),
+            system: system.clone(),
+            max_tokens: Some(128),
+            temperature: None,
+            tools: vec![],
+        };
+        let assess_response = match provider.complete(&assess_request).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("skill refine assess LLM call failed: {}", e);
+                return None;
+            }
+        };
+        if let Some(usage) = &assess_response.usage {
+            self.accumulate_usage(
+                session_id,
+                provider.provider_id(),
+                &assess_response.model,
+                usage.input_tokens,
+                usage.output_tokens,
+            );
+        }
+        // Parse assessment JSON; skip patch if confidence < threshold.
+        let assessment_text = extract_text(&assess_response.content);
+        let assessment = parse_refine_assessment(&assessment_text);
+        if !assessment.should_patch || assessment.confidence < SKILL_REFINE_CONFIDENCE_THRESHOLD {
+            return None;
+        }
+
+        // ── Round 2: execute patch (with create_skill tool) ──────────────────
+        msgs.push(ChatMessage {
+            role: ChatRole::Assistant,
+            content: MessagePart::Text(assessment_text),
+        });
+        msgs.push(ChatMessage {
+            role: ChatRole::User,
+            content: MessagePart::Text(
+                "[internal] Confidence threshold met. \
+                 Call create_skill with action='patch' to apply the improvement now. \
+                 Include the 'reason' field from your assessment."
                     .to_string(),
             ),
         });
@@ -1306,6 +1380,7 @@ impl AgentRuntime {
                             system: &system,
                             model: &effective_model,
                             max_tokens: effective_max_tokens,
+                            skills_content: skills.as_deref(),
                         },
                         session_id,
                     )
@@ -1520,6 +1595,7 @@ impl AgentRuntime {
                             system: &system,
                             model: &effective_model,
                             max_tokens: effective_max_tokens,
+                            skills_content: skills.as_deref(),
                         },
                         session_id,
                     )
@@ -1693,6 +1769,7 @@ impl AgentRuntime {
                             system: &system,
                             model: "",
                             max_tokens: self.max_tokens.unwrap_or(4096),
+                            skills_content: skills.as_deref(),
                         },
                         session_id,
                     )
@@ -1989,6 +2066,7 @@ impl AgentRuntime {
                                     system: &system,
                                     model: "",
                                     max_tokens: self.max_tokens.unwrap_or(4096),
+                                    skills_content: skills.as_deref(),
                                 },
                                 session_id,
                             )
@@ -2115,6 +2193,7 @@ impl AgentRuntime {
                                     system: &system,
                                     model: "",
                                     max_tokens: self.max_tokens.unwrap_or(4096),
+                                    skills_content: skills.as_deref(),
                                 },
                                 session_id,
                             )
@@ -2325,6 +2404,7 @@ impl AgentRuntime {
                             system: &system,
                             model: "",
                             max_tokens: self.max_tokens.unwrap_or(4096),
+                            skills_content: skills.as_deref(),
                         },
                         session_id,
                     )
@@ -2562,6 +2642,7 @@ impl AgentRuntime {
                                     system: &system,
                                     model: "",
                                     max_tokens: self.max_tokens.unwrap_or(4096),
+                                    skills_content: skills.as_deref(),
                                 },
                                 session_id,
                             )
@@ -2675,6 +2756,7 @@ impl AgentRuntime {
                                     system: &system,
                                     model: "",
                                     max_tokens: self.max_tokens.unwrap_or(4096),
+                                    skills_content: skills.as_deref(),
                                 },
                                 session_id,
                             )
@@ -3298,6 +3380,64 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
 
 /// Compact text representation of a skill used for embedding at index time.
 /// Combines name, description, and triggers so the vector captures intent.
+/// Parsed result of the refine-nudge confidence assessment round.
+struct RefineAssessment {
+    should_patch: bool,
+    confidence: f64,
+}
+
+/// Parse the JSON assessment produced by the confidence-check LLM call.
+/// Returns a conservative default (should_patch=false) on any parse error.
+fn parse_refine_assessment(text: &str) -> RefineAssessment {
+    // Strip markdown code fences if present.
+    let cleaned = text
+        .trim()
+        .trim_start_matches("```json")
+        .trim_start_matches("```")
+        .trim_end_matches("```")
+        .trim();
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(cleaned) {
+        let should_patch = v
+            .get("should_patch")
+            .and_then(|b| b.as_bool())
+            .unwrap_or(false);
+        let confidence = v.get("confidence").and_then(|c| c.as_f64()).unwrap_or(0.0);
+        return RefineAssessment {
+            should_patch,
+            confidence,
+        };
+    }
+    RefineAssessment {
+        should_patch: false,
+        confidence: 0.0,
+    }
+}
+
+/// Extract skill names from the injected `# Active Skills` block and read
+/// their CHANGELOG.md files. Returns a formatted string for the refine prompt,
+/// or an empty string if no changelogs are found.
+fn build_changelog_context(skills_block: &str, skills_dir: &std::path::Path) -> String {
+    // Skill names appear as "## skill-name" headings in the block.
+    let names: Vec<&str> = skills_block
+        .lines()
+        .filter_map(|l| l.strip_prefix("## "))
+        .collect();
+    let mut out = String::new();
+    for name in names {
+        let changelog = skills_dir.join(name).join("CHANGELOG.md");
+        if let Ok(content) = std::fs::read_to_string(&changelog) {
+            // Include only the first 500 chars to keep prompt compact.
+            let snippet = if content.len() > 500 {
+                &content[..500]
+            } else {
+                &content
+            };
+            out.push_str(&format!("### {name}\n{snippet}\n\n"));
+        }
+    }
+    out
+}
+
 fn skill_embed_text(skill: &opencrust_skills::SkillDefinition) -> String {
     let fm = &skill.frontmatter;
     let mut parts = vec![fm.name.clone(), fm.description.clone()];
@@ -4487,10 +4627,22 @@ mod tests {
         }
     }
 
-    /// Provider that returns a patch tool_use call for create_skill.
+    /// Provider that simulates the two-round refine nudge flow:
+    /// - Round 1 (tools=[]): returns a high-confidence JSON assessment
+    /// - Round 2 (tools=[create_skill]): returns a patch tool_use call
     struct RefinePatchProvider {
         skill_name: &'static str,
         new_body: &'static str,
+        call_count: std::sync::atomic::AtomicUsize,
+    }
+    impl RefinePatchProvider {
+        fn new(skill_name: &'static str, new_body: &'static str) -> Self {
+            Self {
+                skill_name,
+                new_body,
+                call_count: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
     }
     #[async_trait::async_trait]
     impl LlmProvider for RefinePatchProvider {
@@ -4498,24 +4650,47 @@ mod tests {
             "refine-patch"
         }
         async fn complete(&self, request: &LlmRequest) -> Result<crate::providers::LlmResponse> {
-            assert!(
-                request.tools.iter().any(|t| t.name == "create_skill"),
-                "refine nudge must send create_skill tool definition"
-            );
-            Ok(crate::providers::LlmResponse {
-                content: vec![ContentBlock::ToolUse {
-                    id: "tu_1".to_string(),
-                    name: "create_skill".to_string(),
-                    input: serde_json::json!({
-                        "action": "patch",
-                        "name": self.skill_name,
-                        "body": self.new_body,
-                    }),
-                }],
-                model: String::new(),
-                usage: None,
-                stop_reason: None,
-            })
+            let round = self
+                .call_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if round == 0 {
+                // Round 1: assessment — no tools expected
+                assert!(
+                    request.tools.is_empty(),
+                    "assessment round must send tools=[]"
+                );
+                let json = format!(
+                    r#"{{"should_patch":true,"confidence":0.9,"reason":"step 2 was unclear","skill_name":"{}"}}"#,
+                    self.skill_name
+                );
+                Ok(crate::providers::LlmResponse {
+                    content: vec![ContentBlock::Text { text: json }],
+                    model: String::new(),
+                    usage: None,
+                    stop_reason: None,
+                })
+            } else {
+                // Round 2: patch execution — create_skill tool expected
+                assert!(
+                    request.tools.iter().any(|t| t.name == "create_skill"),
+                    "patch round must send create_skill tool definition"
+                );
+                Ok(crate::providers::LlmResponse {
+                    content: vec![ContentBlock::ToolUse {
+                        id: "tu_1".to_string(),
+                        name: "create_skill".to_string(),
+                        input: serde_json::json!({
+                            "action": "patch",
+                            "name": self.skill_name,
+                            "body": self.new_body,
+                            "reason": "step 2 was unclear",
+                        }),
+                    }],
+                    model: String::new(),
+                    usage: None,
+                    stop_reason: None,
+                })
+            }
         }
         async fn health_check(&self) -> Result<bool> {
             Ok(true)
@@ -4562,6 +4737,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 256,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4586,6 +4762,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 256,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4612,6 +4789,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 256,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4639,6 +4817,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 256,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4692,6 +4871,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 8192,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4714,6 +4894,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 256,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4772,6 +4953,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 256,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4814,6 +4996,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 256,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4837,6 +5020,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 256,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4861,6 +5045,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 256,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4884,10 +5069,10 @@ mod tests {
         .unwrap();
 
         let runtime = runtime_with_create_skill_tool(dir.path());
-        let provider = RefinePatchProvider {
-            skill_name: "my-skill",
-            new_body: "Updated body with improvements and enough characters to pass validation.",
-        };
+        let provider = RefinePatchProvider::new(
+            "my-skill",
+            "Updated body with improvements and enough characters to pass validation.",
+        );
         let result = runtime
             .skill_refine_nudge_followup(
                 SKILL_REFLECTION_THRESHOLD,
@@ -4897,6 +5082,7 @@ mod tests {
                     system: &None,
                     model: "",
                     max_tokens: 512,
+                    skills_content: None,
                 },
                 "sess",
             )
@@ -4915,5 +5101,83 @@ mod tests {
             updated.contains("Updated body"),
             "SKILL.md should reflect the patch"
         );
+        // CHANGELOG.md should be written inside the skill folder.
+        let changelog = std::fs::read_to_string(skill_dir.join("CHANGELOG.md")).unwrap();
+        assert!(
+            changelog.contains("step 2 was unclear"),
+            "CHANGELOG should record patch reason"
+        );
+    }
+
+    #[tokio::test]
+    async fn refine_nudge_skips_patch_when_confidence_too_low() {
+        /// Provider that returns a low-confidence assessment on round 1.
+        struct LowConfidenceProvider;
+        #[async_trait::async_trait]
+        impl LlmProvider for LowConfidenceProvider {
+            fn provider_id(&self) -> &str {
+                "low-conf"
+            }
+            async fn complete(
+                &self,
+                _request: &LlmRequest,
+            ) -> Result<crate::providers::LlmResponse> {
+                Ok(crate::providers::LlmResponse {
+                    content: vec![ContentBlock::Text {
+                        text: r#"{"should_patch":true,"confidence":0.5,"reason":"minor gap","skill_name":"x"}"#.to_string(),
+                    }],
+                    model: String::new(),
+                    usage: None,
+                    stop_reason: None,
+                })
+            }
+            async fn health_check(&self) -> Result<bool> {
+                Ok(true)
+            }
+        }
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = LowConfidenceProvider;
+        let result = runtime
+            .skill_refine_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 512,
+                    skills_content: None,
+                },
+                "sess",
+            )
+            .await;
+        assert!(
+            result.is_none(),
+            "should not patch when confidence < SKILL_REFINE_CONFIDENCE_THRESHOLD"
+        );
+    }
+
+    #[test]
+    fn parse_refine_assessment_valid_json() {
+        let text = r#"{"should_patch":true,"confidence":0.85,"reason":"gap","skill_name":"x"}"#;
+        let a = parse_refine_assessment(text);
+        assert!(a.should_patch);
+        assert!((a.confidence - 0.85).abs() < 1e-9);
+    }
+
+    #[test]
+    fn parse_refine_assessment_with_code_fence() {
+        let text = "```json\n{\"should_patch\":false,\"confidence\":0.3,\"reason\":\"ok\"}\n```";
+        let a = parse_refine_assessment(text);
+        assert!(!a.should_patch);
+    }
+
+    #[test]
+    fn parse_refine_assessment_invalid_returns_no_patch() {
+        let a = parse_refine_assessment("not json at all");
+        assert!(!a.should_patch);
+        assert_eq!(a.confidence, 0.0);
     }
 }

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -744,12 +744,10 @@ impl AgentRuntime {
     ///
     /// Passes `tools: vec![]` to prevent the model from entering another tool loop.
     /// Returns `None` if `create_skill` is not registered, the threshold is not met,
-    /// skills were already injected (agent is executing from an existing skill, not
-    /// discovering a new workflow), or the follow-up call fails.
+    /// or the follow-up call fails.
     async fn skill_nudge_followup(
         &self,
         tool_call_count: usize,
-        skills_were_injected: bool,
         ctx: NudgeContext<'_>,
         session_id: &str,
     ) -> Option<String> {
@@ -761,11 +759,6 @@ impl AgentRuntime {
             max_tokens,
         } = ctx;
         if tool_call_count < SKILL_REFLECTION_THRESHOLD {
-            return None;
-        }
-        // If a skill was already retrieved for this query the agent is executing
-        // from an existing skill — suppress the nudge to avoid asking to save it again.
-        if skills_were_injected {
             return None;
         }
         if !self.tools.iter().any(|t| t.name() == "create_skill") {
@@ -808,6 +801,130 @@ impl AgentRuntime {
                 warn!("skill nudge follow-up LLM call failed: {}", e);
                 None
             }
+        }
+    }
+
+    /// Fire a self-improvement nudge when the agent used an existing skill.
+    ///
+    /// Makes a follow-up LLM call with `create_skill` available so the model can
+    /// call `patch` autonomously if the skill had gaps. Returns a brief user-visible
+    /// note when a patch was applied, or `None` when no improvement was needed.
+    async fn skill_refine_nudge_followup(
+        &self,
+        tool_call_count: usize,
+        ctx: NudgeContext<'_>,
+        session_id: &str,
+    ) -> Option<String> {
+        let NudgeContext {
+            provider,
+            messages,
+            system,
+            model,
+            max_tokens,
+        } = ctx;
+        if tool_call_count < SKILL_REFLECTION_THRESHOLD {
+            return None;
+        }
+        let create_skill_def = self
+            .tools
+            .iter()
+            .find(|t| t.name() == "create_skill")
+            .map(|t| ToolDefinition {
+                name: t.name().to_string(),
+                description: t.description().to_string(),
+                input_schema: t.input_schema(),
+            })?;
+        let mut msgs = messages.to_vec();
+        msgs.push(ChatMessage {
+            role: ChatRole::User,
+            content: MessagePart::Text(
+                "[internal] You just completed a task using an existing skill. \
+                 Silently self-assess: were any steps in the skill unclear, outdated, \
+                 or improvable based on what you just did? \
+                 If yes, call create_skill with action='patch' to improve it now — \
+                 no need to ask the user. \
+                 If the skill worked well and needs no changes, reply with an empty string."
+                    .to_string(),
+            ),
+        });
+        let request = LlmRequest {
+            model: model.to_string(),
+            messages: msgs,
+            system: system.clone(),
+            max_tokens: Some(max_tokens.min(512)),
+            temperature: None,
+            tools: vec![create_skill_def],
+        };
+        let response = match provider.complete(&request).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("skill refine nudge LLM call failed: {}", e);
+                return None;
+            }
+        };
+        if let Some(usage) = &response.usage {
+            self.accumulate_usage(
+                session_id,
+                provider.provider_id(),
+                &response.model,
+                usage.input_tokens,
+                usage.output_tokens,
+            );
+        }
+        // Look for a patch tool call in the response.
+        for block in &response.content {
+            if let ContentBlock::ToolUse { name, input, .. } = block {
+                if name == "create_skill"
+                    && input.get("action").and_then(|v| v.as_str()) == Some("patch")
+                {
+                    let skill_name = input
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let ctx = ToolContext {
+                        session_id: session_id.to_string(),
+                        user_id: None,
+                        heartbeat_depth: 0,
+                        allowed_tools: None,
+                    };
+                    if let Some(tool) = self.find_tool("create_skill") {
+                        match tool.execute(&ctx, input.clone()).await {
+                            Ok(out) if !out.is_error => {
+                                return Some(format!(
+                                    "_(Skill '{skill_name}' updated based on this session.)_"
+                                ));
+                            }
+                            Ok(out) => {
+                                warn!("skill refine patch failed: {}", out.content);
+                            }
+                            Err(e) => {
+                                warn!("skill refine patch error: {}", e);
+                            }
+                        }
+                    }
+                    return None;
+                }
+            }
+        }
+        None
+    }
+
+    /// Dispatch to `skill_refine_nudge_followup` when skills were injected,
+    /// or `skill_nudge_followup` when discovering a new workflow.
+    async fn skill_completion_followup(
+        &self,
+        tool_call_count: usize,
+        skills_were_injected: bool,
+        ctx: NudgeContext<'_>,
+        session_id: &str,
+    ) -> Option<String> {
+        if skills_were_injected {
+            self.skill_refine_nudge_followup(tool_call_count, ctx, session_id)
+                .await
+        } else {
+            self.skill_nudge_followup(tool_call_count, ctx, session_id)
+                .await
         }
     }
 
@@ -1180,7 +1297,7 @@ impl AgentRuntime {
                     warn!("failed to store turn in memory: {}", e);
                 }
                 if let Some(followup) = self
-                    .skill_nudge_followup(
+                    .skill_completion_followup(
                         tool_call_count,
                         skills.is_some(),
                         NudgeContext {
@@ -1394,7 +1511,7 @@ impl AgentRuntime {
                     warn!("failed to store turn in memory: {}", e);
                 }
                 if let Some(followup) = self
-                    .skill_nudge_followup(
+                    .skill_completion_followup(
                         tool_call_count,
                         skills.is_some(),
                         NudgeContext {
@@ -1567,7 +1684,7 @@ impl AgentRuntime {
                 // Post-completion: let the LLM generate a natural follow-up question
                 // asking the user whether to save the workflow as a skill.
                 if let Some(followup) = self
-                    .skill_nudge_followup(
+                    .skill_completion_followup(
                         tool_call_count,
                         skills.is_some(),
                         NudgeContext {
@@ -1863,7 +1980,7 @@ impl AgentRuntime {
                         }
 
                         if let Some(followup) = self
-                            .skill_nudge_followup(
+                            .skill_completion_followup(
                                 tool_call_count,
                                 skills.is_some(),
                                 NudgeContext {
@@ -1989,7 +2106,7 @@ impl AgentRuntime {
                         }
 
                         if let Some(followup) = self
-                            .skill_nudge_followup(
+                            .skill_completion_followup(
                                 tool_call_count,
                                 skills.is_some(),
                                 NudgeContext {
@@ -2199,7 +2316,7 @@ impl AgentRuntime {
                 }
 
                 if let Some(followup) = self
-                    .skill_nudge_followup(
+                    .skill_completion_followup(
                         tool_call_count,
                         skills.is_some(),
                         NudgeContext {
@@ -2436,7 +2553,7 @@ impl AgentRuntime {
 
                         // Post-completion reflection nudge.
                         if let Some(followup) = self
-                            .skill_nudge_followup(
+                            .skill_completion_followup(
                                 tool_call_count,
                                 skills.is_some(),
                                 NudgeContext {
@@ -2549,7 +2666,7 @@ impl AgentRuntime {
 
                         // Post-completion reflection nudge (fallback path).
                         if let Some(followup) = self
-                            .skill_nudge_followup(
+                            .skill_completion_followup(
                                 tool_call_count,
                                 skills.is_some(),
                                 NudgeContext {
@@ -2987,7 +3104,11 @@ fn self_learning_guidance() -> String {
      3. Does a similar skill already exist? (if yes → skip)\n\n\
      If yes to (1) and (2) and no to (3): **ask the user for confirmation before saving** \
      (e.g. 'I found a reusable workflow — would you like me to save it as a skill?'). \
-     Only call `create_skill` after the user confirms."
+     Only call `create_skill` after the user confirms.\n\n\
+     **Improving existing skills (action='patch'):**\n\
+     If you retrieved an existing skill and noticed gaps — steps that were unclear, \
+     outdated, or missing — you may call `create_skill` with `action='patch'` to \
+     improve it autonomously. No user confirmation is required for patches."
         .to_string()
 }
 
@@ -4342,6 +4463,65 @@ mod tests {
         }
     }
 
+    /// Provider for refine-nudge tests: accepts tool definitions, returns a text reply.
+    struct RefineTextProvider {
+        reply: &'static str,
+    }
+    #[async_trait::async_trait]
+    impl LlmProvider for RefineTextProvider {
+        fn provider_id(&self) -> &str {
+            "refine-text"
+        }
+        async fn complete(&self, _request: &LlmRequest) -> Result<crate::providers::LlmResponse> {
+            Ok(crate::providers::LlmResponse {
+                content: vec![ContentBlock::Text {
+                    text: self.reply.to_string(),
+                }],
+                model: String::new(),
+                usage: None,
+                stop_reason: None,
+            })
+        }
+        async fn health_check(&self) -> Result<bool> {
+            Ok(true)
+        }
+    }
+
+    /// Provider that returns a patch tool_use call for create_skill.
+    struct RefinePatchProvider {
+        skill_name: &'static str,
+        new_body: &'static str,
+    }
+    #[async_trait::async_trait]
+    impl LlmProvider for RefinePatchProvider {
+        fn provider_id(&self) -> &str {
+            "refine-patch"
+        }
+        async fn complete(&self, request: &LlmRequest) -> Result<crate::providers::LlmResponse> {
+            assert!(
+                request.tools.iter().any(|t| t.name == "create_skill"),
+                "refine nudge must send create_skill tool definition"
+            );
+            Ok(crate::providers::LlmResponse {
+                content: vec![ContentBlock::ToolUse {
+                    id: "tu_1".to_string(),
+                    name: "create_skill".to_string(),
+                    input: serde_json::json!({
+                        "action": "patch",
+                        "name": self.skill_name,
+                        "body": self.new_body,
+                    }),
+                }],
+                model: String::new(),
+                usage: None,
+                stop_reason: None,
+            })
+        }
+        async fn health_check(&self) -> Result<bool> {
+            Ok(true)
+        }
+    }
+
     struct FailingProvider;
     #[async_trait::async_trait]
     impl LlmProvider for FailingProvider {
@@ -4373,7 +4553,7 @@ mod tests {
         };
         // tool_call_count = 2, threshold = 3 → should not fire
         let result = runtime
-            .skill_nudge_followup(
+            .skill_completion_followup(
                 SKILL_REFLECTION_THRESHOLD - 1,
                 false,
                 NudgeContext {
@@ -4390,15 +4570,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn nudge_returns_none_when_skills_were_injected() {
-        // If a skill was injected the agent is executing from it — don't ask to save again.
+    async fn nudge_returns_none_when_skills_injected_and_no_patch_needed() {
+        // When a skill was injected but the refine nudge determines no patch is needed
+        // (model replies with text, no tool_use), the followup should return None.
         let dir = tempfile::TempDir::new().unwrap();
         let runtime = runtime_with_create_skill_tool(dir.path());
-        let provider = FixedProvider {
-            reply: "Would you like to save this?",
-        };
+        let provider = RefineTextProvider { reply: "" };
         let result = runtime
-            .skill_nudge_followup(
+            .skill_completion_followup(
                 SKILL_REFLECTION_THRESHOLD,
                 true,
                 NudgeContext {
@@ -4413,7 +4592,7 @@ mod tests {
             .await;
         assert!(
             result.is_none(),
-            "should not fire when skills were already injected"
+            "should return None when model signals no improvement needed"
         );
     }
 
@@ -4424,7 +4603,7 @@ mod tests {
             reply: "Would you like to save this?",
         };
         let result = runtime
-            .skill_nudge_followup(
+            .skill_completion_followup(
                 SKILL_REFLECTION_THRESHOLD + 5,
                 false,
                 NudgeContext {
@@ -4451,7 +4630,7 @@ mod tests {
             reply: "Would you like to save this workflow as a reusable skill?",
         };
         let result = runtime
-            .skill_nudge_followup(
+            .skill_completion_followup(
                 SKILL_REFLECTION_THRESHOLD,
                 false,
                 NudgeContext {
@@ -4504,7 +4683,7 @@ mod tests {
         let provider = CheckMaxTokensProvider;
         // Pass a very large max_tokens; method must clamp to 256
         let result = runtime
-            .skill_nudge_followup(
+            .skill_completion_followup(
                 SKILL_REFLECTION_THRESHOLD,
                 false,
                 NudgeContext {
@@ -4526,7 +4705,7 @@ mod tests {
         let runtime = runtime_with_create_skill_tool(dir.path());
         let provider = FailingProvider;
         let result = runtime
-            .skill_nudge_followup(
+            .skill_completion_followup(
                 SKILL_REFLECTION_THRESHOLD,
                 false,
                 NudgeContext {
@@ -4584,7 +4763,7 @@ mod tests {
 
         let history = vec![make_msg(ChatRole::User, "help me rebase")];
         runtime
-            .skill_nudge_followup(
+            .skill_completion_followup(
                 SKILL_REFLECTION_THRESHOLD,
                 false,
                 NudgeContext {
@@ -4615,5 +4794,126 @@ mod tests {
             "injected message must contain [internal] marker"
         );
         assert!(matches!(last.role, ChatRole::User));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // skill_refine_nudge_followup unit tests
+    // ──────────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn refine_nudge_returns_none_below_threshold() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = RefineTextProvider { reply: "" };
+        let result = runtime
+            .skill_refine_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD - 1,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 256,
+                },
+                "sess",
+            )
+            .await;
+        assert!(
+            result.is_none(),
+            "refine nudge must not fire below threshold"
+        );
+    }
+
+    #[tokio::test]
+    async fn refine_nudge_returns_none_without_create_skill_tool() {
+        let runtime = AgentRuntime::new();
+        let provider = RefineTextProvider { reply: "" };
+        let result = runtime
+            .skill_refine_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 256,
+                },
+                "sess",
+            )
+            .await;
+        assert!(
+            result.is_none(),
+            "refine nudge must not fire when create_skill is not registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn refine_nudge_returns_none_when_model_says_no_improvement() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = RefineTextProvider { reply: "" };
+        let result = runtime
+            .skill_refine_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 256,
+                },
+                "sess",
+            )
+            .await;
+        assert!(
+            result.is_none(),
+            "empty model reply means no improvement needed — should return None"
+        );
+    }
+
+    #[tokio::test]
+    async fn refine_nudge_applies_patch_and_returns_note() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Pre-create the skill so patch can find it.
+        let skill_dir = dir.path().join("my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: test\n---\nOriginal body with enough chars to pass validation and be valid.",
+        )
+        .unwrap();
+
+        let runtime = runtime_with_create_skill_tool(dir.path());
+        let provider = RefinePatchProvider {
+            skill_name: "my-skill",
+            new_body: "Updated body with improvements and enough characters to pass validation.",
+        };
+        let result = runtime
+            .skill_refine_nudge_followup(
+                SKILL_REFLECTION_THRESHOLD,
+                NudgeContext {
+                    provider: &provider,
+                    messages: &[],
+                    system: &None,
+                    model: "",
+                    max_tokens: 512,
+                },
+                "sess",
+            )
+            .await;
+        assert!(
+            result.is_some(),
+            "should return a note when patch was applied"
+        );
+        assert!(
+            result.unwrap().contains("my-skill"),
+            "note should mention the skill name"
+        );
+        // Verify the skill file was updated.
+        let updated = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert!(
+            updated.contains("Updated body"),
+            "SKILL.md should reflect the patch"
+        );
     }
 }

--- a/crates/opencrust-agents/src/tools/create_skill_tool.rs
+++ b/crates/opencrust-agents/src/tools/create_skill_tool.rs
@@ -447,10 +447,10 @@ impl Tool for CreateSkillTool {
 fn bump_minor_version(version: Option<&str>) -> String {
     if let Some(v) = version {
         let parts: Vec<&str> = v.trim_matches('"').splitn(3, '.').collect();
-        if parts.len() == 3 {
-            if let (Ok(major), Ok(minor)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) {
-                return format!("{major}.{}.0", minor + 1);
-            }
+        if parts.len() == 3
+            && let (Ok(major), Ok(minor)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>())
+        {
+            return format!("{major}.{}.0", minor + 1);
         }
     }
     "0.1.0".to_string()

--- a/crates/opencrust-agents/src/tools/create_skill_tool.rs
+++ b/crates/opencrust-agents/src/tools/create_skill_tool.rs
@@ -244,6 +244,9 @@ impl CreateSkillTool {
             existing.frontmatter.triggers.clone()
         };
 
+        // Bump minor version: "1.0.0" → "1.1.0", absent → "0.1.0"
+        let new_version = bump_minor_version(existing.frontmatter.version.as_deref());
+
         // Rebuild SKILL.md (preserve rationale and other original fields)
         let mut content = format!("---\nname: {name}\ndescription: {description}\n");
         if let Some(rationale) = &existing.frontmatter.rationale {
@@ -252,6 +255,7 @@ impl CreateSkillTool {
                 rationale.replace('"', "\\\"")
             ));
         }
+        content.push_str(&format!("version: \"{new_version}\"\n"));
         if !triggers.is_empty() {
             content.push_str("triggers:\n");
             for t in &triggers {
@@ -271,8 +275,14 @@ impl CreateSkillTool {
         match installer.install_from_path(&tmp) {
             Ok(skill) => {
                 let _ = std::fs::remove_file(&tmp);
+                // Append changelog entry inside the skill folder.
+                let changelog_note = input
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("auto-patch");
+                append_skill_changelog(&self.skills_dir, &name, &new_version, changelog_note);
                 Ok(ToolOutput::success(format!(
-                    "skill '{}' patched",
+                    "skill '{}' patched → v{new_version}",
                     skill.frontmatter.name
                 )))
             }
@@ -357,6 +367,10 @@ impl Tool for CreateSkillTool {
         )
     }
 
+    fn skills_dir_hint(&self) -> Option<std::path::PathBuf> {
+        Some(self.skills_dir.clone())
+    }
+
     fn input_schema(&self) -> serde_json::Value {
         serde_json::json!({
             "type": "object",
@@ -398,6 +412,10 @@ impl Tool for CreateSkillTool {
                 "content": {
                     "type": "string",
                     "description": "write_file only: content to write to the supplementary file."
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "patch only: one-line summary of what was improved and why. Recorded in CHANGELOG.md."
                 }
             },
             "required": ["name"]
@@ -422,6 +440,47 @@ impl Tool for CreateSkillTool {
             ))),
         }
     }
+}
+
+/// Bump the minor component of a semver string: "1.2.3" → "1.3.0".
+/// Falls back to "0.1.0" when the input is absent or unparseable.
+fn bump_minor_version(version: Option<&str>) -> String {
+    if let Some(v) = version {
+        let parts: Vec<&str> = v.trim_matches('"').splitn(3, '.').collect();
+        if parts.len() == 3 {
+            if let (Ok(major), Ok(minor)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) {
+                return format!("{major}.{}.0", minor + 1);
+            }
+        }
+    }
+    "0.1.0".to_string()
+}
+
+/// Append a timestamped entry to `<skills_dir>/<name>/CHANGELOG.md`.
+/// Silently no-ops for flat-layout skills (no folder) or on I/O errors.
+fn append_skill_changelog(skills_dir: &std::path::Path, name: &str, version: &str, note: &str) {
+    let changelog_path = skills_dir.join(name).join("CHANGELOG.md");
+    // Only write changelog for folder-layout skills.
+    if !skills_dir.join(name).is_dir() {
+        return;
+    }
+    let timestamp = {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let secs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        // Format as YYYY-MM-DD approximation from epoch seconds.
+        let days = secs / 86400;
+        let y = 1970 + days / 365;
+        let d_in_y = days % 365;
+        let m = (d_in_y / 30).min(11) + 1;
+        let d = (d_in_y % 30) + 1;
+        format!("{y:04}-{m:02}-{d:02}")
+    };
+    let entry = format!("## v{version} ({timestamp})\n- {note}\n\n");
+    let existing = std::fs::read_to_string(&changelog_path).unwrap_or_default();
+    let _ = std::fs::write(&changelog_path, format!("{entry}{existing}"));
 }
 
 #[cfg(test)]
@@ -860,5 +919,18 @@ mod tests {
 
         assert!(out.is_error);
         assert!(out.content.contains("action='patch'"));
+    }
+
+    #[test]
+    fn bump_minor_version_increments_minor() {
+        assert_eq!(bump_minor_version(Some("1.0.0")), "1.1.0");
+        assert_eq!(bump_minor_version(Some("2.5.3")), "2.6.0");
+        assert_eq!(bump_minor_version(None), "0.1.0");
+        assert_eq!(bump_minor_version(Some("bad")), "0.1.0");
+    }
+
+    #[test]
+    fn bump_minor_version_with_quoted_version() {
+        assert_eq!(bump_minor_version(Some("\"1.2.0\"")), "1.3.0");
     }
 }

--- a/crates/opencrust-agents/src/tools/mod.rs
+++ b/crates/opencrust-agents/src/tools/mod.rs
@@ -52,6 +52,11 @@ pub trait Tool: Send + Sync {
     fn system_hint(&self) -> Option<&str> {
         None
     }
+    /// Optional path hint for the directory where this tool stores skills.
+    /// Only implemented by skill-management tools (e.g. CreateSkillTool).
+    fn skills_dir_hint(&self) -> Option<std::path::PathBuf> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- **Self-improvement loop**: after using an existing skill with ≥3 tool calls, `skill_refine_nudge_followup()` fires a follow-up LLM call. The model self-assesses and can call `create_skill` with `action='patch'` autonomously — no user confirmation needed
- **Two-round confidence gate**: round 1 asks for a JSON assessment `{should_patch, confidence, reason}`; round 2 (patch execution) only fires when `confidence ≥ 0.7`, preventing low-signal patches
- **Version tracking**: `execute_patch()` bumps the minor version on every patch (`1.0.0 → 1.1.0`) and appends a timestamped entry to `skill-name/CHANGELOG.md`
- **Patch guard**: recent CHANGELOG content is injected into the refine prompt so the model skips re-patching gaps already addressed in prior sessions

## Architecture

```
skill used (skills_were_injected=true, tool_calls ≥ 3)
    ↓
skill_completion_followup() → skill_refine_nudge_followup()
    ↓
Round 1: JSON assessment (tools=[])
    confidence < 0.7 → return None (silent)
    confidence ≥ 0.7 ↓
Round 2: patch execution (tools=[create_skill])
    → execute_patch() bumps version + writes CHANGELOG.md
    → returns "_(Skill 'X' updated based on this session.)_"
```

## Changes

- `runtime.rs`: `skill_refine_nudge_followup()`, `skill_completion_followup()` dispatcher, `build_changelog_context()`, `parse_refine_assessment()`, `SKILL_REFINE_CONFIDENCE_THRESHOLD`
- `create_skill_tool.rs`: version bump in `execute_patch()`, `append_skill_changelog()`, `bump_minor_version()`, `skills_dir_hint()`, `reason` field in schema
- `tools/mod.rs`: `skills_dir_hint()` default method on `Tool` trait

## Test plan

- [ ] 215 tests pass (`cargo test -p opencrust-agents -p opencrust-skills`)
- [ ] `cargo clippy` clean
- [ ] `cargo fmt --check` clean
- [ ] `refine_nudge_applies_patch_and_returns_note` verifies SKILL.md updated + CHANGELOG written
- [ ] `refine_nudge_skips_patch_when_confidence_too_low` verifies confidence gate
- [ ] `bump_minor_version_increments_minor` covers all edge cases
- [ ] `parse_refine_assessment_*` covers valid JSON, code fence, and invalid input

🤖 Generated with [Claude Code](https://claude.com/claude-code)