### PR TITLE
feat(agents,gateway): add file_patch, search_files, memory, send_message tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,6 +2655,7 @@ dependencies = [
  "opencrust-config",
  "opencrust-db",
  "opencrust-skills",
+ "regex",
  "reqwest 0.12.28",
  "rmcp",
  "serde",

--- a/crates/opencrust-agents/Cargo.toml
+++ b/crates/opencrust-agents/Cargo.toml
@@ -25,6 +25,7 @@ dashmap = { workspace = true }
 dirs = "6"
 chrono-tz = "0.10"
 cron = "0.15"
+regex = { workspace = true }
 
 rmcp = { workspace = true, features = ["client", "transport-child-process", "transport-io"], optional = true }
 

--- a/crates/opencrust-agents/src/lib.rs
+++ b/crates/opencrust-agents/src/lib.rs
@@ -20,9 +20,10 @@ pub use providers::{
 };
 pub use runtime::AgentRuntime;
 pub use tools::{
-    BashTool, CancelHeartbeat, CreateSkillTool, DocSearchTool, FileReadTool, FileWriteTool,
-    GoogleSearchTool, HandoffHandle, HandoffTool, ListDocumentsTool, ListHeartbeats,
-    ScheduleHeartbeat, Tool, ToolContext, ToolOutput, WebFetchTool, WebSearchTool,
+    BashTool, CancelHeartbeat, CreateSkillTool, DocSearchTool, FilePatchTool, FileReadTool,
+    FileWriteTool, GoogleSearchTool, HandoffHandle, HandoffTool, ListDocumentsTool, ListHeartbeats,
+    MemoryTool, OutboundMessage, ScheduleHeartbeat, SearchFilesTool, SendMessageHandle,
+    SendMessageTool, Tool, ToolContext, ToolOutput, WebFetchTool, WebSearchTool,
 };
 
 #[cfg(feature = "mcp")]

--- a/crates/opencrust-agents/src/tools/file_patch_tool.rs
+++ b/crates/opencrust-agents/src/tools/file_patch_tool.rs
@@ -1,0 +1,278 @@
+use async_trait::async_trait;
+use opencrust_common::{Error, Result};
+use std::path::PathBuf;
+
+use super::{Tool, ToolContext, ToolOutput};
+
+const MAX_FILE_BYTES: u64 = 1024 * 1024; // 1 MB
+
+/// Apply a targeted find-and-replace edit to a file without rewriting the whole thing.
+pub struct FilePatchTool {
+    allowed_directories: Option<Vec<PathBuf>>,
+}
+
+impl FilePatchTool {
+    pub fn new(allowed_directories: Option<Vec<PathBuf>>) -> Self {
+        Self {
+            allowed_directories,
+        }
+    }
+
+    fn validate_path(&self, path: &std::path::Path) -> Result<()> {
+        if path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(Error::Security("path traversal not allowed".into()));
+        }
+
+        if let Some(allowed) = &self.allowed_directories {
+            let parent = path
+                .parent()
+                .ok_or_else(|| Error::Agent("invalid path".into()))?;
+            let canonical = parent
+                .canonicalize()
+                .map_err(|e| Error::Agent(format!("cannot resolve parent path: {e}")))?;
+            if !allowed.iter().any(|dir| canonical.starts_with(dir)) {
+                return Err(Error::Security("path outside allowed directories".into()));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Tool for FilePatchTool {
+    fn name(&self) -> &str {
+        "file_patch"
+    }
+
+    fn description(&self) -> &str {
+        "Apply a targeted find-and-replace edit to a file. \
+         Safer than file_write for editing existing files — only the changed region is touched. \
+         Fails if old_string is not found or matches more than once \
+         (use replace_all: true to replace every occurrence)."
+    }
+
+    fn system_hint(&self) -> Option<&str> {
+        Some(
+            "Prefer file_patch over file_write when editing existing files — it is safer and \
+             produces minimal diffs. Provide enough context in old_string to make the match \
+             unique. Use replace_all: true only when you intentionally want every occurrence \
+             replaced.",
+        )
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file to edit"
+                },
+                "old_string": {
+                    "type": "string",
+                    "description": "The exact text to find. Must match exactly once unless replace_all is true."
+                },
+                "new_string": {
+                    "type": "string",
+                    "description": "The text to replace it with"
+                },
+                "replace_all": {
+                    "type": "boolean",
+                    "description": "Replace every occurrence of old_string (default: false)"
+                }
+            },
+            "required": ["path", "old_string", "new_string"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        _context: &ToolContext,
+        input: serde_json::Value,
+    ) -> Result<ToolOutput> {
+        let path_str = input
+            .get("path")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Agent("missing 'path' parameter".into()))?;
+
+        let old_string = input
+            .get("old_string")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Agent("missing 'old_string' parameter".into()))?;
+
+        let new_string = input
+            .get("new_string")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Agent("missing 'new_string' parameter".into()))?;
+
+        let replace_all = input
+            .get("replace_all")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let path = PathBuf::from(path_str);
+        self.validate_path(&path)?;
+
+        let metadata = tokio::fs::metadata(&path)
+            .await
+            .map_err(|e| Error::Agent(format!("cannot read file metadata: {e}")))?;
+
+        if metadata.len() > MAX_FILE_BYTES {
+            return Ok(ToolOutput::error(format!(
+                "file too large: {} bytes (limit: {} bytes)",
+                metadata.len(),
+                MAX_FILE_BYTES
+            )));
+        }
+
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .map_err(|e| Error::Agent(format!("failed to read file: {e}")))?;
+
+        let count = content.matches(old_string).count();
+
+        if count == 0 {
+            return Ok(ToolOutput::error(format!(
+                "old_string not found in {path_str}"
+            )));
+        }
+
+        if count > 1 && !replace_all {
+            return Ok(ToolOutput::error(format!(
+                "old_string matches {count} times in {path_str} — \
+                 add more context to make it unique, or use replace_all: true"
+            )));
+        }
+
+        let new_content = if replace_all {
+            content.replace(old_string, new_string)
+        } else {
+            content.replacen(old_string, new_string, 1)
+        };
+
+        tokio::fs::write(&path, &new_content)
+            .await
+            .map_err(|e| Error::Agent(format!("failed to write file: {e}")))?;
+
+        Ok(ToolOutput::success(format!(
+            "patched {path_str}: replaced {count} occurrence(s)"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            session_id: "test".into(),
+            user_id: None,
+            heartbeat_depth: 0,
+            allowed_tools: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn patches_single_occurrence() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write!(tmp, "hello world").unwrap();
+
+        let tool = FilePatchTool::new(None);
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "path": tmp.path().to_str().unwrap(),
+                    "old_string": "world",
+                    "new_string": "rust"
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error, "{}", output.content);
+        let result = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(result, "hello rust");
+    }
+
+    #[tokio::test]
+    async fn errors_when_old_string_not_found() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write!(tmp, "hello world").unwrap();
+
+        let tool = FilePatchTool::new(None);
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "path": tmp.path().to_str().unwrap(),
+                    "old_string": "goodbye",
+                    "new_string": "rust"
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(output.is_error);
+        assert!(output.content.contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn errors_on_ambiguous_match_without_replace_all() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write!(tmp, "foo foo foo").unwrap();
+
+        let tool = FilePatchTool::new(None);
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "path": tmp.path().to_str().unwrap(),
+                    "old_string": "foo",
+                    "new_string": "bar"
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(output.is_error);
+        assert!(output.content.contains("3 times"));
+    }
+
+    #[tokio::test]
+    async fn replace_all_replaces_every_occurrence() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        write!(tmp, "foo foo foo").unwrap();
+
+        let tool = FilePatchTool::new(None);
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "path": tmp.path().to_str().unwrap(),
+                    "old_string": "foo",
+                    "new_string": "bar",
+                    "replace_all": true
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error, "{}", output.content);
+        let result = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(result, "bar bar bar");
+    }
+
+    #[tokio::test]
+    async fn returns_error_on_missing_params() {
+        let tool = FilePatchTool::new(None);
+        assert!(tool.execute(&ctx(), serde_json::json!({})).await.is_err());
+    }
+}

--- a/crates/opencrust-agents/src/tools/memory_tool.rs
+++ b/crates/opencrust-agents/src/tools/memory_tool.rs
@@ -1,0 +1,284 @@
+use async_trait::async_trait;
+use opencrust_common::{Error, Result};
+use opencrust_db::{MemoryRole, MemoryStore, NewMemoryEntry, RecallQuery};
+use std::path::PathBuf;
+
+use super::{Tool, ToolContext, ToolOutput};
+
+const DEFAULT_RECALL_LIMIT: usize = 10;
+const MAX_RECALL_LIMIT: usize = 50;
+const MAX_CONTENT_BYTES: usize = 4096;
+
+/// Explicitly save or recall durable notes that persist across sessions.
+///
+/// Unlike conversation history (which is stored automatically), entries saved
+/// through this tool are tagged as explicit agent notes and survive session
+/// compaction. Use it to remember facts, preferences, or decisions that should
+/// be available in future conversations.
+pub struct MemoryTool {
+    db_path: PathBuf,
+}
+
+impl MemoryTool {
+    pub fn new(db_path: PathBuf) -> Self {
+        Self { db_path }
+    }
+}
+
+#[async_trait]
+impl Tool for MemoryTool {
+    fn name(&self) -> &str {
+        "memory"
+    }
+
+    fn description(&self) -> &str {
+        "Save a durable note to persistent memory, or recall previously saved notes. \
+         Saved notes survive across sessions and are not affected by conversation compaction. \
+         Use action \"save\" to persist a fact/preference/decision, \
+         and action \"recall\" to retrieve relevant notes by keyword."
+    }
+
+    fn system_hint(&self) -> Option<&str> {
+        Some(
+            "Use memory(action=\"save\") to persist important facts, user preferences, or \
+             decisions that should be available in future sessions. \
+             Use memory(action=\"recall\", query=\"...\") to retrieve relevant notes before \
+             answering questions about past interactions or user-specific context.",
+        )
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["save", "recall"],
+                    "description": "\"save\" to persist a note, \"recall\" to search saved notes"
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The note to save (required for action=\"save\")"
+                },
+                "query": {
+                    "type": "string",
+                    "description": "Keyword or phrase to search for (required for action=\"recall\")"
+                },
+                "limit": {
+                    "type": "number",
+                    "description": "Maximum number of notes to return for recall (1–50, default 10)"
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(&self, context: &ToolContext, input: serde_json::Value) -> Result<ToolOutput> {
+        let action = input
+            .get("action")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Agent("missing 'action' parameter".into()))?;
+
+        match action {
+            "save" => {
+                let content = input
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        Error::Agent("missing 'content' parameter for action=save".into())
+                    })?;
+
+                if content.trim().is_empty() {
+                    return Ok(ToolOutput::error("content cannot be empty"));
+                }
+
+                if content.len() > MAX_CONTENT_BYTES {
+                    return Ok(ToolOutput::error(format!(
+                        "content too large: {} bytes (limit: {} bytes)",
+                        content.len(),
+                        MAX_CONTENT_BYTES
+                    )));
+                }
+
+                let store = MemoryStore::open(&self.db_path)
+                    .map_err(|e| Error::Agent(format!("failed to open memory store: {e}")))?;
+
+                let entry = NewMemoryEntry {
+                    session_id: context.session_id.clone(),
+                    channel_id: None,
+                    user_id: context.user_id.clone(),
+                    continuity_key: context.user_id.clone(),
+                    role: MemoryRole::System,
+                    content: content.to_string(),
+                    embedding: None,
+                    embedding_model: None,
+                    metadata: serde_json::json!({ "source": "explicit" }),
+                };
+
+                let id = store
+                    .remember(entry)
+                    .await
+                    .map_err(|e| Error::Agent(format!("failed to save memory: {e}")))?;
+
+                Ok(ToolOutput::success(format!("saved note (id: {id})")))
+            }
+
+            "recall" => {
+                let query = input.get("query").and_then(|v| v.as_str()).ok_or_else(|| {
+                    Error::Agent("missing 'query' parameter for action=recall".into())
+                })?;
+
+                let limit = input
+                    .get("limit")
+                    .and_then(|v| v.as_u64())
+                    .map(|v| (v as usize).clamp(1, MAX_RECALL_LIMIT))
+                    .unwrap_or(DEFAULT_RECALL_LIMIT);
+
+                let store = MemoryStore::open(&self.db_path)
+                    .map_err(|e| Error::Agent(format!("failed to open memory store: {e}")))?;
+
+                let entries = store
+                    .recall(RecallQuery {
+                        query_text: Some(query.to_string()),
+                        query_embedding: None,
+                        session_id: None,
+                        continuity_key: context.user_id.clone(),
+                        limit,
+                    })
+                    .await
+                    .map_err(|e| Error::Agent(format!("recall failed: {e}")))?;
+
+                // Filter to only explicitly saved notes
+                let notes: Vec<_> = entries
+                    .iter()
+                    .filter(|e| {
+                        e.metadata.get("source").and_then(|s| s.as_str()) == Some("explicit")
+                    })
+                    .collect();
+
+                if notes.is_empty() {
+                    return Ok(ToolOutput::success(format!(
+                        "No saved notes found matching {:?}.",
+                        query
+                    )));
+                }
+
+                let mut output = format!("{} note(s) found:\n\n", notes.len());
+                for (i, note) in notes.iter().enumerate() {
+                    output.push_str(&format!(
+                        "[{}/{}] ({})\n{}\n\n",
+                        i + 1,
+                        notes.len(),
+                        note.created_at.format("%Y-%m-%d %H:%M UTC"),
+                        note.content,
+                    ));
+                }
+
+                Ok(ToolOutput::success(output.trim_end()))
+            }
+
+            other => Ok(ToolOutput::error(format!(
+                "unknown action {:?} — must be \"save\" or \"recall\"",
+                other
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            session_id: "test-session".into(),
+            user_id: Some("user-1".into()),
+            heartbeat_depth: 0,
+            allowed_tools: None,
+        }
+    }
+
+    fn make_tool() -> (MemoryTool, NamedTempFile) {
+        let tmp = NamedTempFile::new().unwrap();
+        // Initialise schema
+        MemoryStore::open(tmp.path()).unwrap();
+        let tool = MemoryTool::new(tmp.path().to_path_buf());
+        (tool, tmp)
+    }
+
+    #[tokio::test]
+    async fn save_and_recall_round_trip() {
+        let (tool, _tmp) = make_tool();
+
+        let save = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({ "action": "save", "content": "user prefers dark mode" }),
+            )
+            .await
+            .unwrap();
+        assert!(!save.is_error, "{}", save.content);
+
+        let recall = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({ "action": "recall", "query": "dark mode" }),
+            )
+            .await
+            .unwrap();
+        assert!(!recall.is_error, "{}", recall.content);
+        assert!(recall.content.contains("dark mode"));
+    }
+
+    #[tokio::test]
+    async fn recall_returns_no_results_when_empty() {
+        let (tool, _tmp) = make_tool();
+
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({ "action": "recall", "query": "nothing here" }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error);
+        assert!(output.content.contains("No saved notes"));
+    }
+
+    #[tokio::test]
+    async fn save_rejects_empty_content() {
+        let (tool, _tmp) = make_tool();
+
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({ "action": "save", "content": "   " }),
+            )
+            .await
+            .unwrap();
+
+        assert!(output.is_error);
+    }
+
+    #[tokio::test]
+    async fn unknown_action_returns_error() {
+        let (tool, _tmp) = make_tool();
+
+        let output = tool
+            .execute(&ctx(), serde_json::json!({ "action": "delete" }))
+            .await
+            .unwrap();
+
+        assert!(output.is_error);
+        assert!(output.content.contains("unknown action"));
+    }
+
+    #[tokio::test]
+    async fn missing_action_returns_error() {
+        let (tool, _tmp) = make_tool();
+        let result = tool.execute(&ctx(), serde_json::json!({})).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/opencrust-agents/src/tools/mod.rs
+++ b/crates/opencrust-agents/src/tools/mod.rs
@@ -1,24 +1,32 @@
 pub mod bash_tool;
 pub mod create_skill_tool;
 pub mod doc_search_tool;
+pub mod file_patch_tool;
 pub mod file_read_tool;
 pub mod file_write_tool;
 pub mod google_search_tool;
 pub mod handoff_tool;
 pub mod list_documents_tool;
+pub mod memory_tool;
 pub mod schedule;
+pub mod search_files_tool;
+pub mod send_message_tool;
 pub mod web_fetch_tool;
 pub mod web_search_tool;
 
 pub use bash_tool::BashTool;
 pub use create_skill_tool::CreateSkillTool;
 pub use doc_search_tool::DocSearchTool;
+pub use file_patch_tool::FilePatchTool;
 pub use file_read_tool::FileReadTool;
 pub use file_write_tool::FileWriteTool;
 pub use google_search_tool::GoogleSearchTool;
 pub use handoff_tool::{HandoffHandle, HandoffTool};
 pub use list_documents_tool::ListDocumentsTool;
+pub use memory_tool::MemoryTool;
 pub use schedule::{CancelHeartbeat, ListHeartbeats, ScheduleHeartbeat};
+pub use search_files_tool::SearchFilesTool;
+pub use send_message_tool::{OutboundMessage, SendMessageHandle, SendMessageTool};
 pub use web_fetch_tool::WebFetchTool;
 pub use web_search_tool::WebSearchTool;
 

--- a/crates/opencrust-agents/src/tools/search_files_tool.rs
+++ b/crates/opencrust-agents/src/tools/search_files_tool.rs
@@ -1,0 +1,403 @@
+use async_trait::async_trait;
+use opencrust_common::{Error, Result};
+use regex::RegexBuilder;
+use std::path::{Path, PathBuf};
+
+use super::{Tool, ToolContext, ToolOutput};
+
+const DEFAULT_MAX_RESULTS: usize = 50;
+const HARD_MAX_RESULTS: usize = 200;
+const MAX_FILE_BYTES: u64 = 512 * 1024; // 512 KB per file
+
+/// Search file contents by regex pattern, or find files by name glob.
+pub struct SearchFilesTool;
+
+impl SearchFilesTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SearchFilesTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convert a simple glob pattern (*, ?) into a full-match regex string.
+fn glob_to_regex(glob: &str) -> String {
+    let mut out = String::from("^");
+    for ch in glob.chars() {
+        match ch {
+            '*' => out.push_str(".*"),
+            '?' => out.push('.'),
+            c if ".\\ +^${}[]|()".contains(c) => {
+                out.push('\\');
+                out.push(c);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('$');
+    out
+}
+
+/// Iterative directory walker — returns all file paths under `dir`.
+async fn walk_files(root: &Path, glob_regex: Option<&regex::Regex>) -> Vec<PathBuf> {
+    let mut results = Vec::new();
+    let mut dirs = vec![root.to_path_buf()];
+
+    while let Some(dir) = dirs.pop() {
+        let Ok(mut rd) = tokio::fs::read_dir(&dir).await else {
+            continue;
+        };
+
+        while let Ok(Some(entry)) = rd.next_entry().await {
+            let path = entry.path();
+            let Ok(meta) = tokio::fs::metadata(&path).await else {
+                continue;
+            };
+
+            if meta.is_dir() {
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if !name.starts_with('.') {
+                    dirs.push(path);
+                }
+            } else if meta.is_file() {
+                let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if let Some(rx) = glob_regex {
+                    if !rx.is_match(file_name) {
+                        continue;
+                    }
+                }
+                results.push(path);
+            }
+        }
+    }
+
+    results
+}
+
+#[async_trait]
+impl Tool for SearchFilesTool {
+    fn name(&self) -> &str {
+        "search_files"
+    }
+
+    fn description(&self) -> &str {
+        "Search file contents for a regex pattern, or find files by name glob. \
+         Returns matching lines with file path and line number. \
+         Use instead of running grep/find via bash."
+    }
+
+    fn system_hint(&self) -> Option<&str> {
+        Some(
+            "Use search_files instead of bash grep/find for searching code or text. \
+             Supply a glob (e.g. \"*.rs\") to restrict which files are searched.",
+        )
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Regex pattern to search for in file contents"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Directory (or file) to search in (default: current working directory)"
+                },
+                "glob": {
+                    "type": "string",
+                    "description": "File name glob filter, e.g. \"*.rs\" or \"*.{ts,tsx}\" (default: all files)"
+                },
+                "case_sensitive": {
+                    "type": "boolean",
+                    "description": "Case-sensitive match (default: false)"
+                },
+                "max_results": {
+                    "type": "number",
+                    "description": "Maximum number of matching lines to return (1–200, default 50)"
+                }
+            },
+            "required": ["pattern"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        _context: &ToolContext,
+        input: serde_json::Value,
+    ) -> Result<ToolOutput> {
+        let pattern = input
+            .get("pattern")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Agent("missing 'pattern' parameter".into()))?;
+
+        let search_path = input
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let glob = input.get("glob").and_then(|v| v.as_str());
+
+        let case_sensitive = input
+            .get("case_sensitive")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let max_results = input
+            .get("max_results")
+            .and_then(|v| v.as_u64())
+            .map(|v| (v as usize).clamp(1, HARD_MAX_RESULTS))
+            .unwrap_or(DEFAULT_MAX_RESULTS);
+
+        // Compile the search regex
+        let regex = RegexBuilder::new(pattern)
+            .case_insensitive(!case_sensitive)
+            .build()
+            .map_err(|e| Error::Agent(format!("invalid regex pattern: {e}")))?;
+
+        // Compile the glob filter regex if provided
+        let glob_regex = if let Some(g) = glob {
+            let glob_pattern = glob_to_regex(g);
+            Some(
+                RegexBuilder::new(&glob_pattern)
+                    .case_insensitive(true)
+                    .build()
+                    .map_err(|e| Error::Agent(format!("invalid glob pattern: {e}")))?,
+            )
+        } else {
+            None
+        };
+
+        // Collect files to search
+        let meta = tokio::fs::metadata(&search_path)
+            .await
+            .map_err(|e| Error::Agent(format!("cannot access path: {e}")))?;
+
+        let files = if meta.is_file() {
+            vec![search_path.clone()]
+        } else {
+            walk_files(&search_path, glob_regex.as_ref()).await
+        };
+
+        if files.is_empty() {
+            return Ok(ToolOutput::success(
+                "No files found matching the given path and glob.",
+            ));
+        }
+
+        let mut matches: Vec<String> = Vec::new();
+
+        'files: for file_path in &files {
+            // Skip files that are too large
+            let Ok(fm) = tokio::fs::metadata(file_path).await else {
+                continue;
+            };
+            if fm.len() > MAX_FILE_BYTES {
+                continue;
+            }
+
+            let Ok(content) = tokio::fs::read_to_string(file_path).await else {
+                // Skip binary / unreadable files
+                continue;
+            };
+
+            let display = file_path.display().to_string();
+
+            for (line_no, line) in content.lines().enumerate() {
+                if regex.is_match(line) {
+                    matches.push(format!("{}:{}: {}", display, line_no + 1, line));
+                    if matches.len() >= max_results {
+                        break 'files;
+                    }
+                }
+            }
+        }
+
+        if matches.is_empty() {
+            return Ok(ToolOutput::success(format!(
+                "No matches found for pattern {:?} in {} file(s).",
+                pattern,
+                files.len()
+            )));
+        }
+
+        let truncated = matches.len() >= max_results;
+        let mut output = format!(
+            "{} match(es) in {} file(s):\n\n",
+            matches.len(),
+            files.len()
+        );
+        output.push_str(&matches.join("\n"));
+        if truncated {
+            output.push_str(&format!(
+                "\n\n... results truncated at {max_results} — use max_results or a more specific pattern."
+            ));
+        }
+
+        Ok(ToolOutput::success(output))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::{NamedTempFile, TempDir};
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            session_id: "test".into(),
+            user_id: None,
+            heartbeat_depth: 0,
+            allowed_tools: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn finds_pattern_in_file() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "hello world").unwrap();
+        writeln!(tmp, "goodbye world").unwrap();
+        writeln!(tmp, "hello rust").unwrap();
+
+        let tool = SearchFilesTool::new();
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "pattern": "hello",
+                    "path": tmp.path().to_str().unwrap()
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error, "{}", output.content);
+        assert!(output.content.contains("hello world"));
+        assert!(output.content.contains("hello rust"));
+        assert!(!output.content.contains("goodbye"));
+    }
+
+    #[tokio::test]
+    async fn case_insensitive_by_default() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "Hello World").unwrap();
+
+        let tool = SearchFilesTool::new();
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "pattern": "hello",
+                    "path": tmp.path().to_str().unwrap()
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error, "{}", output.content);
+        assert!(output.content.contains("Hello World"));
+    }
+
+    #[tokio::test]
+    async fn case_sensitive_mode() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "Hello World").unwrap();
+        writeln!(tmp, "hello world").unwrap();
+
+        let tool = SearchFilesTool::new();
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "pattern": "hello",
+                    "path": tmp.path().to_str().unwrap(),
+                    "case_sensitive": true
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error, "{}", output.content);
+        assert!(output.content.contains("hello world"));
+        assert!(!output.content.contains("Hello World"));
+    }
+
+    #[tokio::test]
+    async fn glob_filter_restricts_files() {
+        let dir = TempDir::new().unwrap();
+        let rs_file = dir.path().join("main.rs");
+        let txt_file = dir.path().join("notes.txt");
+        std::fs::write(&rs_file, "fn main() {}\n").unwrap();
+        std::fs::write(&txt_file, "fn main is not here\n").unwrap();
+
+        let tool = SearchFilesTool::new();
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "pattern": "fn main",
+                    "path": dir.path().to_str().unwrap(),
+                    "glob": "*.rs"
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error, "{}", output.content);
+        assert!(output.content.contains("main.rs"));
+        assert!(!output.content.contains("notes.txt"));
+    }
+
+    #[tokio::test]
+    async fn no_match_returns_success_message() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        writeln!(tmp, "nothing here").unwrap();
+
+        let tool = SearchFilesTool::new();
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "pattern": "zzznomatch",
+                    "path": tmp.path().to_str().unwrap()
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error);
+        assert!(output.content.contains("No matches"));
+    }
+
+    #[tokio::test]
+    async fn invalid_regex_returns_error() {
+        let tool = SearchFilesTool::new();
+        let result = tool
+            .execute(&ctx(), serde_json::json!({ "pattern": "[invalid" }))
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn glob_to_regex_wildcard() {
+        let rx = regex::Regex::new(&glob_to_regex("*.rs")).unwrap();
+        assert!(rx.is_match("main.rs"));
+        assert!(rx.is_match("lib.rs"));
+        assert!(!rx.is_match("main.txt"));
+    }
+
+    #[test]
+    fn glob_to_regex_question_mark() {
+        let rx = regex::Regex::new(&glob_to_regex("file?.txt")).unwrap();
+        assert!(rx.is_match("file1.txt"));
+        assert!(rx.is_match("fileA.txt"));
+        assert!(!rx.is_match("file12.txt"));
+    }
+}

--- a/crates/opencrust-agents/src/tools/search_files_tool.rs
+++ b/crates/opencrust-agents/src/tools/search_files_tool.rs
@@ -65,10 +65,10 @@ async fn walk_files(root: &Path, glob_regex: Option<&regex::Regex>) -> Vec<PathB
                 }
             } else if meta.is_file() {
                 let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                if let Some(rx) = glob_regex {
-                    if !rx.is_match(file_name) {
-                        continue;
-                    }
+                if let Some(rx) = glob_regex
+                    && !rx.is_match(file_name)
+                {
+                    continue;
                 }
                 results.push(path);
             }

--- a/crates/opencrust-agents/src/tools/send_message_tool.rs
+++ b/crates/opencrust-agents/src/tools/send_message_tool.rs
@@ -1,0 +1,221 @@
+use async_trait::async_trait;
+use opencrust_common::{Error, Result};
+use std::sync::{Arc, OnceLock};
+use tokio::sync::mpsc;
+
+use super::{Tool, ToolContext, ToolOutput};
+
+/// Outbound message dispatched by the tool to the gateway.
+#[derive(Debug, Clone)]
+pub struct OutboundMessage {
+    /// Channel key from config (e.g. "telegram", "discord", "slack").
+    pub channel_id: String,
+    /// Platform-native recipient identifier (chat_id, user_id, channel_id, etc.).
+    pub recipient_id: String,
+    /// Message text to deliver.
+    pub text: String,
+}
+
+/// Send a proactive message to a connected channel from agent code.
+///
+/// The tool holds a `mpsc::Sender` that is wired at bootstrap time via
+/// `SendMessageHandle::wire()`. Until wired the tool returns an error so it
+/// fails safely without panicking.
+pub struct SendMessageTool {
+    sender: Arc<OnceLock<mpsc::Sender<OutboundMessage>>>,
+}
+
+impl SendMessageTool {
+    /// Create the tool and return the accompanying handle used for wiring.
+    pub fn new() -> (Self, SendMessageHandle) {
+        let cell = Arc::new(OnceLock::new());
+        let tool = Self {
+            sender: Arc::clone(&cell),
+        };
+        let handle = SendMessageHandle { cell };
+        (tool, handle)
+    }
+}
+
+impl Default for SendMessageTool {
+    fn default() -> Self {
+        Self::new().0
+    }
+}
+
+/// Returned by `SendMessageTool::new()`.
+/// Call `wire()` once the gateway's outbound receiver is set up.
+pub struct SendMessageHandle {
+    cell: Arc<OnceLock<mpsc::Sender<OutboundMessage>>>,
+}
+
+impl SendMessageHandle {
+    /// Wire the tool to the outbound sender. Safe to call only once; subsequent
+    /// calls are silently ignored (the `OnceLock` guarantees idempotency).
+    pub fn wire(&self, sender: mpsc::Sender<OutboundMessage>) {
+        let _ = self.cell.set(sender);
+    }
+}
+
+#[async_trait]
+impl Tool for SendMessageTool {
+    fn name(&self) -> &str {
+        "send_message"
+    }
+
+    fn description(&self) -> &str {
+        "Send a proactive message to any connected channel. \
+         Use this to deliver notifications, alerts, or scheduled-job results \
+         to a specific user or chat on a given platform."
+    }
+
+    fn system_hint(&self) -> Option<&str> {
+        Some(
+            "Use send_message to deliver a message to a channel other than the one the user \
+             is currently on, or to notify a specific recipient without waiting for their reply. \
+             channel_id must match a key in the `channels:` section of config.yml \
+             (e.g. \"telegram\", \"discord\", \"slack\"). \
+             recipient_id is the platform-native chat or user ID.",
+        )
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "channel_id": {
+                    "type": "string",
+                    "description": "Channel key from config (e.g. \"telegram\", \"discord\", \"slack\")"
+                },
+                "recipient_id": {
+                    "type": "string",
+                    "description": "Platform-native recipient identifier (chat_id, user_id, channel name, etc.)"
+                },
+                "text": {
+                    "type": "string",
+                    "description": "Message text to send"
+                }
+            },
+            "required": ["channel_id", "recipient_id", "text"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        _context: &ToolContext,
+        input: serde_json::Value,
+    ) -> Result<ToolOutput> {
+        let channel_id = input
+            .get("channel_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Agent("missing 'channel_id' parameter".into()))?
+            .to_string();
+
+        let recipient_id = input
+            .get("recipient_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Agent("missing 'recipient_id' parameter".into()))?
+            .to_string();
+
+        let text = input
+            .get("text")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| Error::Agent("missing 'text' parameter".into()))?
+            .to_string();
+
+        if text.trim().is_empty() {
+            return Ok(ToolOutput::error("text cannot be empty"));
+        }
+
+        let sender = self.sender.get().ok_or_else(|| {
+            Error::Agent(
+                "send_message is not wired — call SendMessageHandle::wire() in bootstrap".into(),
+            )
+        })?;
+
+        sender
+            .send(OutboundMessage {
+                channel_id: channel_id.clone(),
+                recipient_id: recipient_id.clone(),
+                text,
+            })
+            .await
+            .map_err(|_| Error::Agent("outbound message channel closed".into()))?;
+
+        Ok(ToolOutput::success(format!(
+            "message queued for delivery to {channel_id}/{recipient_id}"
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ToolContext {
+        ToolContext {
+            session_id: "test".into(),
+            user_id: None,
+            heartbeat_depth: 0,
+            allowed_tools: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_error_when_not_wired() {
+        let (tool, _handle) = SendMessageTool::new();
+        let result = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "channel_id": "telegram",
+                    "recipient_id": "123",
+                    "text": "hello"
+                }),
+            )
+            .await;
+        // Unwired tool returns Err (not wired)
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn delivers_message_when_wired() {
+        let (tool, handle) = SendMessageTool::new();
+        let (tx, mut rx) = mpsc::channel(8);
+        handle.wire(tx);
+
+        let output = tool
+            .execute(
+                &ctx(),
+                serde_json::json!({
+                    "channel_id": "telegram",
+                    "recipient_id": "999",
+                    "text": "hello from agent"
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.is_error, "{}", output.content);
+
+        let msg = rx.recv().await.unwrap();
+        assert_eq!(msg.channel_id, "telegram");
+        assert_eq!(msg.recipient_id, "999");
+        assert_eq!(msg.text, "hello from agent");
+    }
+
+    #[tokio::test]
+    async fn wire_twice_is_idempotent() {
+        let (_tool, handle) = SendMessageTool::new();
+        let (tx1, _rx1) = mpsc::channel(1);
+        let (tx2, _rx2) = mpsc::channel(1);
+        handle.wire(tx1);
+        handle.wire(tx2); // second call must not panic
+    }
+
+    #[tokio::test]
+    async fn missing_params_return_err() {
+        let (tool, _) = SendMessageTool::new();
+        assert!(tool.execute(&ctx(), serde_json::json!({})).await.is_err());
+    }
+}

--- a/crates/opencrust-cli/src/doctor.rs
+++ b/crates/opencrust-cli/src/doctor.rs
@@ -114,7 +114,7 @@ async fn check_llm_providers(config: &AppConfig) -> Vec<(String, Check)> {
     }
 
     // build_agent_runtime is infallible and logs warnings for bad config entries.
-    let runtime = opencrust_gateway::bootstrap::build_agent_runtime(config).await;
+    let (runtime, _send_handle) = opencrust_gateway::bootstrap::build_agent_runtime(config).await;
 
     match runtime.health_check_all().await {
         Ok(results) => {

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -5,9 +5,10 @@ use std::sync::{Arc, Mutex};
 use opencrust_agents::tools::Tool;
 use opencrust_agents::{
     AgentRuntime, AnthropicProvider, BashTool, ChatMessage, CohereEmbeddingProvider,
-    CreateSkillTool, DocSearchTool, FileReadTool, FileWriteTool, GoogleSearchTool,
-    ListDocumentsTool, McpManager, OllamaEmbeddingProvider, OllamaProvider, OpenAiProvider,
-    WebFetchTool, WebSearchTool,
+    CreateSkillTool, DocSearchTool, FilePatchTool, FileReadTool, FileWriteTool, GoogleSearchTool,
+    ListDocumentsTool, McpManager, MemoryTool, OllamaEmbeddingProvider, OllamaProvider,
+    OpenAiProvider, SearchFilesTool, SendMessageHandle, SendMessageTool, WebFetchTool,
+    WebSearchTool,
 };
 use opencrust_channels::{
     ChannelResponse, MediaAttachment, MqttChannel, MqttOnMessageFn, SlackChannel, SlackGroupFilter,
@@ -57,7 +58,7 @@ pub(crate) fn resolve_api_key(
 }
 
 /// Build a fully-configured `AgentRuntime` from the application config.
-pub async fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
+pub async fn build_agent_runtime(config: &AppConfig) -> (AgentRuntime, SendMessageHandle) {
     let mut runtime = AgentRuntime::new();
 
     // --- LLM Providers ---
@@ -412,6 +413,8 @@ pub async fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
     runtime.register_tool(Box::new(BashTool::new(None)));
     runtime.register_tool(Box::new(FileReadTool::new(None)));
     runtime.register_tool(Box::new(FileWriteTool::new(None)));
+    runtime.register_tool(Box::new(FilePatchTool::new(None)));
+    runtime.register_tool(Box::new(SearchFilesTool::new()));
     runtime.register_tool(Box::new(WebFetchTool::new(None)));
 
     // Self-learning: agent can save reusable skills discovered during conversations.
@@ -571,8 +574,17 @@ pub async fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
             info!("doc_search tool registered ({mode} search)");
             runtime.register_tool(Box::new(ListDocumentsTool::new(memory_db_path.clone())));
             info!("list_documents tool registered");
+
+            // Explicit persistent memory tool — agent-initiated save/recall across sessions.
+            runtime.register_tool(Box::new(MemoryTool::new(memory_db_path.clone())));
+            info!("memory tool registered");
         }
     }
+
+    // --- send_message tool (wired via handle returned to caller) ---
+    let (send_msg_tool, send_msg_handle) = SendMessageTool::new();
+    runtime.register_tool(Box::new(send_msg_tool));
+    info!("send_message tool registered (wire via SendMessageHandle before use)");
 
     // --- Agent Config ---
     if let Some(prompt) = &config.agent.system_prompt {
@@ -624,7 +636,7 @@ pub async fn build_agent_runtime(config: &AppConfig) -> AgentRuntime {
         Err(e) => warn!("failed to read dna.md: {e}"),
     }
 
-    runtime
+    (runtime, send_msg_handle)
 }
 
 /// Resolve MCP server env vars through the vault. Empty values trigger a
@@ -4001,7 +4013,7 @@ mod tests {
     #[tokio::test]
     async fn build_agent_runtime_empty_config_no_crash() {
         let config = AppConfig::default();
-        let runtime = build_agent_runtime(&config).await;
+        let (runtime, _handle) = build_agent_runtime(&config).await;
         // Should succeed with no providers or tools crashing
         assert!(runtime.system_prompt().is_none());
     }
@@ -4020,7 +4032,7 @@ mod tests {
             },
         );
         // Should not panic — unknown providers are logged and skipped
-        let _runtime = build_agent_runtime(&config).await;
+        let _r = build_agent_runtime(&config).await;
     }
 
     #[tokio::test]
@@ -4037,7 +4049,7 @@ mod tests {
             },
         );
         // Should register the vllm provider without panicking
-        let _runtime = build_agent_runtime(&config).await;
+        let _r = build_agent_runtime(&config).await;
     }
 
     #[test]

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -35,7 +35,7 @@ impl GatewayServer {
     pub async fn run(self) -> Result<()> {
         let addr = format!("{}:{}", self.config.gateway.host, self.config.gateway.port);
 
-        let mut agents = build_agent_runtime(&self.config).await;
+        let (mut agents, send_msg_handle) = build_agent_runtime(&self.config).await;
 
         // Connect MCP servers and register their tools
         let (mcp_manager_arc, mcp_tools, mcp_instructions) = build_mcp_tools(&self.config).await;
@@ -88,9 +88,25 @@ impl GatewayServer {
             }
         };
 
-        // Wrap in Arc now that all &mut setup is complete, then wire the HandoffTool.
+        // Wrap in Arc now that all &mut setup is complete, then wire deferred tools.
         let agents = Arc::new(agents);
         handoff_handle.wire(&agents);
+        // SendMessageTool: create an outbound channel and spawn a dispatcher task.
+        // The dispatcher currently logs the message; channel-specific delivery
+        // is wired per channel adapter in a follow-up.
+        let (send_tx, mut send_rx) =
+            tokio::sync::mpsc::channel::<opencrust_agents::OutboundMessage>(64);
+        send_msg_handle.wire(send_tx);
+        tokio::spawn(async move {
+            while let Some(msg) = send_rx.recv().await {
+                tracing::info!(
+                    channel_id = %msg.channel_id,
+                    recipient_id = %msg.recipient_id,
+                    "outbound message queued (channel delivery not yet wired): {}",
+                    msg.text
+                );
+            }
+        });
         let mut state = AppState::new(self.config, Arc::clone(&agents), channels);
         state.mcp_manager_arc = Some(Arc::clone(&mcp_manager_arc));
 

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -91,22 +91,11 @@ impl GatewayServer {
         // Wrap in Arc now that all &mut setup is complete, then wire deferred tools.
         let agents = Arc::new(agents);
         handoff_handle.wire(&agents);
-        // SendMessageTool: create an outbound channel and spawn a dispatcher task.
-        // The dispatcher currently logs the message; channel-specific delivery
-        // is wired per channel adapter in a follow-up.
-        let (send_tx, mut send_rx) =
+        // SendMessageTool: create an outbound channel and wire the tool now.
+        // The dispatcher task is spawned later, after channel_senders are populated.
+        let (send_tx, send_rx) =
             tokio::sync::mpsc::channel::<opencrust_agents::OutboundMessage>(64);
         send_msg_handle.wire(send_tx);
-        tokio::spawn(async move {
-            while let Some(msg) = send_rx.recv().await {
-                tracing::info!(
-                    channel_id = %msg.channel_id,
-                    recipient_id = %msg.recipient_id,
-                    "outbound message queued (channel delivery not yet wired): {}",
-                    msg.text
-                );
-            }
-        });
         let mut state = AppState::new(self.config, Arc::clone(&agents), channels);
         state.mcp_manager_arc = Some(Arc::clone(&mcp_manager_arc));
 
@@ -365,6 +354,57 @@ impl GatewayServer {
                 }
                 shutdown_signal().await;
                 channel.disconnect().await.ok();
+            });
+        }
+
+        // Spawn the send_message dispatcher now that all channel_senders are registered.
+        // Routes OutboundMessage from the agent tool to the correct channel adapter.
+        {
+            let dispatcher_state = Arc::clone(&state);
+            let mut rx = send_rx;
+            tokio::spawn(async move {
+                while let Some(msg) = rx.recv().await {
+                    let Some(sender) = dispatcher_state
+                        .channel_senders
+                        .get(msg.channel_id.as_str())
+                        .map(|s| Arc::clone(&*s))
+                    else {
+                        tracing::warn!(
+                            channel_id = %msg.channel_id,
+                            "send_message: no sender registered for channel"
+                        );
+                        continue;
+                    };
+                    let metadata = match msg.channel_id.as_str() {
+                        "telegram" => {
+                            let chat_id: i64 = msg.recipient_id.parse().unwrap_or(0);
+                            serde_json::json!({ "telegram_chat_id": chat_id })
+                        }
+                        "line" => serde_json::json!({ "line_user_id": msg.recipient_id }),
+                        _ => serde_json::json!({ "recipient_id": msg.recipient_id }),
+                    };
+                    let mut message = Message::text(
+                        SessionId::new(),
+                        ChannelId::from_string(msg.channel_id.clone()),
+                        UserId::new(),
+                        MessageDirection::Outgoing,
+                        msg.text.clone(),
+                    );
+                    message.metadata = metadata;
+                    if let Err(e) = sender.send_message(&message).await {
+                        tracing::warn!(
+                            channel_id = %msg.channel_id,
+                            recipient_id = %msg.recipient_id,
+                            "send_message delivery failed: {e}"
+                        );
+                    } else {
+                        tracing::info!(
+                            channel_id = %msg.channel_id,
+                            recipient_id = %msg.recipient_id,
+                            "send_message delivered"
+                        );
+                    }
+                }
             });
         }
 


### PR DESCRIPTION
## Summary

- Add 4 new agent tools: `file_patch`, `search_files`, `memory`, `send_message`
- Wire `send_message` dispatcher to deliver outbound messages through registered channel adapters (Telegram, LINE)

## Details

### New tools
- **`file_patch`**: Targeted find-and-replace on files — safer than `file_write` for edits
- **`search_files`**: Regex search across directory tree with glob filtering — replaces bash `grep`/`find`
- **`memory`**: Explicit cross-session note save/recall via `MemoryStore` (survives session compaction)
- **`send_message`**: Proactive outbound messaging to any registered channel

### Dispatcher wiring (`send_message`)
Previously the tool only logged outbound messages. Now the dispatcher:
- Spawns **after** all `channel_senders` are registered in `AppState`
- Routes `OutboundMessage` to the correct `ChannelSender` by `channel_id`
- Builds `opencrust_common::Message` with channel-specific metadata (`telegram_chat_id` / `line_user_id`)
- Warns on unknown channel IDs instead of silently dropping

## Test plan
- [x] `cargo test -p opencrust-agents` — all tool unit tests pass
- [x] `cargo test -p opencrust-gateway` — bootstrap/doctor call sites pass
- [ ] Manual: agent calls `send_message("telegram", "<chat_id>", "hello")` → message delivered
- [ ] Manual: agent calls `send_message("line", "<user_id>", "hello")` → message delivered
- [ ] Manual: unknown `channel_id` → warning logged, no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)