### PR TITLE
feat(db,agents): skill usage tracking, pruning, and auto-suggest rate-limiting

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -32,6 +32,8 @@ const DEFAULT_SKILL_RECALL_LIMIT: usize = 5;
 const SKILL_SIMILARITY_THRESHOLD: f64 = 0.25;
 /// Minimum confidence (0–1) required before the refine nudge applies a patch.
 const SKILL_REFINE_CONFIDENCE_THRESHOLD: f64 = 0.7;
+/// Minimum number of cross-session occurrences before a trajectory pattern triggers auto-save.
+const TRAJECTORY_AUTO_SUGGEST_MIN_OCCURRENCES: usize = 5;
 
 /// Default base system prompt when none is configured.
 const DEFAULT_BASE_SYSTEM_PROMPT: &str = "\
@@ -1091,8 +1093,142 @@ impl AgentRuntime {
         None
     }
 
-    /// Dispatch to `skill_refine_nudge_followup` when skills were injected,
-    /// or `skill_nudge_followup` when discovering a new workflow.
+    /// Auto-save a skill when trajectory data shows a cross-session repeated tool sequence
+    /// that is not yet covered by an existing skill.
+    ///
+    /// Fires only when:
+    /// - Trajectory collection is enabled.
+    /// - `tool_call_count >= SKILL_REFLECTION_THRESHOLD` (avoids running on trivial turns).
+    /// - `create_skill` tool is registered.
+    /// - At least one uncovered pattern meets `TRAJECTORY_AUTO_SUGGEST_MIN_OCCURRENCES`.
+    ///
+    /// Makes two LLM calls:
+    /// 1. Ask the model to generate a skill body for the top pattern.
+    /// 2. Execute `create_skill` with `action='create'` to persist it.
+    ///
+    /// Returns a brief user-visible note on success, or `None` when skipped / failed.
+    async fn trajectory_auto_suggest_followup(
+        &self,
+        tool_call_count: usize,
+        ctx: NudgeContext<'_>,
+        session_id: &str,
+    ) -> Option<String> {
+        if tool_call_count < SKILL_REFLECTION_THRESHOLD {
+            return None;
+        }
+        self.trajectory_store.as_ref()?;
+        let create_skill_def = self
+            .tools
+            .iter()
+            .find(|t| t.name() == "create_skill")
+            .map(|t| ToolDefinition {
+                name: t.name().to_string(),
+                description: t.description().to_string(),
+                input_schema: t.input_schema(),
+            })?;
+
+        let suggestions = self.suggest_skills(TRAJECTORY_AUTO_SUGGEST_MIN_OCCURRENCES);
+        let candidate = suggestions.into_iter().find(|s| !s.already_covered)?;
+
+        let NudgeContext {
+            provider,
+            messages,
+            system,
+            model,
+            max_tokens,
+            ..
+        } = ctx;
+
+        // ── Round 1: generate skill body ─────────────────────────────────────
+        let mut msgs = messages.to_vec();
+        msgs.push(ChatMessage {
+            role: ChatRole::User,
+            content: MessagePart::Text(format!(
+                "[internal] The trajectory log shows the tool sequence '{}' has been used \
+                 {} times across sessions and is not yet captured as a skill. \
+                 Generate a concise, reusable skill for this workflow. \
+                 Call create_skill with action='create', providing name, description, \
+                 body (≥80 chars), rationale (≥40 chars), and triggers. \
+                 Use the same language the user writes in. Do not ask the user for confirmation.",
+                candidate.fingerprint, candidate.occurrences
+            )),
+        });
+        let request = LlmRequest {
+            model: model.to_string(),
+            messages: msgs,
+            system: system.clone(),
+            max_tokens: Some(max_tokens.min(1024)),
+            temperature: None,
+            tools: vec![create_skill_def],
+        };
+        let response = match provider.complete(&request).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("trajectory auto-suggest LLM call failed: {e}");
+                return None;
+            }
+        };
+        if let Some(usage) = &response.usage {
+            self.accumulate_usage(
+                session_id,
+                provider.provider_id(),
+                &response.model,
+                usage.input_tokens,
+                usage.output_tokens,
+            );
+        }
+
+        // ── Round 2: execute create_skill if the model called it ─────────────
+        for block in &response.content {
+            if let ContentBlock::ToolUse { name, input, .. } = block
+                && name == "create_skill"
+                && input
+                    .get("action")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("create")
+                    == "create"
+            {
+                let skill_name = input
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                let tool_ctx = ToolContext {
+                    session_id: session_id.to_string(),
+                    user_id: None,
+                    heartbeat_depth: 0,
+                    allowed_tools: None,
+                };
+                if let Some(tool) = self.find_tool("create_skill") {
+                    match tool.execute(&tool_ctx, input.clone()).await {
+                        Ok(out) if !out.is_error => {
+                            info!(
+                                "trajectory auto-suggest: saved skill '{skill_name}' \
+                                 from pattern '{}'",
+                                candidate.fingerprint
+                            );
+                            return Some(format!(
+                                "_(Auto-saved skill '{skill_name}' from repeated workflow \
+                                 '{}'.)_",
+                                candidate.fingerprint
+                            ));
+                        }
+                        Ok(out) => warn!("trajectory auto-suggest create failed: {}", out.content),
+                        Err(e) => warn!("trajectory auto-suggest create error: {e}"),
+                    }
+                }
+                return None;
+            }
+        }
+        None
+    }
+
+    /// Dispatch post-turn skill follow-ups:
+    ///
+    /// 1. If skills were injected → `skill_refine_nudge_followup` (patch existing skill).
+    /// 2. Otherwise, try `trajectory_auto_suggest_followup` first — auto-save a skill when
+    ///    a cross-session pattern meets the threshold.
+    /// 3. Fall back to `skill_nudge_followup` (ask the user) when no pattern qualifies.
     async fn skill_completion_followup(
         &self,
         tool_call_count: usize,
@@ -1100,13 +1236,42 @@ impl AgentRuntime {
         ctx: NudgeContext<'_>,
         session_id: &str,
     ) -> Option<String> {
+        // All NudgeContext fields are references (Copy) — destructure so we can
+        // pass them to multiple async calls without cloning the pointed-to data.
+        let NudgeContext {
+            provider,
+            messages,
+            system,
+            model,
+            max_tokens,
+            skills_content,
+        } = ctx;
+
+        let make_ctx = || NudgeContext {
+            provider,
+            messages,
+            system,
+            model,
+            max_tokens,
+            skills_content,
+        };
+
         if skills_were_injected {
-            self.skill_refine_nudge_followup(tool_call_count, ctx, session_id)
-                .await
-        } else {
-            self.skill_nudge_followup(tool_call_count, ctx, session_id)
-                .await
+            return self
+                .skill_refine_nudge_followup(tool_call_count, make_ctx(), session_id)
+                .await;
         }
+
+        // Try trajectory-driven auto-save before falling back to the interactive nudge.
+        if let Some(note) = self
+            .trajectory_auto_suggest_followup(tool_call_count, make_ctx(), session_id)
+            .await
+        {
+            return Some(note);
+        }
+
+        self.skill_nudge_followup(tool_call_count, make_ctx(), session_id)
+            .await
     }
 
     /// Record a tool call for debug output.

--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -34,6 +34,10 @@ const SKILL_SIMILARITY_THRESHOLD: f64 = 0.25;
 const SKILL_REFINE_CONFIDENCE_THRESHOLD: f64 = 0.7;
 /// Minimum number of cross-session occurrences before a trajectory pattern triggers auto-save.
 const TRAJECTORY_AUTO_SUGGEST_MIN_OCCURRENCES: usize = 5;
+/// Cooldown between trajectory auto-suggest checks (seconds). Prevents querying the DB every turn.
+const TRAJECTORY_SUGGEST_COOLDOWN_SECS: u64 = 600;
+/// Skills not used within this many days are candidates for pruning.
+const SKILL_PRUNE_UNUSED_DAYS: u64 = 30;
 
 /// Default base system prompt when none is configured.
 const DEFAULT_BASE_SYSTEM_PROMPT: &str = "\
@@ -87,6 +91,9 @@ pub struct AgentRuntime {
     trajectory_store: Option<Arc<TrajectoryStore>>,
     /// Per-session turn counter used to order trajectory events.
     session_turn_index: DashMap<String, u32>,
+    /// Timestamp of the last trajectory auto-suggest check. Used to rate-limit
+    /// the cross-session pattern query (at most once per 10 minutes).
+    trajectory_last_suggest_at: Mutex<Option<std::time::Instant>>,
     /// Path to the document store DB for auto-RAG injection.
     doc_db_path: Option<PathBuf>,
     /// Cached document store opened once at startup for auto-RAG.
@@ -145,6 +152,7 @@ impl AgentRuntime {
             debug_accumulator: Mutex::new(HashMap::new()),
             trajectory_store: None,
             session_turn_index: DashMap::new(),
+            trajectory_last_suggest_at: Mutex::new(None),
         }
     }
 
@@ -381,6 +389,74 @@ impl AgentRuntime {
                 .log_turn_end(session_id, turn_index, output, tokens)
                 .unwrap_or_else(|e| warn!("trajectory log_turn_end failed: {e}"));
         }
+    }
+
+    /// Log every skill name found in a prompt block as a usage event.
+    ///
+    /// Parses `## skill-name` headings from the injected skills block so we can
+    /// track which skills are actively retrieved without changing return types of
+    /// the retrieval functions.
+    fn log_injected_skills(&self, session_id: &str, skills_block: &str) {
+        let Some(store) = &self.trajectory_store else {
+            return;
+        };
+        for line in skills_block.lines() {
+            if let Some(name) = line.strip_prefix("## ") {
+                let name = name.trim();
+                if !name.is_empty() {
+                    store
+                        .log_skill_usage(session_id, name)
+                        .unwrap_or_else(|e| warn!("skill usage log failed: {e}"));
+                }
+            }
+        }
+    }
+
+    /// Archive skills that have not been injected in any session for at least
+    /// `SKILL_PRUNE_UNUSED_DAYS` days. Archiving renames the skill folder to
+    /// `{name}.archived` so it can be recovered manually if needed.
+    ///
+    /// Returns the names of skills that were archived.
+    pub fn prune_unused_skills(&self) -> Vec<String> {
+        let Some(store) = &self.trajectory_store else {
+            return Vec::new();
+        };
+        let skills_dir = self.skills_dir();
+        let skills = match opencrust_skills::SkillScanner::new(&skills_dir).discover() {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("prune_unused_skills: skill scan failed: {e}");
+                return Vec::new();
+            }
+        };
+        if skills.is_empty() {
+            return Vec::new();
+        }
+        let cutoff = chrono::Utc::now().timestamp() - (SKILL_PRUNE_UNUSED_DAYS * 86_400) as i64;
+        let names: Vec<&str> = skills.iter().map(|s| s.frontmatter.name.as_str()).collect();
+        let unused = match store.skills_unused_since(&names, cutoff) {
+            Ok(u) => u,
+            Err(e) => {
+                warn!("prune_unused_skills: query failed: {e}");
+                return Vec::new();
+            }
+        };
+        let mut pruned = Vec::new();
+        for name in &unused {
+            let skill_dir = skills_dir.join(name);
+            let archive_dir = skills_dir.join(format!("{name}.archived"));
+            if skill_dir.is_dir() {
+                if let Err(e) = std::fs::rename(&skill_dir, &archive_dir) {
+                    warn!("prune_unused_skills: failed to archive '{name}': {e}");
+                } else {
+                    info!(
+                        "prune_unused_skills: archived skill '{name}' (unused >{SKILL_PRUNE_UNUSED_DAYS}d)"
+                    );
+                    pruned.push(name.clone());
+                }
+            }
+        }
+        pruned
     }
 
     pub fn set_summarization_enabled(&mut self, enabled: bool) {
@@ -1117,6 +1193,20 @@ impl AgentRuntime {
             return None;
         }
         self.trajectory_store.as_ref()?;
+
+        // Rate-limit: skip if we checked within the cooldown window.
+        {
+            let mut last = self
+                .trajectory_last_suggest_at
+                .lock()
+                .unwrap_or_else(|p| p.into_inner());
+            let cooldown = std::time::Duration::from_secs(TRAJECTORY_SUGGEST_COOLDOWN_SECS);
+            if last.is_some_and(|t: std::time::Instant| t.elapsed() < cooldown) {
+                return None;
+            }
+            *last = Some(std::time::Instant::now());
+        }
+
         let create_skill_def = self
             .tools
             .iter()
@@ -1764,6 +1854,9 @@ impl AgentRuntime {
 
         let dna = self.session_dna_content(session_id);
         let skills = self.session_skills_content(session_id, user_text).await;
+        if let Some(block) = &skills {
+            self.log_injected_skills(session_id, block);
+        }
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(user_text).await;
         let user_display = self.session_user_name(session_id);

--- a/crates/opencrust-agents/src/skill_suggester.rs
+++ b/crates/opencrust-agents/src/skill_suggester.rs
@@ -156,4 +156,75 @@ mod tests {
         assert!(!suggestions[0].already_covered);
         assert!(suggestions[0].covered_by.is_none());
     }
+
+    /// End-to-end: trajectory → pattern detection → skill suggestion → coverage check
+    /// with a real skill file on disk that partially covers the tool sequence.
+    #[test]
+    fn covered_when_skill_file_mentions_tools() {
+        let store = make_trajectory_store();
+        // Log "web_search → summarize" 3 times across different sessions
+        for i in 0..3u32 {
+            log_sequence(
+                &store,
+                &format!("session-{i}"),
+                0,
+                &["web_search", "summarize"],
+            );
+        }
+
+        // Write a real skill file that mentions both tools
+        let dir = tempfile::tempdir().expect("tempdir");
+        let skill_path = dir.path().join("web-summarise.md");
+        std::fs::write(
+            &skill_path,
+            r#"---
+name: web-summarise
+description: Search the web and summarise the results using web_search and summarize tools
+triggers:
+  - research
+  - summarise
+---
+Use web_search to find relevant pages, then summarize the content.
+"#,
+        )
+        .unwrap();
+
+        let suggestions = suggest_from_trajectories(&store, dir.path(), 3);
+
+        assert_eq!(suggestions.len(), 1);
+        assert!(
+            suggestions[0].already_covered,
+            "should detect that web-summarise skill covers this sequence"
+        );
+        assert_eq!(suggestions[0].covered_by.as_deref(), Some("web-summarise"));
+    }
+
+    /// End-to-end: unrelated skill does NOT suppress the suggestion.
+    #[test]
+    fn not_covered_when_skill_mentions_different_tools() {
+        let store = make_trajectory_store();
+        for i in 0..3u32 {
+            log_sequence(&store, &format!("s-{i}"), 0, &["bash", "file_write"]);
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("search-skill.md"),
+            r#"---
+name: search-skill
+description: Runs web_search and doc_search to answer questions
+triggers: []
+---
+"#,
+        )
+        .unwrap();
+
+        let suggestions = suggest_from_trajectories(&store, dir.path(), 3);
+
+        assert_eq!(suggestions.len(), 1);
+        assert!(
+            !suggestions[0].already_covered,
+            "unrelated skill should not suppress suggestion"
+        );
+    }
 }

--- a/crates/opencrust-db/src/trajectory_store.rs
+++ b/crates/opencrust-db/src/trajectory_store.rs
@@ -104,7 +104,16 @@ impl TrajectoryStore {
                 created_at  TEXT NOT NULL
             );
             CREATE INDEX IF NOT EXISTS idx_traj_session
-                ON trajectory_events(session_id, turn_index, created_at);",
+                ON trajectory_events(session_id, turn_index, created_at);
+
+            CREATE TABLE IF NOT EXISTS skill_usage_events (
+                id          TEXT PRIMARY KEY,
+                skill_name  TEXT NOT NULL,
+                session_id  TEXT NOT NULL,
+                created_at  INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_skill_usage_name
+                ON skill_usage_events(skill_name, created_at);",
         )
         .map_err(|e| Error::Database(format!("trajectory migration failed: {e}")))?;
         Ok(())
@@ -201,6 +210,59 @@ impl TrajectoryStore {
             latency_ms: None,
             created_at: Utc::now().to_rfc3339(),
         })
+    }
+
+    /// Record that a skill was injected into the system prompt for a session.
+    pub fn log_skill_usage(&self, session_id: &str, skill_name: &str) -> Result<()> {
+        let conn = self.connection()?;
+        conn.execute(
+            "INSERT INTO skill_usage_events (id, skill_name, session_id, created_at)
+             VALUES (?1, ?2, ?3, unixepoch())",
+            params![Uuid::new_v4().to_string(), skill_name, session_id],
+        )
+        .map_err(|e| Error::Database(format!("skill_usage insert failed: {e}")))?;
+        Ok(())
+    }
+
+    /// Return the unix timestamp of the most recent usage of `skill_name`,
+    /// or `None` if the skill has never been logged as used.
+    pub fn skill_last_used_at(&self, skill_name: &str) -> Result<Option<i64>> {
+        let conn = self.connection()?;
+        let mut stmt = conn
+            .prepare("SELECT MAX(created_at) FROM skill_usage_events WHERE skill_name = ?1")
+            .map_err(|e| Error::Database(format!("skill_last_used_at prepare failed: {e}")))?;
+        let ts: Option<i64> = stmt
+            .query_row(params![skill_name], |row| row.get(0))
+            .map_err(|e| Error::Database(format!("skill_last_used_at query failed: {e}")))?;
+        Ok(ts)
+    }
+
+    /// Return the names from `skill_names` that have not been used since
+    /// `cutoff_unix` (seconds since epoch). Skills with no usage record at all
+    /// are considered unused.
+    pub fn skills_unused_since(
+        &self,
+        skill_names: &[&str],
+        cutoff_unix: i64,
+    ) -> Result<Vec<String>> {
+        if skill_names.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.connection()?;
+        let mut unused = Vec::new();
+        for name in skill_names {
+            let mut stmt = conn
+                .prepare("SELECT MAX(created_at) FROM skill_usage_events WHERE skill_name = ?1")
+                .map_err(|e| Error::Database(format!("skills_unused_since prepare failed: {e}")))?;
+            let ts: Option<i64> = stmt
+                .query_row(params![name], |row| row.get(0))
+                .map_err(|e| Error::Database(format!("skills_unused_since query failed: {e}")))?;
+            match ts {
+                Some(last) if last >= cutoff_unix => {}
+                _ => unused.push(name.to_string()),
+            }
+        }
+        Ok(unused)
     }
 
     /// Return all trajectory events for a session ordered by turn and time.
@@ -472,5 +534,49 @@ mod tests {
         let results = store.find_repeated_tool_sequences(2).unwrap();
         assert_eq!(results.len(), 2);
         assert!(results[0].occurrences >= results[1].occurrences);
+    }
+
+    #[test]
+    fn skill_usage_log_and_last_used() {
+        let store = make_store();
+        assert!(store.skill_last_used_at("my-skill").unwrap().is_none());
+
+        store.log_skill_usage("s1", "my-skill").unwrap();
+        store.log_skill_usage("s2", "my-skill").unwrap();
+        store.log_skill_usage("s1", "other-skill").unwrap();
+
+        let ts = store.skill_last_used_at("my-skill").unwrap();
+        assert!(ts.is_some(), "should have a usage timestamp");
+        assert!(ts.unwrap() > 0);
+
+        let ts2 = store.skill_last_used_at("other-skill").unwrap();
+        assert!(ts2.is_some());
+    }
+
+    #[test]
+    fn skills_unused_since_returns_correct_subset() {
+        let store = make_store();
+        store.log_skill_usage("s1", "active-skill").unwrap();
+
+        // cutoff = far future → everything counts as unused
+        let far_future = chrono::Utc::now().timestamp() + 9999;
+        let unused = store
+            .skills_unused_since(&["active-skill", "never-used"], far_future)
+            .unwrap();
+        assert_eq!(unused, vec!["active-skill", "never-used"]);
+
+        // cutoff = past → recently used skill is NOT unused
+        let past = chrono::Utc::now().timestamp() - 9999;
+        let unused2 = store
+            .skills_unused_since(&["active-skill", "never-used"], past)
+            .unwrap();
+        assert_eq!(unused2, vec!["never-used"]);
+    }
+
+    #[test]
+    fn skills_unused_since_empty_input_returns_empty() {
+        let store = make_store();
+        let result = store.skills_unused_since(&[], 0).unwrap();
+        assert!(result.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Continues the self-improvement loop from #367/#368/#369, closing three gaps identified after those PRs:

- **Skill usage tracking** — every skill injected into the system prompt is logged to a new `skill_usage_events` table so the system knows which skills are actively used across sessions.
- **Skill pruning** — `prune_unused_skills()` archives (renames to `{name}.archived`) any skill folder that has not been injected in the past 30 days, keeping the library clean without destroying data.
- **Rate-limit on trajectory auto-suggest** — the cross-session pattern query now fires at most once per 10 minutes (`TRAJECTORY_SUGGEST_COOLDOWN_SECS = 600`) to prevent hitting SQLite on every qualifying turn.

### Changes

**`opencrust-db` — `trajectory_store.rs`**
- New `skill_usage_events` table (migration is additive, backward-compatible)
- `log_skill_usage(session_id, skill_name)` — insert a usage event
- `skill_last_used_at(skill_name) -> Option<i64>` — unix timestamp of last use
- `skills_unused_since(names, cutoff_unix) -> Vec<String>` — names not used since cutoff

**`opencrust-agents` — `runtime.rs`**
- `log_injected_skills(session_id, block)` — parses `## skill-name` headings from the injected skills block and calls `log_skill_usage` for each
- Called in `process_message_impl` immediately after `session_skills_content()`
- `prune_unused_skills() -> Vec<String>` — public method, archives unused skills, returns pruned names
- `trajectory_last_suggest_at: Mutex<Option<Instant>>` field + cooldown check in `trajectory_auto_suggest_followup`

### Constants

| Constant | Value | Purpose |
|---|---|---|
| `TRAJECTORY_SUGGEST_COOLDOWN_SECS` | 600 | Min seconds between trajectory pattern queries |
| `SKILL_PRUNE_UNUSED_DAYS` | 30 | Days of inactivity before a skill is archived |

## Test plan

- [ ] `cargo test --workspace` — all green (4 new unit tests for DB methods)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `skill_usage_log_and_last_used` — logs usage, returns timestamp
- [ ] `skills_unused_since_returns_correct_subset` — active vs never-used distinction
- [ ] `skills_unused_since_empty_input_returns_empty` — edge case
- [ ] Manual: enable trajectory collection, load a skill, call `prune_unused_skills()` after 0-day cutoff, confirm folder renamed to `.archived`

🤖 Generated with [Claude Code](https://claude.com/claude-code)