### PR TITLE
feat: trajectory collection for tool-loop observability

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -10,6 +10,7 @@ use futures::future::join_all;
 use opencrust_common::{Error, Result};
 use opencrust_db::{
     DocumentStore, MemoryEntry, MemoryProvider, MemoryRole, NewMemoryEntry, RecallQuery,
+    TrajectoryStore,
 };
 use tokio::sync::mpsc;
 use tracing::{info, instrument, warn};
@@ -80,6 +81,10 @@ pub struct AgentRuntime {
     debug: bool,
     /// Debug info accumulated during message processing, keyed by session_id.
     debug_accumulator: Mutex<HashMap<String, Vec<String>>>,
+    /// Optional trajectory store. When set, every tool call and turn end is persisted.
+    trajectory_store: Option<Arc<TrajectoryStore>>,
+    /// Per-session turn counter used to order trajectory events.
+    session_turn_index: DashMap<String, u32>,
     /// Path to the document store DB for auto-RAG injection.
     doc_db_path: Option<PathBuf>,
     /// Cached document store opened once at startup for auto-RAG.
@@ -136,6 +141,8 @@ impl AgentRuntime {
             session_skills_override: DashMap::new(),
             debug: false,
             debug_accumulator: Mutex::new(HashMap::new()),
+            trajectory_store: None,
+            session_turn_index: DashMap::new(),
         }
     }
 
@@ -304,6 +311,58 @@ impl AgentRuntime {
 
     pub fn set_recall_limit(&mut self, limit: usize) {
         self.recall_limit = limit;
+    }
+
+    pub fn set_trajectory_store(&mut self, store: Arc<TrajectoryStore>) {
+        self.trajectory_store = Some(store);
+    }
+
+    /// Increment the per-session turn counter and return the index for this turn.
+    fn traj_advance_turn(&self, session_id: &str) -> u32 {
+        let mut entry = self
+            .session_turn_index
+            .entry(session_id.to_string())
+            .or_insert(0);
+        let idx = *entry;
+        *entry += 1;
+        idx
+    }
+
+    fn traj_log_tool_call(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        name: &str,
+        input: &serde_json::Value,
+    ) {
+        if let Some(store) = &self.trajectory_store {
+            store
+                .log_tool_call(session_id, turn_index, name, &input.to_string())
+                .unwrap_or_else(|e| warn!("trajectory log_tool_call failed: {e}"));
+        }
+    }
+
+    fn traj_log_tool_result(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        name: &str,
+        output: &str,
+        latency_ms: u64,
+    ) {
+        if let Some(store) = &self.trajectory_store {
+            store
+                .log_tool_result(session_id, turn_index, name, output, latency_ms)
+                .unwrap_or_else(|e| warn!("trajectory log_tool_result failed: {e}"));
+        }
+    }
+
+    fn traj_log_turn_end(&self, session_id: &str, turn_index: u32, output: &str, tokens: u32) {
+        if let Some(store) = &self.trajectory_store {
+            store
+                .log_turn_end(session_id, turn_index, output, tokens)
+                .unwrap_or_else(|e| warn!("trajectory log_turn_end failed: {e}"));
+        }
     }
 
     pub fn set_summarization_enabled(&mut self, enabled: bool) {
@@ -739,6 +798,39 @@ impl AgentRuntime {
             .iter()
             .find(|t| t.name() == name)
             .map(|t| t.as_ref())
+    }
+
+    /// Execute a tool, logging call/result to the trajectory store and recording debug info.
+    async fn run_tool(
+        &self,
+        session_id: &str,
+        traj_turn_index: u32,
+        context: &ToolContext,
+        name: &str,
+        input: &serde_json::Value,
+    ) -> ToolOutput {
+        self.traj_log_tool_call(session_id, traj_turn_index, name, input);
+        let t0 = std::time::Instant::now();
+        let output = match self.check_tool_allowed(session_id, name) {
+            Err(e) => ToolOutput::error(e.to_string()),
+            Ok(()) => match self.find_tool(name) {
+                Some(tool) => tool
+                    .execute(context, input.clone())
+                    .await
+                    .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
+                None => ToolOutput::error(format!("unknown tool: {}", name)),
+            },
+        };
+        let latency_ms = t0.elapsed().as_millis() as u64;
+        self.traj_log_tool_result(
+            session_id,
+            traj_turn_index,
+            name,
+            &output.content,
+            latency_ms,
+        );
+        self.record_debug_tool_call(session_id, name, &input.to_string());
+        output
     }
 
     /// Return the skills directory from the registered `create_skill` tool, if any.
@@ -1334,6 +1426,7 @@ impl AgentRuntime {
         trim_messages_to_budget(&mut messages, &system, &tool_defs, max_ctx);
 
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: effective_model.clone(),
@@ -1388,6 +1481,7 @@ impl AgentRuntime {
                     final_text.push_str("\n\n");
                     final_text.push_str(&followup);
                 }
+                self.traj_log_turn_end(session_id, traj_turn_index, &final_text, 0);
                 return Ok(final_text);
             }
 
@@ -1405,16 +1499,9 @@ impl AgentRuntime {
                         heartbeat_depth: depth,
                         allowed_tools: self.session_allowed_tools(session_id),
                     };
-                    let output = match self.check_tool_allowed(session_id, name) {
-                        Err(e) => ToolOutput::error(e.to_string()),
-                        Ok(()) => match self.find_tool(name) {
-                            Some(tool) => tool
-                                .execute(&context, input.clone())
-                                .await
-                                .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                            None => ToolOutput::error(format!("unknown tool: {}", name)),
-                        },
-                    };
+                    let output = self
+                        .run_tool(session_id, traj_turn_index, &context, name, input)
+                        .await;
                     tool_results.push(ContentBlock::ToolResult {
                         tool_use_id: id.clone(),
                         content: output.content,
@@ -1549,6 +1636,7 @@ impl AgentRuntime {
         };
 
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: effective_model.clone(),
@@ -1620,16 +1708,9 @@ impl AgentRuntime {
                         heartbeat_depth: 0,
                         allowed_tools: self.session_allowed_tools(session_id),
                     };
-                    let output = match self.check_tool_allowed(session_id, name) {
-                        Err(e) => ToolOutput::error(e.to_string()),
-                        Ok(()) => match self.find_tool(name) {
-                            Some(tool) => tool
-                                .execute(&context, input.clone())
-                                .await
-                                .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                            None => ToolOutput::error(format!("unknown tool: {}", name)),
-                        },
-                    };
+                    let output = self
+                        .run_tool(session_id, traj_turn_index, &context, name, input)
+                        .await;
                     tool_results.push(ContentBlock::ToolResult {
                         tool_use_id: id.clone(),
                         content: output.content,
@@ -1722,6 +1803,7 @@ impl AgentRuntime {
         trim_messages_to_budget(&mut messages, &system, &tool_defs, max_ctx);
 
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: String::new(),
@@ -1778,6 +1860,7 @@ impl AgentRuntime {
                     final_text.push_str(&followup);
                 }
 
+                self.traj_log_turn_end(session_id, traj_turn_index, &final_text, 0);
                 return Ok(final_text);
             }
 
@@ -1804,17 +1887,9 @@ impl AgentRuntime {
                         heartbeat_depth,
                         allowed_tools: self.session_allowed_tools(session_id),
                     };
-                    let output = match self.check_tool_allowed(session_id, name) {
-                        Err(e) => ToolOutput::error(e.to_string()),
-                        Ok(()) => match self.find_tool(name) {
-                            Some(tool) => tool
-                                .execute(&context, input.clone())
-                                .await
-                                .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                            None => ToolOutput::error(format!("unknown tool: {}", name)),
-                        },
-                    };
-                    self.record_debug_tool_call(session_id, name, &input.to_string());
+                    let output = self
+                        .run_tool(session_id, traj_turn_index, &context, name, input)
+                        .await;
                     tool_results.push(ContentBlock::ToolResult {
                         tool_use_id: id.clone(),
                         content: output.content,
@@ -1969,6 +2044,7 @@ impl AgentRuntime {
 
         let mut full_response = String::new();
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: String::new(),
@@ -2117,17 +2193,9 @@ impl AgentRuntime {
                             heartbeat_depth: 0,
                             allowed_tools: self.session_allowed_tools(session_id),
                         };
-                        let output = match self.check_tool_allowed(session_id, name) {
-                            Err(e) => ToolOutput::error(e.to_string()),
-                            Ok(()) => match self.find_tool(name) {
-                                Some(tool) => tool
-                                    .execute(&context, input)
-                                    .await
-                                    .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                                None => ToolOutput::error(format!("unknown tool: {}", name)),
-                            },
-                        };
-                        self.record_debug_tool_call(session_id, name, input_json);
+                        let output = self
+                            .run_tool(session_id, traj_turn_index, &context, name, &input)
+                            .await;
                         tool_results.push(ContentBlock::ToolResult {
                             tool_use_id: id.clone(),
                             content: output.content,
@@ -2227,16 +2295,9 @@ impl AgentRuntime {
                                 heartbeat_depth: 0,
                                 allowed_tools: self.session_allowed_tools(session_id),
                             };
-                            let output = match self.check_tool_allowed(session_id, name) {
-                                Err(e) => ToolOutput::error(e.to_string()),
-                                Ok(()) => match self.find_tool(name) {
-                                    Some(tool) => tool
-                                        .execute(&context, input.clone())
-                                        .await
-                                        .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                                    None => ToolOutput::error(format!("unknown tool: {}", name)),
-                                },
-                            };
+                            let output = self
+                                .run_tool(session_id, traj_turn_index, &context, name, input)
+                                .await;
                             tool_results.push(ContentBlock::ToolResult {
                                 tool_use_id: id.clone(),
                                 content: output.content,
@@ -2350,6 +2411,7 @@ impl AgentRuntime {
         };
 
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: String::new(),
@@ -2437,17 +2499,9 @@ impl AgentRuntime {
                         heartbeat_depth,
                         allowed_tools: self.session_allowed_tools(session_id),
                     };
-                    let output = match self.check_tool_allowed(session_id, name) {
-                        Err(e) => ToolOutput::error(e.to_string()),
-                        Ok(()) => match self.find_tool(name) {
-                            Some(tool) => tool
-                                .execute(&context, input.clone())
-                                .await
-                                .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                            None => ToolOutput::error(format!("unknown tool: {}", name)),
-                        },
-                    };
-                    self.record_debug_tool_call(session_id, name, &input.to_string());
+                    let output = self
+                        .run_tool(session_id, traj_turn_index, &context, name, input)
+                        .await;
                     tool_results.push(ContentBlock::ToolResult {
                         tool_use_id: id.clone(),
                         content: output.content,
@@ -2559,6 +2613,7 @@ impl AgentRuntime {
 
         let mut full_response = String::new();
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: String::new(),
@@ -2704,17 +2759,9 @@ impl AgentRuntime {
                             heartbeat_depth: 0,
                             allowed_tools: self.session_allowed_tools(session_id),
                         };
-                        let output = match self.check_tool_allowed(session_id, name) {
-                            Err(e) => ToolOutput::error(e.to_string()),
-                            Ok(()) => match self.find_tool(name) {
-                                Some(tool) => tool
-                                    .execute(&context, input)
-                                    .await
-                                    .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                                None => ToolOutput::error(format!("unknown tool: {}", name)),
-                            },
-                        };
-                        self.record_debug_tool_call(session_id, name, input_json);
+                        let output = self
+                            .run_tool(session_id, traj_turn_index, &context, name, &input)
+                            .await;
                         tool_results.push(ContentBlock::ToolResult {
                             tool_use_id: id.clone(),
                             content: output.content,
@@ -2803,16 +2850,9 @@ impl AgentRuntime {
                                 heartbeat_depth: 0,
                                 allowed_tools: self.session_allowed_tools(session_id),
                             };
-                            let output = match self.check_tool_allowed(session_id, name) {
-                                Err(e) => ToolOutput::error(e.to_string()),
-                                Ok(()) => match self.find_tool(name) {
-                                    Some(tool) => tool
-                                        .execute(&context, input.clone())
-                                        .await
-                                        .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                                    None => ToolOutput::error(format!("unknown tool: {}", name)),
-                                },
-                            };
+                            let output = self
+                                .run_tool(session_id, traj_turn_index, &context, name, input)
+                                .await;
                             tool_results.push(ContentBlock::ToolResult {
                                 tool_use_id: id.clone(),
                                 content: output.content,

--- a/crates/opencrust-config/src/model.rs
+++ b/crates/opencrust-config/src/model.rs
@@ -232,6 +232,9 @@ pub struct AgentConfig {
     /// Max skills injected per turn via semantic search (default: 5).
     /// When skill count ≤ this limit all skills are always injected (no embedding call needed).
     pub skill_recall_limit: Option<usize>,
+    /// Persist every tool call and result to a trajectory database for analysis and training.
+    /// Default: false. Stored in `{data_dir}/trajectories.db`.
+    pub collect_trajectories: Option<bool>,
 }
 
 /// A named agent configuration for multi-agent routing.

--- a/crates/opencrust-db/src/lib.rs
+++ b/crates/opencrust-db/src/lib.rs
@@ -2,6 +2,7 @@ pub mod document_store;
 pub mod memory_store;
 pub mod migrations;
 pub mod session_store;
+pub mod trajectory_store;
 pub mod vector_store;
 
 pub use document_store::{DocumentChunk, DocumentInfo, DocumentStore};
@@ -10,4 +11,5 @@ pub use memory_store::{
     RecallQuery, SessionContext,
 };
 pub use session_store::{ScheduledTask, SessionStore, UsageAttribution, UsageRecord};
+pub use trajectory_store::{TrajectoryEvent, TrajectoryEventType, TrajectoryStore};
 pub use vector_store::VectorStore;

--- a/crates/opencrust-db/src/trajectory_store.rs
+++ b/crates/opencrust-db/src/trajectory_store.rs
@@ -1,0 +1,317 @@
+use chrono::Utc;
+use opencrust_common::{Error, Result};
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+/// A single recorded step within a turn's tool loop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryEvent {
+    pub id: String,
+    pub session_id: String,
+    pub turn_index: u32,
+    pub event_type: TrajectoryEventType,
+    pub tool_name: Option<String>,
+    /// JSON-encoded input args (tool_call) or output text (tool_result / turn_end).
+    pub payload: String,
+    pub latency_ms: Option<u64>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrajectoryEventType {
+    ToolCall,
+    ToolResult,
+    TurnEnd,
+}
+
+impl TrajectoryEventType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::ToolCall => "tool_call",
+            Self::ToolResult => "tool_result",
+            Self::TurnEnd => "turn_end",
+        }
+    }
+
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "tool_call" => Some(Self::ToolCall),
+            "tool_result" => Some(Self::ToolResult),
+            "turn_end" => Some(Self::TurnEnd),
+            _ => None,
+        }
+    }
+}
+
+/// SQLite-backed store for per-turn trajectory events.
+///
+/// Each turn in the agent tool loop produces a sequence of `tool_call` /
+/// `tool_result` pairs followed by a single `turn_end` event. These are
+/// used for skill auto-suggestion, debug replay, and training-data export.
+pub struct TrajectoryStore {
+    conn: Mutex<Connection>,
+}
+
+impl TrajectoryStore {
+    pub fn open(db_path: &Path) -> Result<Self> {
+        let conn = Connection::open(db_path)
+            .map_err(|e| Error::Database(format!("failed to open trajectory db: {e}")))?;
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
+        store.run_migrations()?;
+        Ok(store)
+    }
+
+    pub fn in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()
+            .map_err(|e| Error::Database(format!("failed to open in-memory trajectory db: {e}")))?;
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
+        store.run_migrations()?;
+        Ok(store)
+    }
+
+    fn run_migrations(&self) -> Result<()> {
+        let conn = self.connection()?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS trajectory_events (
+                id          TEXT PRIMARY KEY,
+                session_id  TEXT NOT NULL,
+                turn_index  INTEGER NOT NULL,
+                event_type  TEXT NOT NULL,
+                tool_name   TEXT,
+                payload     TEXT NOT NULL,
+                latency_ms  INTEGER,
+                created_at  TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_traj_session
+                ON trajectory_events(session_id, turn_index, created_at);",
+        )
+        .map_err(|e| Error::Database(format!("trajectory migration failed: {e}")))?;
+        Ok(())
+    }
+
+    fn connection(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {
+        self.conn
+            .lock()
+            .map_err(|_| Error::Database("trajectory store lock poisoned".into()))
+    }
+
+    fn insert(&self, event: &TrajectoryEvent) -> Result<()> {
+        let conn = self.connection()?;
+        conn.execute(
+            "INSERT INTO trajectory_events
+             (id, session_id, turn_index, event_type, tool_name, payload, latency_ms, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                event.id,
+                event.session_id,
+                event.turn_index,
+                event.event_type.as_str(),
+                event.tool_name,
+                event.payload,
+                event.latency_ms.map(|v| v as i64),
+                event.created_at,
+            ],
+        )
+        .map_err(|e| Error::Database(format!("trajectory insert failed: {e}")))?;
+        Ok(())
+    }
+
+    /// Record that a tool was about to be called.
+    pub fn log_tool_call(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        tool_name: &str,
+        input_json: &str,
+    ) -> Result<()> {
+        self.insert(&TrajectoryEvent {
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            turn_index,
+            event_type: TrajectoryEventType::ToolCall,
+            tool_name: Some(tool_name.to_string()),
+            payload: input_json.to_string(),
+            latency_ms: None,
+            created_at: Utc::now().to_rfc3339(),
+        })
+    }
+
+    /// Record the result of a tool call.
+    pub fn log_tool_result(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        tool_name: &str,
+        output_text: &str,
+        latency_ms: u64,
+    ) -> Result<()> {
+        self.insert(&TrajectoryEvent {
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            turn_index,
+            event_type: TrajectoryEventType::ToolResult,
+            tool_name: Some(tool_name.to_string()),
+            payload: output_text.to_string(),
+            latency_ms: Some(latency_ms),
+            created_at: Utc::now().to_rfc3339(),
+        })
+    }
+
+    /// Record the final assistant output at the end of a turn.
+    pub fn log_turn_end(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        final_output: &str,
+        total_tokens: u32,
+    ) -> Result<()> {
+        let payload = serde_json::json!({
+            "output": final_output,
+            "total_tokens": total_tokens,
+        })
+        .to_string();
+        self.insert(&TrajectoryEvent {
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            turn_index,
+            event_type: TrajectoryEventType::TurnEnd,
+            tool_name: None,
+            payload,
+            latency_ms: None,
+            created_at: Utc::now().to_rfc3339(),
+        })
+    }
+
+    /// Return all trajectory events for a session ordered by turn and time.
+    pub fn export_session(&self, session_id: &str) -> Result<Vec<TrajectoryEvent>> {
+        let conn = self.connection()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, session_id, turn_index, event_type, tool_name, payload, latency_ms, created_at
+                 FROM trajectory_events
+                 WHERE session_id = ?1
+                 ORDER BY turn_index, created_at",
+            )
+            .map_err(|e| Error::Database(format!("trajectory export prepare failed: {e}")))?;
+
+        let rows = stmt
+            .query_map(params![session_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, u32>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, Option<i64>>(6)?,
+                    row.get::<_, String>(7)?,
+                ))
+            })
+            .map_err(|e| Error::Database(format!("trajectory export query failed: {e}")))?;
+
+        rows.map(|r| {
+            r.map_err(|e| Error::Database(format!("trajectory row error: {e}")))
+                .and_then(|(id, sid, ti, et, tn, payload, lat, ca)| {
+                    let event_type = TrajectoryEventType::from_str(&et)
+                        .ok_or_else(|| Error::Database(format!("unknown event_type: {et}")))?;
+                    Ok(TrajectoryEvent {
+                        id,
+                        session_id: sid,
+                        turn_index: ti,
+                        event_type,
+                        tool_name: tn,
+                        payload,
+                        latency_ms: lat.map(|v| v as u64),
+                        created_at: ca,
+                    })
+                })
+        })
+        .collect()
+    }
+
+    /// Count total stored events for a session.
+    pub fn count_session_events(&self, session_id: &str) -> Result<usize> {
+        let conn = self.connection()?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM trajectory_events WHERE session_id = ?1",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(format!("trajectory count failed: {e}")))?;
+        Ok(count as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_store() -> TrajectoryStore {
+        TrajectoryStore::in_memory().expect("in-memory store should open")
+    }
+
+    #[test]
+    fn log_and_export_round_trip() {
+        let store = make_store();
+        store
+            .log_tool_call("s1", 0, "web_search", r#"{"query":"X"}"#)
+            .unwrap();
+        store
+            .log_tool_result("s1", 0, "web_search", "results...", 320)
+            .unwrap();
+        store.log_turn_end("s1", 0, "final answer", 500).unwrap();
+
+        let events = store.export_session("s1").unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].event_type, TrajectoryEventType::ToolCall);
+        assert_eq!(events[1].event_type, TrajectoryEventType::ToolResult);
+        assert_eq!(events[1].latency_ms, Some(320));
+        assert_eq!(events[2].event_type, TrajectoryEventType::TurnEnd);
+    }
+
+    #[test]
+    fn export_scoped_to_session() {
+        let store = make_store();
+        store.log_tool_call("s1", 0, "tool_a", "{}").unwrap();
+        store.log_tool_call("s2", 0, "tool_b", "{}").unwrap();
+
+        let s1 = store.export_session("s1").unwrap();
+        let s2 = store.export_session("s2").unwrap();
+        assert_eq!(s1.len(), 1);
+        assert_eq!(s2.len(), 1);
+        assert_eq!(s1[0].tool_name.as_deref(), Some("tool_a"));
+        assert_eq!(s2[0].tool_name.as_deref(), Some("tool_b"));
+    }
+
+    #[test]
+    fn count_session_events_correct() {
+        let store = make_store();
+        store.log_tool_call("s1", 0, "t", "{}").unwrap();
+        store.log_tool_result("s1", 0, "t", "out", 10).unwrap();
+        store.log_turn_end("s1", 0, "done", 100).unwrap();
+        assert_eq!(store.count_session_events("s1").unwrap(), 3);
+        assert_eq!(store.count_session_events("s2").unwrap(), 0);
+    }
+
+    #[test]
+    fn events_ordered_by_turn_then_time() {
+        let store = make_store();
+        store.log_turn_end("s1", 1, "turn1", 100).unwrap();
+        store.log_tool_call("s1", 0, "tool", "{}").unwrap();
+        store.log_turn_end("s1", 0, "turn0", 50).unwrap();
+
+        let events = store.export_session("s1").unwrap();
+        assert_eq!(events[0].turn_index, 0);
+        assert_eq!(events[0].event_type, TrajectoryEventType::ToolCall);
+        assert_eq!(events[2].turn_index, 1);
+    }
+}

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -18,7 +18,7 @@ use opencrust_channels::{
 #[cfg(target_os = "macos")]
 use opencrust_channels::{IMessageChannel, IMessageGroupFilter, IMessageOnMessageFn};
 use opencrust_config::AppConfig;
-use opencrust_db::{MemoryStore, VectorStore};
+use opencrust_db::{MemoryStore, TrajectoryStore, VectorStore};
 use opencrust_security::{Allowlist, ChannelPolicy, DmAuthResult, PairingManager, check_dm_auth};
 use tracing::{info, warn};
 
@@ -608,6 +608,20 @@ pub async fn build_agent_runtime(config: &AppConfig) -> (AgentRuntime, SendMessa
     }
     if let Some(limit) = config.agent.skill_recall_limit {
         runtime.set_skill_recall_limit(limit);
+    }
+    if config.agent.collect_trajectories.unwrap_or(false) {
+        let traj_dir = config
+            .data_dir
+            .clone()
+            .unwrap_or_else(|| opencrust_config::ConfigLoader::default_config_dir().join("data"));
+        let traj_path = traj_dir.join("trajectories.db");
+        match TrajectoryStore::open(&traj_path) {
+            Ok(store) => {
+                runtime.set_trajectory_store(Arc::new(store));
+                info!("trajectory store opened at {}", traj_path.display());
+            }
+            Err(e) => warn!("failed to open trajectory store: {e}"),
+        }
     }
 
     // --- Skills ---


### PR DESCRIPTION
## Summary

- Adds opt-in `TrajectoryStore` (SQLite) that logs every tool call, tool result, and turn-end event during the agent tool loop
- Consolidates all 8 tool-execution sites in `runtime.rs` into a single `run_tool` helper — cleaner and ensures consistent logging
- New config flag `collect_trajectories` under `[agent]` — disabled by default (zero overhead when off)
- Stored at `{data_dir}/trajectories.db`

## Why

Trajectory data enables capabilities that per-turn skill nudges cannot provide:
- **Cross-session pattern detection** — detect tool sequences that repeat across many sessions → auto-propose skills
- **Debug replay** — inspect exactly what tools fired and their latency for any past turn
- **Training-data export** — export JSONL for fine-tuning tool-calling models (similar to Hermes Agent's trajectory compression)

## Usage

```toml
# ~/.opencrust/config.toml
[agent]
collect_trajectories = true
```

Query directly:
```sql
SELECT session_id, turn_index, event_type, tool_name, latency_ms
FROM trajectory_events ORDER BY created_at DESC LIMIT 20;
```

## Changes

| Crate | Change |
|---|---|
| `opencrust-db` | New `TrajectoryStore` + `TrajectoryEvent` + 4 unit tests |
| `opencrust-config` | `collect_trajectories: Option<bool>` in `AgentConfig` |
| `opencrust-agents` | `run_tool` helper replaces 8 inline tool-exec blocks; `traj_advance_turn` per-session counter |
| `opencrust-gateway` | Init `TrajectoryStore` at bootstrap when flag is set |

## Test plan

- [ ] `cargo test -p opencrust-db` — 4 new trajectory tests pass
- [ ] `cargo test` — all 680+ tests pass, no regressions
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean
- [ ] Manual: set `collect_trajectories = true`, send a message requiring tool use, verify rows appear in `trajectories.db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)