### PR TITLE
docs: add Hermes comparison to Why OpenCrust? table (all languages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ Pre-compiled binaries for Linux (x86_64, aarch64), macOS (Intel, Apple Silicon),
 
 *Benchmarks measured on a 1 vCPU, 1 GB RAM DigitalOcean droplet.*
 
+### vs Hermes (NousResearch)
+
+| | **OpenCrust** | **Hermes** (Python) |
+|---|---|---|
+| **Language** | Rust | Python |
+| **Security scan** | ✅ | ❌ |
+| **Self-improvement** | ✅ confidence gate + CHANGELOG | ✅ basic |
+| **Channels** | 9 | 10+ |
+| **Binary size** | 16 MB | N/A |
+
 ## Security
 
 OpenCrust is built for the security requirements of always-on AI agents that access private data and communicate externally.

--- a/README.md
+++ b/README.md
@@ -142,37 +142,29 @@ Pre-compiled binaries for Linux (x86_64, aarch64), macOS (Intel, Apple Silicon),
 
 ## Why OpenCrust?
 
-### vs OpenClaw, ZeroClaw, and other AI agent frameworks
+### vs OpenClaw, ZeroClaw, Hermes, and other AI agent frameworks
 
-| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) |
-|---|---|---|---|
-| **Binary size** | 16 MB | ~1.2 GB (with node_modules) | ~25 MB |
-| **Memory at idle** | 13 MB | ~388 MB | ~20 MB |
-| **Cold start** | 3 ms | 13.9 s | ~50 ms |
-| **Credential storage** | AES-256-GCM encrypted vault | Plaintext config file | Plaintext config file |
-| **Auth default** | Enabled (WebSocket pairing) | Disabled by default | Disabled by default |
-| **Scheduling** | Cron, interval, one-shot | Yes | No |
-| **Multi-agent routing** | Yes (named agents) | Yes (agentId) | No |
-| **Session orchestration** | Yes | Yes | No |
-| **MCP support** | Stdio + HTTP | Stdio + HTTP | Stdio |
-| **Channels** | 9 | 6+ | 4 |
-| **LLM providers** | 15 | 10+ | 22+ |
-| **Pre-compiled binaries** | Yes | N/A (Node.js) | Build from source |
-| **Config hot-reload** | Yes | No | No |
-| **WASM plugin system** | Optional (sandboxed) | No | No |
-| **Self-update** | Yes (`opencrust update`) | npm | Build from source |
+| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) | **Hermes** (Python) |
+|---|---|---|---|---|
+| **Binary size** | 16 MB | ~1.2 GB (with node_modules) | ~25 MB | N/A |
+| **Memory at idle** | 13 MB | ~388 MB | ~20 MB | — |
+| **Cold start** | 3 ms | 13.9 s | ~50 ms | — |
+| **Credential storage** | AES-256-GCM encrypted vault | Plaintext config file | Plaintext config file | — |
+| **Auth default** | Enabled (WebSocket pairing) | Disabled by default | Disabled by default | — |
+| **Scheduling** | Cron, interval, one-shot | Yes | No | — |
+| **Multi-agent routing** | Yes (named agents) | Yes (agentId) | No | — |
+| **Session orchestration** | Yes | Yes | No | — |
+| **MCP support** | Stdio + HTTP | Stdio + HTTP | Stdio | — |
+| **Channels** | 9 | 6+ | 4 | 10+ |
+| **LLM providers** | 15 | 10+ | 22+ | — |
+| **Pre-compiled binaries** | Yes | N/A (Node.js) | Build from source | — |
+| **Config hot-reload** | Yes | No | No | — |
+| **WASM plugin system** | Optional (sandboxed) | No | No | — |
+| **Self-update** | Yes (`opencrust update`) | npm | Build from source | — |
+| **Security scan** | ✅ | — | — | ❌ |
+| **Self-improvement** | ✅ confidence gate + CHANGELOG | — | — | ✅ basic |
 
 *Benchmarks measured on a 1 vCPU, 1 GB RAM DigitalOcean droplet.*
-
-### vs Hermes (NousResearch)
-
-| | **OpenCrust** | **Hermes** (Python) |
-|---|---|---|
-| **Language** | Rust | Python |
-| **Security scan** | ✅ | ❌ |
-| **Self-improvement** | ✅ confidence gate + CHANGELOG | ✅ basic |
-| **Channels** | 9 | 10+ |
-| **Binary size** | 16 MB | N/A |
 
 ## Security
 

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -141,37 +141,29 @@ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) और Windows (x86_64) �
 
 ## OpenCrust क्यों?
 
-### OpenClaw, ZeroClaw और अन्य फ्रेमवर्क से तुलना
+### OpenClaw, ZeroClaw, Hermes और अन्य फ्रेमवर्क से तुलना
 
-| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) |
-|---|---|---|---|
-| **Binary आकार** | 16 MB | ~1.2 GB (node_modules सहित) | ~25 MB |
-| **Idle RAM** | 13 MB | ~388 MB | ~20 MB |
-| **Cold start** | 3 ms | 13.9 s | ~50 ms |
-| **Credential स्टोरेज** | AES-256-GCM vault | plaintext config file | plaintext config file |
-| **डिफ़ॉल्ट Auth** | चालू (WebSocket pairing) | बंद | बंद |
-| **Scheduling** | Cron, interval, one-shot | हाँ | नहीं |
-| **Multi-agent routing** | हाँ (named agents) | हाँ (agentId) | नहीं |
-| **Session orchestration** | हाँ | हाँ | नहीं |
-| **MCP support** | Stdio + HTTP | Stdio + HTTP | Stdio |
-| **Channels** | 9 | 6+ | 4 |
-| **LLM providers** | 15 | 10+ | 22+ |
-| **Pre-compiled binary** | हाँ | N/A (Node.js) | Source से Build |
-| **Config hot-reload** | हाँ | नहीं | नहीं |
-| **WASM plugin system** | Optional (sandboxed) | नहीं | नहीं |
-| **Self-update** | हाँ (`opencrust update`) | npm | Source से Build |
+| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) | **Hermes** (Python) |
+|---|---|---|---|---|
+| **Binary आकार** | 16 MB | ~1.2 GB (node_modules सहित) | ~25 MB | N/A |
+| **Idle RAM** | 13 MB | ~388 MB | ~20 MB | — |
+| **Cold start** | 3 ms | 13.9 s | ~50 ms | — |
+| **Credential स्टोरेज** | AES-256-GCM vault | plaintext config file | plaintext config file | — |
+| **डिफ़ॉल्ट Auth** | चालू (WebSocket pairing) | बंद | बंद | — |
+| **Scheduling** | Cron, interval, one-shot | हाँ | नहीं | — |
+| **Multi-agent routing** | हाँ (named agents) | हाँ (agentId) | नहीं | — |
+| **Session orchestration** | हाँ | हाँ | नहीं | — |
+| **MCP support** | Stdio + HTTP | Stdio + HTTP | Stdio | — |
+| **Channels** | 9 | 6+ | 4 | 10+ |
+| **LLM providers** | 15 | 10+ | 22+ | — |
+| **Pre-compiled binary** | हाँ | N/A (Node.js) | Source से Build | — |
+| **Config hot-reload** | हाँ | नहीं | नहीं | — |
+| **WASM plugin system** | Optional (sandboxed) | नहीं | नहीं | — |
+| **Self-update** | हाँ (`opencrust update`) | npm | Source से Build | — |
+| **Security scan** | ✅ | — | — | ❌ |
+| **Self-improvement** | ✅ confidence gate + CHANGELOG | — | — | ✅ basic |
 
 *DigitalOcean droplet 1 vCPU, 1 GB RAM पर मापा गया — [खुद टेस्ट करें](../bench/)*
-
-### Hermes (NousResearch) से तुलना
-
-| | **OpenCrust** | **Hermes** (Python) |
-|---|---|---|
-| **भाषा** | Rust | Python |
-| **Security scan** | ✅ | ❌ |
-| **Self-improvement** | ✅ confidence gate + CHANGELOG | ✅ basic |
-| **Channels** | 9 | 10+ |
-| **Binary आकार** | 16 MB | N/A |
 
 ## सुरक्षा
 

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -163,6 +163,16 @@ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) और Windows (x86_64) �
 
 *DigitalOcean droplet 1 vCPU, 1 GB RAM पर मापा गया — [खुद टेस्ट करें](../bench/)*
 
+### Hermes (NousResearch) से तुलना
+
+| | **OpenCrust** | **Hermes** (Python) |
+|---|---|---|
+| **भाषा** | Rust | Python |
+| **Security scan** | ✅ | ❌ |
+| **Self-improvement** | ✅ confidence gate + CHANGELOG | ✅ basic |
+| **Channels** | 9 | 10+ |
+| **Binary आकार** | 16 MB | N/A |
+
 ## सुरक्षा
 
 OpenCrust को हमेशा चलने वाले AI agents के लिए डिज़ाइन किया गया है जो संवेदनशील डेटा तक पहुंचते हैं।

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -141,37 +141,29 @@ binary สำหรับ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) 
 
 ## ทำไมต้อง OpenCrust?
 
-### เทียบกับ OpenClaw, ZeroClaw และเฟรมเวิร์คอื่น
+### เทียบกับ OpenClaw, ZeroClaw, Hermes และเฟรมเวิร์คอื่น
 
-| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) |
-|---|---|---|---|
-| **ขนาด binary** | 16 MB | ~1.2 GB (รวม node_modules) | ~25 MB |
-| **RAM ขณะ idle** | 13 MB | ~388 MB | ~20 MB |
-| **Cold start** | 3 ms | 13.9 s | ~50 ms |
-| **เก็บ credential** | vault เข้ารหัส AES-256-GCM | plaintext config file | plaintext config file |
-| **Auth ค่าเริ่มต้น** | เปิดใช้ (WebSocket pairing) | ปิดใช้ | ปิดใช้ |
-| **Scheduling** | Cron, interval, one-shot | ใช่ | ไม่ |
-| **Multi-agent routing** | ใช่ (named agents) | ใช่ (agentId) | ไม่ |
-| **Session orchestration** | ใช่ | ใช่ | ไม่ |
-| **MCP support** | Stdio + HTTP | Stdio + HTTP | Stdio |
-| **ช่องทาง** | 9 | 6+ | 4 |
-| **LLM provider** | 15 | 10+ | 22+ |
-| **Pre-compiled binary** | ใช่ | N/A (Node.js) | Build จาก source |
-| **Config hot-reload** | ใช่ | ไม่ | ไม่ |
-| **WASM plugin system** | Optional (sandboxed) | ไม่ | ไม่ |
-| **Self-update** | ใช่ (`opencrust update`) | npm | Build จาก source |
+| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) | **Hermes** (Python) |
+|---|---|---|---|---|
+| **ขนาด binary** | 16 MB | ~1.2 GB (รวม node_modules) | ~25 MB | N/A |
+| **RAM ขณะ idle** | 13 MB | ~388 MB | ~20 MB | — |
+| **Cold start** | 3 ms | 13.9 s | ~50 ms | — |
+| **เก็บ credential** | vault เข้ารหัส AES-256-GCM | plaintext config file | plaintext config file | — |
+| **Auth ค่าเริ่มต้น** | เปิดใช้ (WebSocket pairing) | ปิดใช้ | ปิดใช้ | — |
+| **Scheduling** | Cron, interval, one-shot | ใช่ | ไม่ | — |
+| **Multi-agent routing** | ใช่ (named agents) | ใช่ (agentId) | ไม่ | — |
+| **Session orchestration** | ใช่ | ใช่ | ไม่ | — |
+| **MCP support** | Stdio + HTTP | Stdio + HTTP | Stdio | — |
+| **ช่องทาง** | 9 | 6+ | 4 | 10+ |
+| **LLM provider** | 15 | 10+ | 22+ | — |
+| **Pre-compiled binary** | ใช่ | N/A (Node.js) | Build จาก source | — |
+| **Config hot-reload** | ใช่ | ไม่ | ไม่ | — |
+| **WASM plugin system** | Optional (sandboxed) | ไม่ | ไม่ | — |
+| **Self-update** | ใช่ (`opencrust update`) | npm | Build จาก source | — |
+| **Security scan** | ✅ | — | — | ❌ |
+| **Self-improvement** | ✅ confidence gate + CHANGELOG | — | — | ✅ basic |
 
 *วัดผลบน DigitalOcean droplet 1 vCPU, 1 GB RAM [ทดสอบเองได้](../bench/)*
-
-### เทียบกับ Hermes (NousResearch)
-
-| | **OpenCrust** | **Hermes** (Python) |
-|---|---|---|
-| **ภาษา** | Rust | Python |
-| **Security scan** | ✅ | ❌ |
-| **Self-improvement** | ✅ confidence gate + CHANGELOG | ✅ basic |
-| **ช่องทาง** | 9 | 10+ |
-| **ขนาด binary** | 16 MB | N/A |
 
 ## ความปลอดภัย
 

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -163,6 +163,16 @@ binary สำหรับ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) 
 
 *วัดผลบน DigitalOcean droplet 1 vCPU, 1 GB RAM [ทดสอบเองได้](../bench/)*
 
+### เทียบกับ Hermes (NousResearch)
+
+| | **OpenCrust** | **Hermes** (Python) |
+|---|---|---|
+| **ภาษา** | Rust | Python |
+| **Security scan** | ✅ | ❌ |
+| **Self-improvement** | ✅ confidence gate + CHANGELOG | ✅ basic |
+| **ช่องทาง** | 9 | 10+ |
+| **ขนาด binary** | 16 MB | N/A |
+
 ## ความปลอดภัย
 
 OpenCrust ถูกออกแบบสำหรับ AI agent ที่ทำงานตลอดเวลาและเข้าถึงข้อมูลส่วนตัว

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -141,37 +141,29 @@ Goodbye!
 
 ## 为什么选择 OpenCrust?
 
-### 与 OpenClaw、ZeroClaw 等 AI 代理框架对比
+### 与 OpenClaw、ZeroClaw、Hermes 等 AI 代理框架对比
 
-| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) |
-|---|---|---|---|
-| **二进制文件大小** | 16 MB | ~1.2 GB (包含 node_modules) | ~25 MB |
-| **空闲状态内存** | 13 MB | ~388 MB | ~20 MB |
-| **冷启动速度** | 3 ms | 13.9 s | ~50 ms |
-| **凭据存储方式** | AES-256-GCM 加密库 | 明文配置文件 | 明文配置文件 |
-| **默认身份验证** | 已启用 (WebSocket 配对) | 默认禁用 | 默认禁用 |
-| **任务调度** | Cron, 间隔, 单次执行 | 是 | 否 |
-| **多代理路由** | 是 (命名代理) | 是 (agentId) | 否 |
-| **会话编排** | 是 | 是 | 否 |
-| **MCP 支持** | Stdio + HTTP | Stdio + HTTP | Stdio |
-| **渠道数量** | 9 | 6+ | 4 |
-| **LLM 供应商数量** | 15 | 10+ | 22+ |
-| **预编译二进制文件** | 是 | 无 (Node.js) | 源码编译 |
-| **配置热重载** | 是 | 否 | 否 |
-| **WASM 插件系统** | 可选 (沙盒隔离) | 否 | 否 |
-| **自动更新** | 是 (`opencrust update`) | npm | 源码编译 |
+| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) | **Hermes** (Python) |
+|---|---|---|---|---|
+| **二进制文件大小** | 16 MB | ~1.2 GB (包含 node_modules) | ~25 MB | N/A |
+| **空闲状态内存** | 13 MB | ~388 MB | ~20 MB | — |
+| **冷启动速度** | 3 ms | 13.9 s | ~50 ms | — |
+| **凭据存储方式** | AES-256-GCM 加密库 | 明文配置文件 | 明文配置文件 | — |
+| **默认身份验证** | 已启用 (WebSocket 配对) | 默认禁用 | 默认禁用 | — |
+| **任务调度** | Cron, 间隔, 单次执行 | 是 | 否 | — |
+| **多代理路由** | 是 (命名代理) | 是 (agentId) | 否 | — |
+| **会话编排** | 是 | 是 | 否 | — |
+| **MCP 支持** | Stdio + HTTP | Stdio + HTTP | Stdio | — |
+| **渠道数量** | 9 | 6+ | 4 | 10+ |
+| **LLM 供应商数量** | 15 | 10+ | 22+ | — |
+| **预编译二进制文件** | 是 | 无 (Node.js) | 源码编译 | — |
+| **配置热重载** | 是 | 否 | 否 | — |
+| **WASM 插件系统** | 可选 (沙盒隔离) | 否 | 否 | — |
+| **自动更新** | 是 (`opencrust update`) | npm | 源码编译 | — |
+| **安全扫描** | ✅ | — | — | ❌ |
+| **自我改进** | ✅ confidence gate + CHANGELOG | — | — | ✅ basic |
 
 *性能基准测试在 1 vCPU, 1 GB RAM 的 DigitalOcean Droplet 上进行。*
-
-### 与 Hermes (NousResearch) 对比
-
-| | **OpenCrust** | **Hermes** (Python) |
-|---|---|---|
-| **语言** | Rust | Python |
-| **安全扫描** | ✅ | ❌ |
-| **自我改进** | ✅ confidence gate + CHANGELOG | ✅ basic |
-| **渠道数量** | 9 | 10+ |
-| **二进制文件大小** | 16 MB | N/A |
 
 ## 安全
 

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -163,6 +163,16 @@ Goodbye!
 
 *性能基准测试在 1 vCPU, 1 GB RAM 的 DigitalOcean Droplet 上进行。*
 
+### 与 Hermes (NousResearch) 对比
+
+| | **OpenCrust** | **Hermes** (Python) |
+|---|---|---|
+| **语言** | Rust | Python |
+| **安全扫描** | ✅ | ❌ |
+| **自我改进** | ✅ confidence gate + CHANGELOG | ✅ basic |
+| **渠道数量** | 9 | 10+ |
+| **二进制文件大小** | 16 MB | N/A |
+
 ## 安全
 
 OpenCrust 专门为需要访问私有数据并进行外部通信的“全天候” AI 代理设计。


### PR DESCRIPTION
## Summary

- Adds Hermes (NousResearch) as a column in the existing framework comparison table across all 4 README languages (EN, TH, ZH, HI)
- Rows with Hermes data: Binary size, Channels, Security scan, Self-improvement
- Rows without Hermes data show `—`
- Removes the separate "vs Hermes" section — everything now lives in one unified table

## Test plan

- [ ] Verify table renders correctly in GitHub Markdown preview for all 4 files
- [ ] Confirm no broken links or formatting issues

🤖 Generated with [Claude Code](https://claude.ai/claude-code)