### PR TITLE
feat(agents,gateway): route group RAG through tool-free synthesis

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -2995,6 +2995,69 @@ impl AgentRuntime {
         parts.push("=== END DOCUMENT CONTEXT ===".to_string());
         Some(parts.join("\n\n"))
     }
+
+    /// Answer `question` from `context_block` with a single, tool-free LLM call.
+    ///
+    /// Used by the group-chat RAG layer so that retrieved chat history is
+    /// reported as-is, without the agent invoking file/bash tools to "verify"
+    /// paths or other information that already exists in the context.
+    pub async fn synthesize_from_context(
+        &self,
+        session_id: &str,
+        context_block: &str,
+        question: &str,
+        history: &[ChatMessage],
+    ) -> Result<String> {
+        let provider = self
+            .default_provider()
+            .ok_or_else(|| Error::Agent("no LLM provider configured".into()))?;
+
+        let system = Some(
+            "You extract and report information from a provided group-chat context block. \
+             Answer the user's question using ONLY what is written in [Group chat context]. \
+             Do NOT check files, verify paths, run commands, or call any tools. \
+             The context is the ground truth — report it directly."
+                .to_string(),
+        );
+
+        let user_content = format!("[Group chat context]\n{context_block}\n\n---\n{question}");
+
+        let mut messages: Vec<ChatMessage> = history.to_vec();
+        messages.push(ChatMessage {
+            role: ChatRole::User,
+            content: MessagePart::Text(user_content),
+        });
+
+        let request = LlmRequest {
+            model: String::new(),
+            messages,
+            system,
+            max_tokens: Some(self.max_tokens.unwrap_or(4096)),
+            temperature: None,
+            tools: vec![], // structurally no tools — prevents FileRead/Bash from firing
+        };
+
+        let response = provider.complete(&request).await?;
+
+        if let Some(usage) = &response.usage {
+            self.accumulate_usage(
+                session_id,
+                provider.provider_id(),
+                &response.model,
+                usage.input_tokens,
+                usage.output_tokens,
+            );
+        }
+
+        let text = extract_text(&response.content);
+        if text.is_empty() {
+            return Err(Error::Agent(
+                "empty response from LLM during context synthesis".into(),
+            ));
+        }
+
+        Ok(text)
+    }
 }
 
 impl Default for AgentRuntime {

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -2960,6 +2960,10 @@ pub fn build_line_channels(
             .clone()
             .unwrap_or_else(|| opencrust_config::ConfigLoader::default_config_dir().join("data"));
 
+        // Clone before on_message moves these into its capture.
+        let rag_rate_limit_pre = Arc::clone(&rate_limit_config);
+        let rag_guardrails_pre = Arc::clone(&guardrails_config);
+
         let on_message: LineOnMessageFn = Arc::new(
             move |user_id: String,
                   context_id: String,
@@ -3315,6 +3319,12 @@ pub fn build_line_channels(
                         let rag_provider = Arc::clone(&provider);
                         let rag_allowlist = Arc::clone(&allowlist);
                         let inner_on_message = Arc::clone(&on_message);
+                        let rag_state = Arc::clone(state);
+                        let rag_agents = Arc::clone(&state.agents);
+                        let rag_rate_limit = rag_rate_limit_pre;
+                        let rag_guardrails = rag_guardrails_pre;
+                        let rag_max_input_chars = max_input_chars;
+                        let rag_max_output_chars = max_output_chars;
                         // Lazy cache: user_id → display_name, populated on first query per user.
                         let name_cache: Arc<Mutex<HashMap<String, String>>> =
                             Arc::new(Mutex::new(HashMap::new()));
@@ -3335,6 +3345,12 @@ pub fn build_line_channels(
                                 let name_cache = Arc::clone(&name_cache);
                                 let rag_client = rag_client.clone();
                                 let rag_token = rag_token.clone();
+                                let state = Arc::clone(&rag_state);
+                                let agents = Arc::clone(&rag_agents);
+                                let rate_limit_config = Arc::clone(&rag_rate_limit);
+                                let guardrails_config = Arc::clone(&rag_guardrails);
+                                let max_input_chars = rag_max_input_chars;
+                                let max_output_chars = rag_max_output_chars;
                                 Box::pin(async move {
                                     // RAG group commands (mention required, handled before agent).
                                     // Strip leading @mention token so "@bot !cmd" matches "!cmd".
@@ -3400,74 +3416,158 @@ pub fn build_line_channels(
                                         }
                                     }
 
-                                    let augmented_text = if is_group && file.is_none() {
-                                        match provider.embed_query(&text).await {
-                                            Ok(query_embedding) => {
-                                                let dims = query_embedding.len();
-                                                match store.search_group_messages(
-                                                    "line",
-                                                    &context_id,
-                                                    &query_embedding,
-                                                    dims,
-                                                    top_k,
-                                                ) {
-                                                    Ok(hits) if !hits.is_empty() => {
-                                                        let mut lines =
-                                                            Vec::with_capacity(hits.len());
-                                                        for (uid, msg) in &hits {
-                                                            let display = {
-                                                                let cached = name_cache
-                                                                    .lock()
-                                                                    .unwrap()
-                                                                    .get(uid)
-                                                                    .cloned();
-                                                                if let Some(name) = cached {
-                                                                    name
-                                                                } else {
-                                                                    match opencrust_channels::line::api::get_group_member_display_name(
-                                                                        &rag_client,
-                                                                        &rag_token,
-                                                                        &context_id,
-                                                                        uid,
-                                                                        opencrust_channels::line::api::LINE_API_BASE,
-                                                                    )
-                                                                    .await
-                                                                    {
-                                                                        Ok(name) => {
-                                                                            name_cache
-                                                                                .lock()
-                                                                                .unwrap()
-                                                                                .insert(
-                                                                                    uid.clone(),
-                                                                                    name.clone(),
-                                                                                );
-                                                                            name
-                                                                        }
-                                                                        Err(_) => uid.clone(),
+                                    // When the group RAG search finds relevant messages, route
+                                    // through a dedicated tool-free synthesis call so the LLM
+                                    // cannot invoke FileRead/Bash to "verify" paths that already
+                                    // exist verbatim in the retrieved context.
+                                    // Only falls through to the full agent pipeline when no hits.
+                                    if is_group && file.is_none() {
+                                        if let Ok(query_embedding) =
+                                            provider.embed_query(&text).await
+                                        {
+                                            let dims = query_embedding.len();
+                                            if let Ok(hits) = store.search_group_messages(
+                                                "line",
+                                                &context_id,
+                                                &query_embedding,
+                                                dims,
+                                                top_k,
+                                            ) {
+                                                if !hits.is_empty() {
+                                                    let mut lines =
+                                                        Vec::with_capacity(hits.len());
+                                                    for (uid, msg) in &hits {
+                                                        let display = {
+                                                            let cached = name_cache
+                                                                .lock()
+                                                                .unwrap()
+                                                                .get(uid)
+                                                                .cloned();
+                                                            if let Some(n) = cached {
+                                                                n
+                                                            } else {
+                                                                match opencrust_channels::line::api::get_group_member_display_name(
+                                                                    &rag_client,
+                                                                    &rag_token,
+                                                                    &context_id,
+                                                                    uid,
+                                                                    opencrust_channels::line::api::LINE_API_BASE,
+                                                                )
+                                                                .await
+                                                                {
+                                                                    Ok(n) => {
+                                                                        name_cache
+                                                                            .lock()
+                                                                            .unwrap()
+                                                                            .insert(
+                                                                                uid.clone(),
+                                                                                n.clone(),
+                                                                            );
+                                                                        n
                                                                     }
+                                                                    Err(_) => uid.clone(),
                                                                 }
-                                                            };
-                                                            lines.push(format!(
-                                                                "{display}: {msg}"
+                                                            }
+                                                        };
+                                                        lines.push(format!("{display}: {msg}"));
+                                                    }
+                                                    let context_block = lines.join("\n");
+
+                                                    // Security checks: run once on the synthesis
+                                                    // path. The fallback inner() path runs its own
+                                                    // checks independently, so there is no
+                                                    // double-counting.
+                                                    state
+                                                        .check_user_rate_limit(
+                                                            &user_id,
+                                                            &rate_limit_config,
+                                                        )
+                                                        .map_err(|e| e)?;
+                                                    let session_id = format!("line-{context_id}");
+                                                    state
+                                                        .check_token_budget(
+                                                            &session_id,
+                                                            &user_id,
+                                                            &guardrails_config,
+                                                        )
+                                                        .await
+                                                        .map_err(|e| e)?;
+                                                    let text =
+                                                        opencrust_security::InputValidator::sanitize(&text);
+                                                    if opencrust_security::InputValidator::check_prompt_injection(&text) {
+                                                        return Err("input rejected: potential prompt injection detected".to_string());
+                                                    }
+                                                    if opencrust_security::InputValidator::exceeds_length(&text, max_input_chars) {
+                                                        return Err(format!(
+                                                            "input rejected: message exceeds {max_input_chars} character limit"
+                                                        ));
+                                                    }
+
+                                                    // Tool-free synthesis: the LLM answers from
+                                                    // context only, with no tools registered.
+                                                    state
+                                                        .hydrate_session_history(
+                                                            &session_id,
+                                                            Some("line"),
+                                                            Some(&user_id),
+                                                        )
+                                                        .await;
+                                                    let history = state.session_history(&session_id);
+                                                    match agents
+                                                        .synthesize_from_context(
+                                                            &session_id,
+                                                            &context_block,
+                                                            &text,
+                                                            &history,
+                                                        )
+                                                        .await
+                                                    {
+                                                        Ok(response) => {
+                                                            let response =
+                                                                opencrust_security::InputValidator::truncate_output(
+                                                                    &response,
+                                                                    max_output_chars,
+                                                                );
+                                                            state
+                                                                .persist_turn(
+                                                                    &session_id,
+                                                                    Some("line"),
+                                                                    Some(&user_id),
+                                                                    &text,
+                                                                    &response,
+                                                                    Some(serde_json::json!({"line_user_id": user_id})),
+                                                                )
+                                                                .await;
+                                                            if let Some((input, output, provider_id, model)) =
+                                                                agents.take_session_usage(&session_id)
+                                                            {
+                                                                state
+                                                                    .persist_usage(
+                                                                        &session_id,
+                                                                        &provider_id,
+                                                                        &model,
+                                                                        input,
+                                                                        output,
+                                                                    )
+                                                                    .await;
+                                                            }
+                                                            return Ok(ChannelResponse::Text(
+                                                                response,
                                                             ));
                                                         }
-                                                        let context_block = lines.join("\n");
-                                                        format!(
-                                                            "[Recent group context — these are recent messages from this group chat. \
-Use them if relevant to the user's question. \
-Each line is formatted as <display_name>: <message>.]\n\
-{context_block}\n---\n{text}"
-                                                        )
+                                                        Err(e) => {
+                                                            warn!(
+                                                                "group RAG synthesis failed, falling back to agent: {e}"
+                                                            );
+                                                        }
                                                     }
-                                                    _ => text,
                                                 }
                                             }
-                                            Err(_) => text,
                                         }
-                                    } else {
-                                        text
-                                    };
-                                    inner(user_id, context_id, augmented_text, is_group, file, delta_tx).await
+                                    }
+
+                                    // No RAG hits (or synthesis failed): full agent pipeline.
+                                    inner(user_id, context_id, text, is_group, file, delta_tx).await
                                 })
                             },
                         );

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -3421,10 +3421,11 @@ pub fn build_line_channels(
                                     // cannot invoke FileRead/Bash to "verify" paths that already
                                     // exist verbatim in the retrieved context.
                                     // Only falls through to the full agent pipeline when no hits.
-                                    if is_group && file.is_none() {
-                                        if let Ok(query_embedding) =
+                                    if is_group
+                                        && file.is_none()
+                                        && let Ok(query_embedding) =
                                             provider.embed_query(&text).await
-                                        {
+                                    {
                                             let dims = query_embedding.len();
                                             if let Ok(hits) = store.search_group_messages(
                                                 "line",
@@ -3432,8 +3433,7 @@ pub fn build_line_channels(
                                                 &query_embedding,
                                                 dims,
                                                 top_k,
-                                            ) {
-                                                if !hits.is_empty() {
+                                            ) && !hits.is_empty() {
                                                     let mut lines =
                                                         Vec::with_capacity(hits.len());
                                                     for (uid, msg) in &hits {
@@ -3482,7 +3482,7 @@ pub fn build_line_channels(
                                                             &user_id,
                                                             &rate_limit_config,
                                                         )
-                                                        .map_err(|e| e)?;
+                                                        ?;
                                                     let session_id = format!("line-{context_id}");
                                                     state
                                                         .check_token_budget(
@@ -3490,8 +3490,7 @@ pub fn build_line_channels(
                                                             &user_id,
                                                             &guardrails_config,
                                                         )
-                                                        .await
-                                                        .map_err(|e| e)?;
+                                                        .await?;
                                                     let text =
                                                         opencrust_security::InputValidator::sanitize(&text);
                                                     if opencrust_security::InputValidator::check_prompt_injection(&text) {
@@ -3562,8 +3561,6 @@ pub fn build_line_channels(
                                                         }
                                                     }
                                                 }
-                                            }
-                                        }
                                     }
 
                                     // No RAG hits (or synthesis failed): full agent pipeline.


### PR DESCRIPTION
## Summary

- Add `synthesize_from_context()` to `AgentRuntime` — a single, tool-free LLM call that answers directly from retrieved group-chat history, preventing the model from invoking `FileRead`/`Bash` to re-verify context that already exists verbatim in the RAG hits
- Wire the new path into the LINE group-chat handler so RAG hits are answered via synthesis (with rate-limit, token-budget, and prompt-injection checks) before falling through to the full agent pipeline
- Falls back gracefully to the full agent pipeline when there are no hits or synthesis fails

## Test plan

- [ ] Unit test `synthesize_from_context` with a mock provider returning a non-empty response
- [ ] Unit test the fallback path when synthesis returns an error
- [ ] Integration test: LINE group message with matching RAG hits returns a response without invoking any tools
- [ ] Integration test: LINE group message with no RAG hits still reaches the agent pipeline normally
- [ ] Verify rate-limit / token-budget / prompt-injection checks fire on the synthesis path
- [ ] Confirm `tools: vec![]` prevents FileRead/Bash from being registered in the synthesis request

🤖 Generated with [Claude Code](https://claude.com/claude-code)