### PR TITLE
feat: cross-session skill suggestion from trajectory patterns

### DIFF
--- a/crates/opencrust-agents/src/lib.rs
+++ b/crates/opencrust-agents/src/lib.rs
@@ -8,6 +8,7 @@ pub mod ollama;
 pub mod openai;
 pub mod providers;
 pub mod runtime;
+pub mod skill_suggester;
 pub mod tools;
 
 pub use anthropic::AnthropicProvider;
@@ -19,6 +20,7 @@ pub use providers::{
     StreamEvent, ToolDefinition,
 };
 pub use runtime::AgentRuntime;
+pub use skill_suggester::{SkillSuggestion, suggest_from_trajectories};
 pub use tools::{
     BashTool, CancelHeartbeat, CreateSkillTool, DocSearchTool, FilePatchTool, FileReadTool,
     FileWriteTool, GoogleSearchTool, HandoffHandle, HandoffTool, ListDocumentsTool, ListHeartbeats,

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -317,6 +317,22 @@ impl AgentRuntime {
         self.trajectory_store = Some(store);
     }
 
+    /// Analyse stored trajectories and return skill suggestions for tool sequences
+    /// that have been repeated at least `min_occurrences` times.
+    ///
+    /// Returns an empty vec when trajectory collection is disabled or no patterns
+    /// meet the threshold.
+    pub fn suggest_skills(
+        &self,
+        min_occurrences: usize,
+    ) -> Vec<crate::skill_suggester::SkillSuggestion> {
+        let Some(store) = &self.trajectory_store else {
+            return Vec::new();
+        };
+        let skills_dir = self.skills_dir();
+        crate::skill_suggester::suggest_from_trajectories(store, &skills_dir, min_occurrences)
+    }
+
     /// Increment the per-session turn counter and return the index for this turn.
     fn traj_advance_turn(&self, session_id: &str) -> u32 {
         let mut entry = self

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -10,6 +10,7 @@ use futures::future::join_all;
 use opencrust_common::{Error, Result};
 use opencrust_db::{
     DocumentStore, MemoryEntry, MemoryProvider, MemoryRole, NewMemoryEntry, RecallQuery,
+    TrajectoryStore,
 };
 use tokio::sync::mpsc;
 use tracing::{info, instrument, warn};
@@ -80,6 +81,10 @@ pub struct AgentRuntime {
     debug: bool,
     /// Debug info accumulated during message processing, keyed by session_id.
     debug_accumulator: Mutex<HashMap<String, Vec<String>>>,
+    /// Optional trajectory store. When set, every tool call and turn end is persisted.
+    trajectory_store: Option<Arc<TrajectoryStore>>,
+    /// Per-session turn counter used to order trajectory events.
+    session_turn_index: DashMap<String, u32>,
     /// Path to the document store DB for auto-RAG injection.
     doc_db_path: Option<PathBuf>,
     /// Cached document store opened once at startup for auto-RAG.
@@ -136,6 +141,8 @@ impl AgentRuntime {
             session_skills_override: DashMap::new(),
             debug: false,
             debug_accumulator: Mutex::new(HashMap::new()),
+            trajectory_store: None,
+            session_turn_index: DashMap::new(),
         }
     }
 
@@ -304,6 +311,58 @@ impl AgentRuntime {
 
     pub fn set_recall_limit(&mut self, limit: usize) {
         self.recall_limit = limit;
+    }
+
+    pub fn set_trajectory_store(&mut self, store: Arc<TrajectoryStore>) {
+        self.trajectory_store = Some(store);
+    }
+
+    /// Increment the per-session turn counter and return the index for this turn.
+    fn traj_advance_turn(&self, session_id: &str) -> u32 {
+        let mut entry = self
+            .session_turn_index
+            .entry(session_id.to_string())
+            .or_insert(0);
+        let idx = *entry;
+        *entry += 1;
+        idx
+    }
+
+    fn traj_log_tool_call(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        name: &str,
+        input: &serde_json::Value,
+    ) {
+        if let Some(store) = &self.trajectory_store {
+            store
+                .log_tool_call(session_id, turn_index, name, &input.to_string())
+                .unwrap_or_else(|e| warn!("trajectory log_tool_call failed: {e}"));
+        }
+    }
+
+    fn traj_log_tool_result(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        name: &str,
+        output: &str,
+        latency_ms: u64,
+    ) {
+        if let Some(store) = &self.trajectory_store {
+            store
+                .log_tool_result(session_id, turn_index, name, output, latency_ms)
+                .unwrap_or_else(|e| warn!("trajectory log_tool_result failed: {e}"));
+        }
+    }
+
+    fn traj_log_turn_end(&self, session_id: &str, turn_index: u32, output: &str, tokens: u32) {
+        if let Some(store) = &self.trajectory_store {
+            store
+                .log_turn_end(session_id, turn_index, output, tokens)
+                .unwrap_or_else(|e| warn!("trajectory log_turn_end failed: {e}"));
+        }
     }
 
     pub fn set_summarization_enabled(&mut self, enabled: bool) {
@@ -739,6 +798,39 @@ impl AgentRuntime {
             .iter()
             .find(|t| t.name() == name)
             .map(|t| t.as_ref())
+    }
+
+    /// Execute a tool, logging call/result to the trajectory store and recording debug info.
+    async fn run_tool(
+        &self,
+        session_id: &str,
+        traj_turn_index: u32,
+        context: &ToolContext,
+        name: &str,
+        input: &serde_json::Value,
+    ) -> ToolOutput {
+        self.traj_log_tool_call(session_id, traj_turn_index, name, input);
+        let t0 = std::time::Instant::now();
+        let output = match self.check_tool_allowed(session_id, name) {
+            Err(e) => ToolOutput::error(e.to_string()),
+            Ok(()) => match self.find_tool(name) {
+                Some(tool) => tool
+                    .execute(context, input.clone())
+                    .await
+                    .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
+                None => ToolOutput::error(format!("unknown tool: {}", name)),
+            },
+        };
+        let latency_ms = t0.elapsed().as_millis() as u64;
+        self.traj_log_tool_result(
+            session_id,
+            traj_turn_index,
+            name,
+            &output.content,
+            latency_ms,
+        );
+        self.record_debug_tool_call(session_id, name, &input.to_string());
+        output
     }
 
     /// Return the skills directory from the registered `create_skill` tool, if any.
@@ -1334,6 +1426,7 @@ impl AgentRuntime {
         trim_messages_to_budget(&mut messages, &system, &tool_defs, max_ctx);
 
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: effective_model.clone(),
@@ -1388,6 +1481,7 @@ impl AgentRuntime {
                     final_text.push_str("\n\n");
                     final_text.push_str(&followup);
                 }
+                self.traj_log_turn_end(session_id, traj_turn_index, &final_text, 0);
                 return Ok(final_text);
             }
 
@@ -1405,16 +1499,9 @@ impl AgentRuntime {
                         heartbeat_depth: depth,
                         allowed_tools: self.session_allowed_tools(session_id),
                     };
-                    let output = match self.check_tool_allowed(session_id, name) {
-                        Err(e) => ToolOutput::error(e.to_string()),
-                        Ok(()) => match self.find_tool(name) {
-                            Some(tool) => tool
-                                .execute(&context, input.clone())
-                                .await
-                                .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                            None => ToolOutput::error(format!("unknown tool: {}", name)),
-                        },
-                    };
+                    let output = self
+                        .run_tool(session_id, traj_turn_index, &context, name, input)
+                        .await;
                     tool_results.push(ContentBlock::ToolResult {
                         tool_use_id: id.clone(),
                         content: output.content,
@@ -1549,6 +1636,7 @@ impl AgentRuntime {
         };
 
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: effective_model.clone(),
@@ -1620,16 +1708,9 @@ impl AgentRuntime {
                         heartbeat_depth: 0,
                         allowed_tools: self.session_allowed_tools(session_id),
                     };
-                    let output = match self.check_tool_allowed(session_id, name) {
-                        Err(e) => ToolOutput::error(e.to_string()),
-                        Ok(()) => match self.find_tool(name) {
-                            Some(tool) => tool
-                                .execute(&context, input.clone())
-                                .await
-                                .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                            None => ToolOutput::error(format!("unknown tool: {}", name)),
-                        },
-                    };
+                    let output = self
+                        .run_tool(session_id, traj_turn_index, &context, name, input)
+                        .await;
                     tool_results.push(ContentBlock::ToolResult {
                         tool_use_id: id.clone(),
                         content: output.content,
@@ -1722,6 +1803,7 @@ impl AgentRuntime {
         trim_messages_to_budget(&mut messages, &system, &tool_defs, max_ctx);
 
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: String::new(),
@@ -1778,6 +1860,7 @@ impl AgentRuntime {
                     final_text.push_str(&followup);
                 }
 
+                self.traj_log_turn_end(session_id, traj_turn_index, &final_text, 0);
                 return Ok(final_text);
             }
 
@@ -1804,17 +1887,9 @@ impl AgentRuntime {
                         heartbeat_depth,
                         allowed_tools: self.session_allowed_tools(session_id),
                     };
-                    let output = match self.check_tool_allowed(session_id, name) {
-                        Err(e) => ToolOutput::error(e.to_string()),
-                        Ok(()) => match self.find_tool(name) {
-                            Some(tool) => tool
-                                .execute(&context, input.clone())
-                                .await
-                                .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                            None => ToolOutput::error(format!("unknown tool: {}", name)),
-                        },
-                    };
-                    self.record_debug_tool_call(session_id, name, &input.to_string());
+                    let output = self
+                        .run_tool(session_id, traj_turn_index, &context, name, input)
+                        .await;
                     tool_results.push(ContentBlock::ToolResult {
                         tool_use_id: id.clone(),
                         content: output.content,
@@ -1969,6 +2044,7 @@ impl AgentRuntime {
 
         let mut full_response = String::new();
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: String::new(),
@@ -2117,17 +2193,9 @@ impl AgentRuntime {
                             heartbeat_depth: 0,
                             allowed_tools: self.session_allowed_tools(session_id),
                         };
-                        let output = match self.check_tool_allowed(session_id, name) {
-                            Err(e) => ToolOutput::error(e.to_string()),
-                            Ok(()) => match self.find_tool(name) {
-                                Some(tool) => tool
-                                    .execute(&context, input)
-                                    .await
-                                    .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                                None => ToolOutput::error(format!("unknown tool: {}", name)),
-                            },
-                        };
-                        self.record_debug_tool_call(session_id, name, input_json);
+                        let output = self
+                            .run_tool(session_id, traj_turn_index, &context, name, &input)
+                            .await;
                         tool_results.push(ContentBlock::ToolResult {
                             tool_use_id: id.clone(),
                             content: output.content,
@@ -2227,16 +2295,9 @@ impl AgentRuntime {
                                 heartbeat_depth: 0,
                                 allowed_tools: self.session_allowed_tools(session_id),
                             };
-                            let output = match self.check_tool_allowed(session_id, name) {
-                                Err(e) => ToolOutput::error(e.to_string()),
-                                Ok(()) => match self.find_tool(name) {
-                                    Some(tool) => tool
-                                        .execute(&context, input.clone())
-                                        .await
-                                        .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                                    None => ToolOutput::error(format!("unknown tool: {}", name)),
-                                },
-                            };
+                            let output = self
+                                .run_tool(session_id, traj_turn_index, &context, name, input)
+                                .await;
                             tool_results.push(ContentBlock::ToolResult {
                                 tool_use_id: id.clone(),
                                 content: output.content,
@@ -2350,6 +2411,7 @@ impl AgentRuntime {
         };
 
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: String::new(),
@@ -2437,17 +2499,9 @@ impl AgentRuntime {
                         heartbeat_depth,
                         allowed_tools: self.session_allowed_tools(session_id),
                     };
-                    let output = match self.check_tool_allowed(session_id, name) {
-                        Err(e) => ToolOutput::error(e.to_string()),
-                        Ok(()) => match self.find_tool(name) {
-                            Some(tool) => tool
-                                .execute(&context, input.clone())
-                                .await
-                                .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                            None => ToolOutput::error(format!("unknown tool: {}", name)),
-                        },
-                    };
-                    self.record_debug_tool_call(session_id, name, &input.to_string());
+                    let output = self
+                        .run_tool(session_id, traj_turn_index, &context, name, input)
+                        .await;
                     tool_results.push(ContentBlock::ToolResult {
                         tool_use_id: id.clone(),
                         content: output.content,
@@ -2559,6 +2613,7 @@ impl AgentRuntime {
 
         let mut full_response = String::new();
         let mut tool_call_count: usize = 0;
+        let traj_turn_index = self.traj_advance_turn(session_id);
         for _iteration in 0..MAX_TOOL_ITERATIONS {
             let request = LlmRequest {
                 model: String::new(),
@@ -2704,17 +2759,9 @@ impl AgentRuntime {
                             heartbeat_depth: 0,
                             allowed_tools: self.session_allowed_tools(session_id),
                         };
-                        let output = match self.check_tool_allowed(session_id, name) {
-                            Err(e) => ToolOutput::error(e.to_string()),
-                            Ok(()) => match self.find_tool(name) {
-                                Some(tool) => tool
-                                    .execute(&context, input)
-                                    .await
-                                    .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                                None => ToolOutput::error(format!("unknown tool: {}", name)),
-                            },
-                        };
-                        self.record_debug_tool_call(session_id, name, input_json);
+                        let output = self
+                            .run_tool(session_id, traj_turn_index, &context, name, &input)
+                            .await;
                         tool_results.push(ContentBlock::ToolResult {
                             tool_use_id: id.clone(),
                             content: output.content,
@@ -2803,16 +2850,9 @@ impl AgentRuntime {
                                 heartbeat_depth: 0,
                                 allowed_tools: self.session_allowed_tools(session_id),
                             };
-                            let output = match self.check_tool_allowed(session_id, name) {
-                                Err(e) => ToolOutput::error(e.to_string()),
-                                Ok(()) => match self.find_tool(name) {
-                                    Some(tool) => tool
-                                        .execute(&context, input.clone())
-                                        .await
-                                        .unwrap_or_else(|e| ToolOutput::error(e.to_string())),
-                                    None => ToolOutput::error(format!("unknown tool: {}", name)),
-                                },
-                            };
+                            let output = self
+                                .run_tool(session_id, traj_turn_index, &context, name, input)
+                                .await;
                             tool_results.push(ContentBlock::ToolResult {
                                 tool_use_id: id.clone(),
                                 content: output.content,

--- a/crates/opencrust-agents/src/skill_suggester.rs
+++ b/crates/opencrust-agents/src/skill_suggester.rs
@@ -1,0 +1,159 @@
+use opencrust_db::{RepeatedToolSequence, TrajectoryStore};
+use opencrust_skills::{SkillDefinition, SkillScanner};
+use std::path::Path;
+use std::sync::Arc;
+use tracing::warn;
+
+/// A suggested skill derived from a repeated tool sequence in the trajectory log.
+#[derive(Debug, Clone)]
+pub struct SkillSuggestion {
+    /// Human-readable sequence fingerprint, e.g. "web_search → summarize".
+    pub fingerprint: String,
+    /// Ordered tool names that make up the sequence.
+    pub tools: Vec<String>,
+    /// Number of turns where this sequence was observed.
+    pub occurrences: usize,
+    /// True if an existing skill already appears to cover this sequence.
+    pub already_covered: bool,
+    /// Name of the existing skill that covers it, if any.
+    pub covered_by: Option<String>,
+}
+
+/// Analyse trajectory data against existing skills and return suggestions for
+/// new skills that would codify frequently-repeated tool workflows.
+pub fn suggest_from_trajectories(
+    trajectory_store: &Arc<TrajectoryStore>,
+    skills_dir: &Path,
+    min_occurrences: usize,
+) -> Vec<SkillSuggestion> {
+    let sequences = match trajectory_store.find_repeated_tool_sequences(min_occurrences) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("skill suggester: trajectory query failed: {e}");
+            return Vec::new();
+        }
+    };
+
+    if sequences.is_empty() {
+        return Vec::new();
+    }
+
+    let existing_skills = load_existing_skills(skills_dir);
+
+    sequences
+        .into_iter()
+        .map(|seq| {
+            let (already_covered, covered_by) = check_coverage(&seq, &existing_skills);
+            SkillSuggestion {
+                fingerprint: seq.fingerprint,
+                tools: seq.tools,
+                occurrences: seq.occurrences,
+                already_covered,
+                covered_by,
+            }
+        })
+        .collect()
+}
+
+fn load_existing_skills(skills_dir: &Path) -> Vec<SkillDefinition> {
+    if !skills_dir.exists() {
+        return Vec::new();
+    }
+    match SkillScanner::new(skills_dir).discover() {
+        Ok(skills) => skills,
+        Err(e) => {
+            warn!("skill suggester: failed to scan skills directory: {e}");
+            Vec::new()
+        }
+    }
+}
+
+/// Check if any existing skill already covers the given tool sequence.
+///
+/// Coverage is determined by checking whether the skill's name, description,
+/// or triggers mention any of the tool names in the sequence. This is a
+/// heuristic — it avoids duplicate suggestions for workflows that are already
+/// captured as skills.
+fn check_coverage(
+    seq: &RepeatedToolSequence,
+    skills: &[SkillDefinition],
+) -> (bool, Option<String>) {
+    for skill in skills {
+        let haystack = format!(
+            "{} {} {}",
+            skill.frontmatter.name,
+            skill.frontmatter.description,
+            skill.frontmatter.triggers.join(" "),
+        )
+        .to_lowercase();
+
+        let matches = seq
+            .tools
+            .iter()
+            .filter(|tool| {
+                haystack.contains(tool.replace('_', " ").as_str())
+                    || haystack.contains(tool.as_str())
+            })
+            .count();
+
+        // If at least half the tools in the sequence are mentioned in the skill → covered.
+        if matches * 2 >= seq.tools.len() {
+            return (true, Some(skill.frontmatter.name.clone()));
+        }
+    }
+    (false, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn make_trajectory_store() -> Arc<TrajectoryStore> {
+        Arc::new(TrajectoryStore::in_memory().expect("in-memory store"))
+    }
+
+    fn log_sequence(store: &TrajectoryStore, session: &str, turn: u32, tools: &[&str]) {
+        for tool in tools {
+            store.log_tool_call(session, turn, tool, "{}").unwrap();
+            store
+                .log_tool_result(session, turn, tool, "out", 10)
+                .unwrap();
+        }
+        store.log_turn_end(session, turn, "done", 0).unwrap();
+    }
+
+    #[test]
+    fn returns_empty_when_no_repeated_sequences() {
+        let store = make_trajectory_store();
+        log_sequence(&store, "s1", 0, &["web_search", "summarize"]);
+        // Only 1 occurrence → below default min_occurrences=3
+        let suggestions = suggest_from_trajectories(&store, Path::new("/nonexistent"), 3);
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn returns_suggestion_when_sequence_repeated() {
+        let store = make_trajectory_store();
+        for i in 0..3u32 {
+            log_sequence(&store, "s1", i, &["web_search", "doc_search"]);
+        }
+        let suggestions = suggest_from_trajectories(&store, Path::new("/nonexistent"), 3);
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].fingerprint, "web_search → doc_search");
+        assert_eq!(suggestions[0].occurrences, 3);
+        assert!(!suggestions[0].already_covered);
+    }
+
+    #[test]
+    fn not_covered_when_skills_dir_missing() {
+        let store = make_trajectory_store();
+        for i in 0..3u32 {
+            log_sequence(&store, "s1", i, &["web_search", "summarize"]);
+        }
+        let suggestions = suggest_from_trajectories(&store, Path::new("/nonexistent/skills"), 3);
+        assert_eq!(suggestions.len(), 1);
+        assert!(!suggestions[0].already_covered);
+        assert!(suggestions[0].covered_by.is_none());
+    }
+}

--- a/crates/opencrust-config/src/model.rs
+++ b/crates/opencrust-config/src/model.rs
@@ -232,6 +232,9 @@ pub struct AgentConfig {
     /// Max skills injected per turn via semantic search (default: 5).
     /// When skill count ≤ this limit all skills are always injected (no embedding call needed).
     pub skill_recall_limit: Option<usize>,
+    /// Persist every tool call and result to a trajectory database for analysis and training.
+    /// Default: false. Stored in `{data_dir}/trajectories.db`.
+    pub collect_trajectories: Option<bool>,
 }
 
 /// A named agent configuration for multi-agent routing.

--- a/crates/opencrust-db/src/lib.rs
+++ b/crates/opencrust-db/src/lib.rs
@@ -11,5 +11,7 @@ pub use memory_store::{
     RecallQuery, SessionContext,
 };
 pub use session_store::{ScheduledTask, SessionStore, UsageAttribution, UsageRecord};
-pub use trajectory_store::{TrajectoryEvent, TrajectoryEventType, TrajectoryStore};
+pub use trajectory_store::{
+    RepeatedToolSequence, TrajectoryEvent, TrajectoryEventType, TrajectoryStore,
+};
 pub use vector_store::VectorStore;

--- a/crates/opencrust-db/src/lib.rs
+++ b/crates/opencrust-db/src/lib.rs
@@ -2,6 +2,7 @@ pub mod document_store;
 pub mod memory_store;
 pub mod migrations;
 pub mod session_store;
+pub mod trajectory_store;
 pub mod vector_store;
 
 pub use document_store::{DocumentChunk, DocumentInfo, DocumentStore};
@@ -10,4 +11,5 @@ pub use memory_store::{
     RecallQuery, SessionContext,
 };
 pub use session_store::{ScheduledTask, SessionStore, UsageAttribution, UsageRecord};
+pub use trajectory_store::{TrajectoryEvent, TrajectoryEventType, TrajectoryStore};
 pub use vector_store::VectorStore;

--- a/crates/opencrust-db/src/trajectory_store.rs
+++ b/crates/opencrust-db/src/trajectory_store.rs
@@ -1,0 +1,317 @@
+use chrono::Utc;
+use opencrust_common::{Error, Result};
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+/// A single recorded step within a turn's tool loop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryEvent {
+    pub id: String,
+    pub session_id: String,
+    pub turn_index: u32,
+    pub event_type: TrajectoryEventType,
+    pub tool_name: Option<String>,
+    /// JSON-encoded input args (tool_call) or output text (tool_result / turn_end).
+    pub payload: String,
+    pub latency_ms: Option<u64>,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrajectoryEventType {
+    ToolCall,
+    ToolResult,
+    TurnEnd,
+}
+
+impl TrajectoryEventType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::ToolCall => "tool_call",
+            Self::ToolResult => "tool_result",
+            Self::TurnEnd => "turn_end",
+        }
+    }
+
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "tool_call" => Some(Self::ToolCall),
+            "tool_result" => Some(Self::ToolResult),
+            "turn_end" => Some(Self::TurnEnd),
+            _ => None,
+        }
+    }
+}
+
+/// SQLite-backed store for per-turn trajectory events.
+///
+/// Each turn in the agent tool loop produces a sequence of `tool_call` /
+/// `tool_result` pairs followed by a single `turn_end` event. These are
+/// used for skill auto-suggestion, debug replay, and training-data export.
+pub struct TrajectoryStore {
+    conn: Mutex<Connection>,
+}
+
+impl TrajectoryStore {
+    pub fn open(db_path: &Path) -> Result<Self> {
+        let conn = Connection::open(db_path)
+            .map_err(|e| Error::Database(format!("failed to open trajectory db: {e}")))?;
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
+        store.run_migrations()?;
+        Ok(store)
+    }
+
+    pub fn in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory()
+            .map_err(|e| Error::Database(format!("failed to open in-memory trajectory db: {e}")))?;
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
+        store.run_migrations()?;
+        Ok(store)
+    }
+
+    fn run_migrations(&self) -> Result<()> {
+        let conn = self.connection()?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS trajectory_events (
+                id          TEXT PRIMARY KEY,
+                session_id  TEXT NOT NULL,
+                turn_index  INTEGER NOT NULL,
+                event_type  TEXT NOT NULL,
+                tool_name   TEXT,
+                payload     TEXT NOT NULL,
+                latency_ms  INTEGER,
+                created_at  TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_traj_session
+                ON trajectory_events(session_id, turn_index, created_at);",
+        )
+        .map_err(|e| Error::Database(format!("trajectory migration failed: {e}")))?;
+        Ok(())
+    }
+
+    fn connection(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {
+        self.conn
+            .lock()
+            .map_err(|_| Error::Database("trajectory store lock poisoned".into()))
+    }
+
+    fn insert(&self, event: &TrajectoryEvent) -> Result<()> {
+        let conn = self.connection()?;
+        conn.execute(
+            "INSERT INTO trajectory_events
+             (id, session_id, turn_index, event_type, tool_name, payload, latency_ms, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                event.id,
+                event.session_id,
+                event.turn_index,
+                event.event_type.as_str(),
+                event.tool_name,
+                event.payload,
+                event.latency_ms.map(|v| v as i64),
+                event.created_at,
+            ],
+        )
+        .map_err(|e| Error::Database(format!("trajectory insert failed: {e}")))?;
+        Ok(())
+    }
+
+    /// Record that a tool was about to be called.
+    pub fn log_tool_call(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        tool_name: &str,
+        input_json: &str,
+    ) -> Result<()> {
+        self.insert(&TrajectoryEvent {
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            turn_index,
+            event_type: TrajectoryEventType::ToolCall,
+            tool_name: Some(tool_name.to_string()),
+            payload: input_json.to_string(),
+            latency_ms: None,
+            created_at: Utc::now().to_rfc3339(),
+        })
+    }
+
+    /// Record the result of a tool call.
+    pub fn log_tool_result(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        tool_name: &str,
+        output_text: &str,
+        latency_ms: u64,
+    ) -> Result<()> {
+        self.insert(&TrajectoryEvent {
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            turn_index,
+            event_type: TrajectoryEventType::ToolResult,
+            tool_name: Some(tool_name.to_string()),
+            payload: output_text.to_string(),
+            latency_ms: Some(latency_ms),
+            created_at: Utc::now().to_rfc3339(),
+        })
+    }
+
+    /// Record the final assistant output at the end of a turn.
+    pub fn log_turn_end(
+        &self,
+        session_id: &str,
+        turn_index: u32,
+        final_output: &str,
+        total_tokens: u32,
+    ) -> Result<()> {
+        let payload = serde_json::json!({
+            "output": final_output,
+            "total_tokens": total_tokens,
+        })
+        .to_string();
+        self.insert(&TrajectoryEvent {
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            turn_index,
+            event_type: TrajectoryEventType::TurnEnd,
+            tool_name: None,
+            payload,
+            latency_ms: None,
+            created_at: Utc::now().to_rfc3339(),
+        })
+    }
+
+    /// Return all trajectory events for a session ordered by turn and time.
+    pub fn export_session(&self, session_id: &str) -> Result<Vec<TrajectoryEvent>> {
+        let conn = self.connection()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, session_id, turn_index, event_type, tool_name, payload, latency_ms, created_at
+                 FROM trajectory_events
+                 WHERE session_id = ?1
+                 ORDER BY turn_index, created_at",
+            )
+            .map_err(|e| Error::Database(format!("trajectory export prepare failed: {e}")))?;
+
+        let rows = stmt
+            .query_map(params![session_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, u32>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, Option<i64>>(6)?,
+                    row.get::<_, String>(7)?,
+                ))
+            })
+            .map_err(|e| Error::Database(format!("trajectory export query failed: {e}")))?;
+
+        rows.map(|r| {
+            r.map_err(|e| Error::Database(format!("trajectory row error: {e}")))
+                .and_then(|(id, sid, ti, et, tn, payload, lat, ca)| {
+                    let event_type = TrajectoryEventType::from_str(&et)
+                        .ok_or_else(|| Error::Database(format!("unknown event_type: {et}")))?;
+                    Ok(TrajectoryEvent {
+                        id,
+                        session_id: sid,
+                        turn_index: ti,
+                        event_type,
+                        tool_name: tn,
+                        payload,
+                        latency_ms: lat.map(|v| v as u64),
+                        created_at: ca,
+                    })
+                })
+        })
+        .collect()
+    }
+
+    /// Count total stored events for a session.
+    pub fn count_session_events(&self, session_id: &str) -> Result<usize> {
+        let conn = self.connection()?;
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM trajectory_events WHERE session_id = ?1",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| Error::Database(format!("trajectory count failed: {e}")))?;
+        Ok(count as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_store() -> TrajectoryStore {
+        TrajectoryStore::in_memory().expect("in-memory store should open")
+    }
+
+    #[test]
+    fn log_and_export_round_trip() {
+        let store = make_store();
+        store
+            .log_tool_call("s1", 0, "web_search", r#"{"query":"X"}"#)
+            .unwrap();
+        store
+            .log_tool_result("s1", 0, "web_search", "results...", 320)
+            .unwrap();
+        store.log_turn_end("s1", 0, "final answer", 500).unwrap();
+
+        let events = store.export_session("s1").unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].event_type, TrajectoryEventType::ToolCall);
+        assert_eq!(events[1].event_type, TrajectoryEventType::ToolResult);
+        assert_eq!(events[1].latency_ms, Some(320));
+        assert_eq!(events[2].event_type, TrajectoryEventType::TurnEnd);
+    }
+
+    #[test]
+    fn export_scoped_to_session() {
+        let store = make_store();
+        store.log_tool_call("s1", 0, "tool_a", "{}").unwrap();
+        store.log_tool_call("s2", 0, "tool_b", "{}").unwrap();
+
+        let s1 = store.export_session("s1").unwrap();
+        let s2 = store.export_session("s2").unwrap();
+        assert_eq!(s1.len(), 1);
+        assert_eq!(s2.len(), 1);
+        assert_eq!(s1[0].tool_name.as_deref(), Some("tool_a"));
+        assert_eq!(s2[0].tool_name.as_deref(), Some("tool_b"));
+    }
+
+    #[test]
+    fn count_session_events_correct() {
+        let store = make_store();
+        store.log_tool_call("s1", 0, "t", "{}").unwrap();
+        store.log_tool_result("s1", 0, "t", "out", 10).unwrap();
+        store.log_turn_end("s1", 0, "done", 100).unwrap();
+        assert_eq!(store.count_session_events("s1").unwrap(), 3);
+        assert_eq!(store.count_session_events("s2").unwrap(), 0);
+    }
+
+    #[test]
+    fn events_ordered_by_turn_then_time() {
+        let store = make_store();
+        store.log_turn_end("s1", 1, "turn1", 100).unwrap();
+        store.log_tool_call("s1", 0, "tool", "{}").unwrap();
+        store.log_turn_end("s1", 0, "turn0", 50).unwrap();
+
+        let events = store.export_session("s1").unwrap();
+        assert_eq!(events[0].turn_index, 0);
+        assert_eq!(events[0].event_type, TrajectoryEventType::ToolCall);
+        assert_eq!(events[2].turn_index, 1);
+    }
+}

--- a/crates/opencrust-db/src/trajectory_store.rs
+++ b/crates/opencrust-db/src/trajectory_store.rs
@@ -47,6 +47,19 @@ impl TrajectoryEventType {
     }
 }
 
+/// A tool-call sequence that appears repeatedly across sessions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepeatedToolSequence {
+    /// Human-readable fingerprint, e.g. "web_search → web_search → summarize".
+    pub fingerprint: String,
+    /// Ordered list of tool names in this sequence.
+    pub tools: Vec<String>,
+    /// Number of turns where this exact sequence was observed.
+    pub occurrences: usize,
+    /// One session_id where this sequence was seen (for context).
+    pub example_session: String,
+}
+
 /// SQLite-backed store for per-turn trajectory events.
 ///
 /// Each turn in the agent tool loop produces a sequence of `tool_call` /
@@ -237,6 +250,90 @@ impl TrajectoryStore {
         .collect()
     }
 
+    /// Return tool sequences (ordered list of tool names per turn) that appear at least
+    /// `min_occurrences` times across all sessions.
+    ///
+    /// A "sequence" is the ordered list of tool names called within one turn (one
+    /// user→assistant exchange). Sequences with a single tool call are excluded
+    /// because single-tool patterns are too coarse for skill suggestions.
+    pub fn find_repeated_tool_sequences(
+        &self,
+        min_occurrences: usize,
+    ) -> Result<Vec<RepeatedToolSequence>> {
+        let conn = self.connection()?;
+
+        // Fetch all tool_call events ordered so we can group by (session, turn).
+        let mut stmt = conn
+            .prepare(
+                "SELECT session_id, turn_index, tool_name
+                 FROM trajectory_events
+                 WHERE event_type = 'tool_call' AND tool_name IS NOT NULL
+                 ORDER BY session_id, turn_index, created_at",
+            )
+            .map_err(|e| Error::Database(format!("trajectory sequence prepare failed: {e}")))?;
+
+        // Collect (session_id, turn_index) → [tool_name, ...].
+        let mut turn_tools: std::collections::HashMap<(String, u32), Vec<String>> =
+            std::collections::HashMap::new();
+        let mut example_sessions: std::collections::HashMap<String, String> =
+            std::collections::HashMap::new();
+
+        let rows = stmt
+            .query_map(rusqlite::params![], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, u32>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })
+            .map_err(|e| Error::Database(format!("trajectory sequence query failed: {e}")))?;
+
+        for row in rows {
+            let (session_id, turn_index, tool_name) =
+                row.map_err(|e| Error::Database(format!("trajectory row error: {e}")))?;
+            turn_tools
+                .entry((session_id.clone(), turn_index))
+                .or_default()
+                .push(tool_name);
+            example_sessions
+                .entry(session_id.clone() + &turn_index.to_string())
+                .or_insert(session_id);
+        }
+
+        // Count how often each tool sequence fingerprint appears.
+        let mut counts: std::collections::HashMap<String, (usize, Vec<String>, String)> =
+            std::collections::HashMap::new();
+
+        for ((session_id, turn_index), tools) in &turn_tools {
+            if tools.len() < 2 {
+                continue; // single-tool turns are too coarse
+            }
+            let fingerprint = tools.join(" → ");
+            let key = session_id.clone() + &turn_index.to_string();
+            let example = example_sessions.get(&key).cloned().unwrap_or_default();
+            let entry = counts
+                .entry(fingerprint)
+                .or_insert((0, tools.clone(), example));
+            entry.0 += 1;
+        }
+
+        let mut results: Vec<RepeatedToolSequence> = counts
+            .into_iter()
+            .filter(|(_, (count, _, _))| *count >= min_occurrences)
+            .map(
+                |(fingerprint, (occurrences, tools, example_session))| RepeatedToolSequence {
+                    fingerprint,
+                    tools,
+                    occurrences,
+                    example_session,
+                },
+            )
+            .collect();
+
+        results.sort_by(|a, b| b.occurrences.cmp(&a.occurrences));
+        Ok(results)
+    }
+
     /// Count total stored events for a session.
     pub fn count_session_events(&self, session_id: &str) -> Result<usize> {
         let conn = self.connection()?;
@@ -313,5 +410,67 @@ mod tests {
         assert_eq!(events[0].turn_index, 0);
         assert_eq!(events[0].event_type, TrajectoryEventType::ToolCall);
         assert_eq!(events[2].turn_index, 1);
+    }
+
+    fn log_sequence(store: &TrajectoryStore, session: &str, turn: u32, tools: &[&str]) {
+        for tool in tools {
+            store.log_tool_call(session, turn, tool, "{}").unwrap();
+            store
+                .log_tool_result(session, turn, tool, "out", 10)
+                .unwrap();
+        }
+        store.log_turn_end(session, turn, "done", 0).unwrap();
+    }
+
+    #[test]
+    fn repeated_sequence_detected() {
+        let store = make_store();
+        // Same sequence in 3 different turns across 2 sessions
+        log_sequence(&store, "s1", 0, &["web_search", "summarize"]);
+        log_sequence(&store, "s1", 1, &["web_search", "summarize"]);
+        log_sequence(&store, "s2", 0, &["web_search", "summarize"]);
+
+        let results = store.find_repeated_tool_sequences(2).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].fingerprint, "web_search → summarize");
+        assert_eq!(results[0].occurrences, 3);
+    }
+
+    #[test]
+    fn below_min_occurrences_excluded() {
+        let store = make_store();
+        log_sequence(&store, "s1", 0, &["web_search", "summarize"]);
+        log_sequence(&store, "s1", 1, &["doc_search", "summarize"]);
+
+        // Both sequences appear only once → neither meets min_occurrences=2
+        let results = store.find_repeated_tool_sequences(2).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn single_tool_turns_excluded() {
+        let store = make_store();
+        // Single-tool turns should never be suggested
+        log_sequence(&store, "s1", 0, &["web_search"]);
+        log_sequence(&store, "s1", 1, &["web_search"]);
+        log_sequence(&store, "s2", 0, &["web_search"]);
+
+        let results = store.find_repeated_tool_sequences(2).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn results_sorted_by_occurrences_desc() {
+        let store = make_store();
+        log_sequence(&store, "s1", 0, &["web_search", "summarize"]);
+        log_sequence(&store, "s1", 1, &["web_search", "summarize"]);
+        log_sequence(&store, "s2", 0, &["web_search", "summarize"]);
+
+        log_sequence(&store, "s3", 0, &["doc_search", "web_search"]);
+        log_sequence(&store, "s3", 1, &["doc_search", "web_search"]);
+
+        let results = store.find_repeated_tool_sequences(2).unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results[0].occurrences >= results[1].occurrences);
     }
 }

--- a/crates/opencrust-db/src/trajectory_store.rs
+++ b/crates/opencrust-db/src/trajectory_store.rs
@@ -330,7 +330,7 @@ impl TrajectoryStore {
             )
             .collect();
 
-        results.sort_by(|a, b| b.occurrences.cmp(&a.occurrences));
+        results.sort_by_key(|b| std::cmp::Reverse(b.occurrences));
         Ok(results)
     }
 

--- a/crates/opencrust-gateway/src/bootstrap.rs
+++ b/crates/opencrust-gateway/src/bootstrap.rs
@@ -18,7 +18,7 @@ use opencrust_channels::{
 #[cfg(target_os = "macos")]
 use opencrust_channels::{IMessageChannel, IMessageGroupFilter, IMessageOnMessageFn};
 use opencrust_config::AppConfig;
-use opencrust_db::{MemoryStore, VectorStore};
+use opencrust_db::{MemoryStore, TrajectoryStore, VectorStore};
 use opencrust_security::{Allowlist, ChannelPolicy, DmAuthResult, PairingManager, check_dm_auth};
 use tracing::{info, warn};
 
@@ -608,6 +608,20 @@ pub async fn build_agent_runtime(config: &AppConfig) -> (AgentRuntime, SendMessa
     }
     if let Some(limit) = config.agent.skill_recall_limit {
         runtime.set_skill_recall_limit(limit);
+    }
+    if config.agent.collect_trajectories.unwrap_or(false) {
+        let traj_dir = config
+            .data_dir
+            .clone()
+            .unwrap_or_else(|| opencrust_config::ConfigLoader::default_config_dir().join("data"));
+        let traj_path = traj_dir.join("trajectories.db");
+        match TrajectoryStore::open(&traj_path) {
+            Ok(store) => {
+                runtime.set_trajectory_store(Arc::new(store));
+                info!("trajectory store opened at {}", traj_path.display());
+            }
+            Err(e) => warn!("failed to open trajectory store: {e}"),
+        }
     }
 
     // --- Skills ---


### PR DESCRIPTION
## Summary

- Adds `find_repeated_tool_sequences` to `TrajectoryStore` — queries trajectory data and returns tool sequences that repeat across turns, sorted by frequency
- New `SkillSuggester` module checks repeated sequences against existing skills to avoid proposing duplicates
- `AgentRuntime::suggest_skills(min_occurrences)` — public API to get suggestions at any time

Depends on #367 (trajectory collection).

## Why

The existing `skill_nudge_followup` fires per-turn (after ≥3 tool calls) and asks the user whether to save. This works but:
- Fires every turn even if user repeatedly declines
- Has no visibility into whether similar patterns appear across many sessions

`suggest_skills` enables a qualitatively different approach: analyse many sessions at once, surface patterns the user hasn't captured yet, and skip ones already covered by existing skills.

## Usage

```rust
// After collecting trajectories for a while:
let suggestions = runtime.suggest_skills(3); // seen ≥ 3 times
for s in suggestions.iter().filter(|s| !s.already_covered) {
    println!("Consider saving '{}' as a skill ({} occurrences)", s.fingerprint, s.occurrences);
}
```

## Test plan

- [ ] `cargo test -p opencrust-db` — 4 new pattern-detection tests pass
- [ ] `cargo test -p opencrust-agents` — 3 new suggester tests pass
- [ ] `cargo test` — all tests pass, no regressions
- [ ] `cargo clippy -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)