### PR TITLE
bench(db): batch document ingest benchmark

### DIFF
--- a/.github/workflows/doc-ingest-bench.yml
+++ b/.github/workflows/doc-ingest-bench.yml
@@ -1,0 +1,31 @@
+name: Document Ingest Benchmark
+
+on:
+  push:
+    branches:
+      - opt/opt-2-batch-doc-db-bench
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.head_ref == 'opt/opt-2-batch-doc-db-bench'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+      - name: Run benchmark tests
+        run: cargo test -p opencrust-gateway --test document_ingest_bench -- --ignored --nocapture --test-threads=1

--- a/crates/opencrust-cli/src/main.rs
+++ b/crates/opencrust-cli/src/main.rs
@@ -379,8 +379,8 @@ pub async fn run_ingest(
             }
         };
 
-        let mut chunk_error = false;
         let mut warned_embed = false;
+        let mut embeddings = Vec::with_capacity(chunks.len());
         for chunk in &chunks {
             let embedding = if let Some(provider) = embedding_provider {
                 match provider
@@ -403,31 +403,30 @@ pub async fn run_ingest(
                 None
             };
 
-            let model = embedding_provider.map(|p| p.model().to_string());
-            let dims = embedding.as_ref().map(|e| e.len());
-
-            if let Err(e) = store.add_chunk(
-                &doc_id,
-                chunk.index,
-                &chunk.text,
-                embedding.as_deref(),
-                model.as_deref(),
-                dims,
-                Some(chunk.token_count),
-            ) {
-                println!(" fail ({e})");
-                let _ = store.remove_document(&file_name);
-                chunk_error = true;
-                break;
-            }
+            embeddings.push(embedding);
         }
 
-        if chunk_error {
+        let model = embedding_provider.map(|p| p.model().to_string());
+        let batch_chunks = chunks
+            .iter()
+            .zip(embeddings.iter())
+            .map(|(chunk, embedding)| opencrust_db::NewDocumentChunk {
+                chunk_index: chunk.index,
+                text: &chunk.text,
+                embedding: embedding.as_deref(),
+                model: model.as_deref(),
+                dims: embedding.as_ref().map(|e| e.len()),
+                token_count: Some(chunk.token_count),
+            })
+            .collect::<Vec<_>>();
+
+        if let Err(e) = store.add_chunks_batch(&doc_id, &batch_chunks) {
+            println!(" fail ({e})");
+            let _ = store.remove_document(&file_name);
             summary.failed += 1;
             continue;
         }
 
-        store.update_chunk_count(&doc_id, chunks.len())?;
         println!(" done");
         summary.ingested += 1;
     }
@@ -1210,6 +1209,7 @@ async fn async_main(
                     let embedding_provider = build_embedding_provider(&config);
 
                     // Add chunks with embeddings
+                    let mut embeddings = Vec::with_capacity(chunks.len());
                     for chunk in &chunks {
                         let embedding = if let Some(ref provider) = embedding_provider {
                             match provider
@@ -1239,21 +1239,24 @@ async fn async_main(
                             None
                         };
 
-                        let model = embedding_provider.as_ref().map(|p| p.model().to_string());
-                        let dims = embedding.as_ref().map(|e| e.len());
-
-                        doc_store.add_chunk(
-                            &doc_id,
-                            chunk.index,
-                            &chunk.text,
-                            embedding.as_deref(),
-                            model.as_deref(),
-                            dims,
-                            Some(chunk.token_count),
-                        )?;
+                        embeddings.push(embedding);
                     }
 
-                    doc_store.update_chunk_count(&doc_id, chunks.len())?;
+                    let model = embedding_provider.as_ref().map(|p| p.model().to_string());
+                    let batch_chunks = chunks
+                        .iter()
+                        .zip(embeddings.iter())
+                        .map(|(chunk, embedding)| opencrust_db::NewDocumentChunk {
+                            chunk_index: chunk.index,
+                            text: &chunk.text,
+                            embedding: embedding.as_deref(),
+                            model: model.as_deref(),
+                            dims: embedding.as_ref().map(|e| e.len()),
+                            token_count: Some(chunk.token_count),
+                        })
+                        .collect::<Vec<_>>();
+
+                    doc_store.add_chunks_batch(&doc_id, &batch_chunks)?;
 
                     let has_embeddings = embedding_provider.is_some();
                     println!(

--- a/crates/opencrust-db/src/document_store.rs
+++ b/crates/opencrust-db/src/document_store.rs
@@ -31,6 +31,17 @@ pub struct DocumentChunk {
     pub score: f64,
 }
 
+/// A chunk to insert into a document store.
+#[derive(Debug, Clone, Copy)]
+pub struct NewDocumentChunk<'a> {
+    pub chunk_index: usize,
+    pub text: &'a str,
+    pub embedding: Option<&'a [f32]>,
+    pub model: Option<&'a str>,
+    pub dims: Option<usize>,
+    pub token_count: Option<usize>,
+}
+
 /// Store for RAG document ingestion and vector-based retrieval.
 ///
 /// Similarity search uses sqlite-vec KNN when available (fast, scales to
@@ -118,10 +129,7 @@ impl DocumentStore {
     // sqlite-vec helpers
     // -----------------------------------------------------------------------
 
-    /// Ensure a `vec_doc_chunks_{dims}` virtual table exists for the given
-    /// embedding dimensionality. No-op if vec is disabled or table exists.
-    fn ensure_doc_vec_table(&self, dims: usize) -> Result<()> {
-        let conn = self.connection()?;
+    fn ensure_doc_vec_table_on_conn(conn: &Connection, dims: usize) -> Result<()> {
         let table = format!("vec_doc_chunks_{dims}");
 
         let exists: bool = conn
@@ -148,11 +156,19 @@ impl DocumentStore {
     /// Insert a chunk embedding into the sqlite-vec index.
     /// Maps chunk UUID → integer rowid via `vec_doc_id_map`.
     fn insert_chunk_into_vec(&self, chunk_id: &str, embedding: &[f32], dims: usize) -> Result<()> {
-        self.ensure_doc_vec_table(dims)?;
+        let conn = self.connection()?;
+        Self::insert_chunk_into_vec_on_conn(&conn, chunk_id, embedding, dims)
+    }
+
+    fn insert_chunk_into_vec_on_conn(
+        conn: &Connection,
+        chunk_id: &str,
+        embedding: &[f32],
+        dims: usize,
+    ) -> Result<()> {
+        Self::ensure_doc_vec_table_on_conn(conn, dims)?;
         let table = format!("vec_doc_chunks_{dims}");
         let blob = embedding_to_blob(embedding);
-
-        let conn = self.connection()?;
 
         conn.execute(
             "INSERT OR IGNORE INTO vec_doc_id_map (chunk_id) VALUES (?)",
@@ -306,6 +322,72 @@ impl DocumentStore {
             id, doc_id, chunk_index
         );
         Ok(id)
+    }
+
+    /// Add many chunks in a single SQLite transaction and update the parent
+    /// document's cached chunk count. Returns generated chunk IDs in input order.
+    pub fn add_chunks_batch(
+        &self,
+        doc_id: &str,
+        chunks: &[NewDocumentChunk<'_>],
+    ) -> Result<Vec<String>> {
+        let ids = (0..chunks.len())
+            .map(|_| Uuid::new_v4().to_string())
+            .collect::<Vec<_>>();
+
+        let mut conn = self.connection()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| Error::Database(format!("failed to start chunk batch: {e}")))?;
+
+        {
+            let mut stmt = tx
+                .prepare(
+                    "INSERT INTO document_chunks (
+                        id, document_id, chunk_index, text,
+                        embedding, embedding_model, embedding_dimensions, token_count
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                )
+                .map_err(|e| Error::Database(format!("failed to prepare chunk batch: {e}")))?;
+
+            for (id, chunk) in ids.iter().zip(chunks.iter()) {
+                let embedding_blob = chunk.embedding.map(embedding_to_blob);
+                let dims_i64 = chunk.dims.map(|d| d as i64);
+                let token_count_i64 = chunk.token_count.map(|t| t as i64);
+
+                stmt.execute(params![
+                    id,
+                    doc_id,
+                    chunk.chunk_index as i64,
+                    chunk.text,
+                    embedding_blob,
+                    chunk.model,
+                    dims_i64,
+                    token_count_i64,
+                ])
+                .map_err(|e| Error::Database(format!("failed to insert document chunk: {e}")))?;
+            }
+        }
+
+        if self.vec_enabled {
+            for (id, chunk) in ids.iter().zip(chunks.iter()) {
+                if let (Some(embedding), Some(dims)) = (chunk.embedding, chunk.dims) {
+                    Self::insert_chunk_into_vec_on_conn(&tx, id, embedding, dims)?;
+                }
+            }
+        }
+
+        tx.execute(
+            "UPDATE documents SET chunk_count = ? WHERE id = ?",
+            params![chunks.len() as i64, doc_id],
+        )
+        .map_err(|e| Error::Database(format!("failed to update chunk count: {e}")))?;
+
+        tx.commit()
+            .map_err(|e| Error::Database(format!("failed to commit chunk batch: {e}")))?;
+
+        debug!("added {} chunks for document {}", chunks.len(), doc_id);
+        Ok(ids)
     }
 
     /// Update the cached chunk count on the parent document row.
@@ -977,6 +1059,53 @@ mod tests {
             .expect("get_document_by_name")
             .expect("document should exist");
         assert_eq!(doc.chunk_count, 2);
+    }
+
+    #[test]
+    fn add_chunks_batch_inserts_chunks_and_updates_count() {
+        let store = DocumentStore::in_memory().expect("store");
+        let doc_id = store
+            .add_document("batch-notes.txt", None, "text/plain")
+            .expect("add_document");
+
+        store
+            .add_chunks_batch(
+                &doc_id,
+                &[
+                    NewDocumentChunk {
+                        chunk_index: 0,
+                        text: "first chunk",
+                        embedding: None,
+                        model: None,
+                        dims: None,
+                        token_count: Some(2),
+                    },
+                    NewDocumentChunk {
+                        chunk_index: 1,
+                        text: "second chunk",
+                        embedding: None,
+                        model: None,
+                        dims: None,
+                        token_count: Some(2),
+                    },
+                ],
+            )
+            .expect("add_chunks_batch");
+
+        let doc = store
+            .get_document_by_name("batch-notes.txt")
+            .expect("get_document_by_name")
+            .expect("document should exist");
+        assert_eq!(doc.chunk_count, 2);
+
+        let chunks = store
+            .get_chunks_by_document_id(&doc_id)
+            .expect("get_chunks_by_document_id");
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert_eq!(chunks[0].text, "first chunk");
+        assert_eq!(chunks[1].chunk_index, 1);
+        assert_eq!(chunks[1].text, "second chunk");
     }
 
     #[test]

--- a/crates/opencrust-db/src/lib.rs
+++ b/crates/opencrust-db/src/lib.rs
@@ -5,7 +5,7 @@ pub mod session_store;
 pub mod trajectory_store;
 pub mod vector_store;
 
-pub use document_store::{DocumentChunk, DocumentInfo, DocumentStore};
+pub use document_store::{DocumentChunk, DocumentInfo, DocumentStore, NewDocumentChunk};
 pub use memory_store::{
     CompactionReport, MemoryEntry, MemoryProvider, MemoryRole, MemoryStore, NewMemoryEntry,
     RecallQuery, SessionContext,

--- a/crates/opencrust-gateway/src/ingest.rs
+++ b/crates/opencrust-gateway/src/ingest.rs
@@ -3,7 +3,7 @@
 use opencrust_agents::EmbeddingProvider;
 use opencrust_channels::ChannelResponse;
 use opencrust_common::{Error, Result};
-use opencrust_db::DocumentStore;
+use opencrust_db::{DocumentStore, NewDocumentChunk};
 use std::path::Path;
 use tracing::{info, warn};
 
@@ -163,6 +163,7 @@ async fn ingest_text(
 
     let has_embeddings = embedding_provider.is_some();
 
+    let mut embeddings = Vec::with_capacity(chunks.len());
     for chunk in &chunks {
         let embedding = if let Some(provider) = embedding_provider {
             match provider
@@ -182,21 +183,24 @@ async fn ingest_text(
             None
         };
 
-        let model = embedding_provider.map(|p| p.model().to_string());
-        let dims = embedding.as_ref().map(|e| e.len());
-
-        doc_store.add_chunk(
-            &doc_id,
-            chunk.index,
-            &chunk.text,
-            embedding.as_deref(),
-            model.as_deref(),
-            dims,
-            Some(chunk.token_count),
-        )?;
+        embeddings.push(embedding);
     }
 
-    doc_store.update_chunk_count(&doc_id, chunks.len())?;
+    let model = embedding_provider.map(|p| p.model().to_string());
+    let batch_chunks = chunks
+        .iter()
+        .zip(embeddings.iter())
+        .map(|(chunk, embedding)| NewDocumentChunk {
+            chunk_index: chunk.index,
+            text: &chunk.text,
+            embedding: embedding.as_deref(),
+            model: model.as_deref(),
+            dims: embedding.as_ref().map(|e| e.len()),
+            token_count: Some(chunk.token_count),
+        })
+        .collect::<Vec<_>>();
+
+    doc_store.add_chunks_batch(&doc_id, &batch_chunks)?;
 
     info!(
         "ingested '{name}': {} chunks{}",

--- a/crates/opencrust-gateway/tests/document_ingest_bench.rs
+++ b/crates/opencrust-gateway/tests/document_ingest_bench.rs
@@ -1,0 +1,358 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use opencrust_common::Result;
+use opencrust_db::{DocumentStore, NewDocumentChunk};
+use opencrust_gateway::ingest::{IngestResult, ingest_from_path};
+use opencrust_media::{ChunkOptions, chunk_text};
+
+const FIXTURE_NAME: &str = "README.md";
+const FIXTURE_TEXT: &str = include_str!("../../../README.md");
+const ITERATIONS: usize = 3;
+
+#[derive(Debug)]
+struct TimedRun {
+    duration: Duration,
+    chunk_count: usize,
+}
+
+fn median_duration(durations: &[Duration]) -> Duration {
+    let mut durations = durations.to_vec();
+    durations.sort_unstable_by_key(|d| d.as_nanos());
+    durations[durations.len() / 2]
+}
+
+fn mean_duration(durations: &[Duration]) -> Duration {
+    let total_nanos: u128 = durations.iter().map(Duration::as_nanos).sum();
+    let mean_nanos = total_nanos / durations.len() as u128;
+    Duration::from_nanos(mean_nanos as u64)
+}
+
+fn format_duration(duration: Duration) -> String {
+    format!("{:.2} ms", duration.as_secs_f64() * 1000.0)
+}
+
+fn fixture_file() -> Result<(tempfile::TempDir, PathBuf)> {
+    let dir = tempfile::tempdir().map_err(|e| {
+        opencrust_common::Error::Agent(format!(
+            "failed to create tempdir for benchmark fixture: {e}"
+        ))
+    })?;
+    let path = dir.path().join(FIXTURE_NAME);
+    fs::write(&path, FIXTURE_TEXT).map_err(|e| {
+        opencrust_common::Error::Agent(format!("failed to write benchmark fixture: {e}"))
+    })?;
+    Ok((dir, path))
+}
+
+fn doc_store_in_tempdir(dir: &tempfile::TempDir) -> Result<DocumentStore> {
+    DocumentStore::open(&dir.path().join("benchmark.db"))
+}
+
+fn legacy_ingest_from_path(path: &Path, doc_store: &DocumentStore) -> Result<IngestResult> {
+    let text = opencrust_media::extract_text(path)?;
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.display().to_string());
+    let source_path = path.display().to_string();
+    let mime = opencrust_media::detect_mime_type(path);
+    let chunks = chunk_text(&text, &ChunkOptions::default());
+
+    let doc_id = doc_store.add_document(&name, Some(source_path.as_str()), mime)?;
+    for chunk in &chunks {
+        doc_store.add_chunk(
+            &doc_id,
+            chunk.index,
+            &chunk.text,
+            None,
+            None,
+            None,
+            Some(chunk.token_count),
+        )?;
+    }
+    doc_store.update_chunk_count(&doc_id, chunks.len())?;
+
+    let doc = doc_store
+        .get_document_by_name(&name)?
+        .expect("document should exist after legacy ingest");
+    assert_eq!(doc.chunk_count, chunks.len());
+
+    Ok(IngestResult {
+        name,
+        chunk_count: chunks.len(),
+        has_embeddings: false,
+        replaced: false,
+    })
+}
+
+fn legacy_store_chunks(
+    doc_store: &DocumentStore,
+    name: &str,
+    source_path: Option<String>,
+    mime: &str,
+    chunks: &[opencrust_media::TextChunk],
+) -> Result<IngestResult> {
+    let doc_id = doc_store.add_document(name, source_path.as_deref(), mime)?;
+    for chunk in chunks {
+        doc_store.add_chunk(
+            &doc_id,
+            chunk.index,
+            &chunk.text,
+            None,
+            None,
+            None,
+            Some(chunk.token_count),
+        )?;
+    }
+    doc_store.update_chunk_count(&doc_id, chunks.len())?;
+
+    let doc = doc_store
+        .get_document_by_name(name)?
+        .expect("document should exist after legacy store");
+    assert_eq!(doc.chunk_count, chunks.len());
+
+    Ok(IngestResult {
+        name: name.to_string(),
+        chunk_count: chunks.len(),
+        has_embeddings: false,
+        replaced: false,
+    })
+}
+
+async fn batch_ingest_from_path(path: &Path, doc_store: &DocumentStore) -> Result<IngestResult> {
+    ingest_from_path(path, doc_store, None, false).await
+}
+
+fn batch_store_chunks(
+    doc_store: &DocumentStore,
+    name: &str,
+    source_path: Option<String>,
+    mime: &str,
+    chunks: &[opencrust_media::TextChunk],
+) -> Result<IngestResult> {
+    let doc_id = doc_store.add_document(name, source_path.as_deref(), mime)?;
+    let batch_chunks = chunks
+        .iter()
+        .map(|chunk| NewDocumentChunk {
+            chunk_index: chunk.index,
+            text: &chunk.text,
+            embedding: None,
+            model: None,
+            dims: None,
+            token_count: Some(chunk.token_count),
+        })
+        .collect::<Vec<_>>();
+
+    doc_store.add_chunks_batch(&doc_id, &batch_chunks)?;
+
+    let doc = doc_store
+        .get_document_by_name(name)?
+        .expect("document should exist after batch store");
+    assert_eq!(doc.chunk_count, chunks.len());
+
+    Ok(IngestResult {
+        name: name.to_string(),
+        chunk_count: chunks.len(),
+        has_embeddings: false,
+        replaced: false,
+    })
+}
+
+#[tokio::test]
+#[ignore = "benchmark"]
+async fn benchmark_full_ingest_path() {
+    let mut legacy_times = Vec::with_capacity(ITERATIONS);
+    let mut batch_times = Vec::with_capacity(ITERATIONS);
+
+    for run in 0..ITERATIONS {
+        let legacy_first = run % 2 == 0;
+
+        let (legacy, batch) = if legacy_first {
+            let (legacy_dir, legacy_path) = fixture_file().expect("fixture file");
+            let legacy_store = doc_store_in_tempdir(&legacy_dir).expect("legacy store");
+            let legacy_started = Instant::now();
+            let legacy =
+                legacy_ingest_from_path(&legacy_path, &legacy_store).expect("legacy full ingest");
+            let legacy_elapsed = legacy_started.elapsed();
+
+            let (batch_dir, batch_path) = fixture_file().expect("fixture file");
+            let batch_store = doc_store_in_tempdir(&batch_dir).expect("batch store");
+            let batch_started = Instant::now();
+            let batch = batch_ingest_from_path(&batch_path, &batch_store)
+                .await
+                .expect("batch full ingest");
+            let batch_elapsed = batch_started.elapsed();
+
+            (
+                TimedRun {
+                    duration: legacy_elapsed,
+                    chunk_count: legacy.chunk_count,
+                },
+                TimedRun {
+                    duration: batch_elapsed,
+                    chunk_count: batch.chunk_count,
+                },
+            )
+        } else {
+            let (batch_dir, batch_path) = fixture_file().expect("fixture file");
+            let batch_store = doc_store_in_tempdir(&batch_dir).expect("batch store");
+            let batch_started = Instant::now();
+            let batch = batch_ingest_from_path(&batch_path, &batch_store)
+                .await
+                .expect("batch full ingest");
+            let batch_elapsed = batch_started.elapsed();
+
+            let (legacy_dir, legacy_path) = fixture_file().expect("fixture file");
+            let legacy_store = doc_store_in_tempdir(&legacy_dir).expect("legacy store");
+            let legacy_started = Instant::now();
+            let legacy =
+                legacy_ingest_from_path(&legacy_path, &legacy_store).expect("legacy full ingest");
+            let legacy_elapsed = legacy_started.elapsed();
+
+            (
+                TimedRun {
+                    duration: legacy_elapsed,
+                    chunk_count: legacy.chunk_count,
+                },
+                TimedRun {
+                    duration: batch_elapsed,
+                    chunk_count: batch.chunk_count,
+                },
+            )
+        };
+
+        assert_eq!(legacy.chunk_count, batch.chunk_count);
+
+        println!(
+            "full ingest run {}: legacy {}, batch {}, chunks {}",
+            run + 1,
+            format_duration(legacy.duration),
+            format_duration(batch.duration),
+            legacy.chunk_count
+        );
+
+        legacy_times.push(legacy.duration);
+        batch_times.push(batch.duration);
+    }
+
+    let legacy_mean = mean_duration(&legacy_times);
+    let batch_mean = mean_duration(&batch_times);
+    let legacy_median = median_duration(&legacy_times);
+    let batch_median = median_duration(&batch_times);
+    let speedup = legacy_median.as_secs_f64() / batch_median.as_secs_f64();
+    let mean_speedup = legacy_mean.as_secs_f64() / batch_mean.as_secs_f64();
+
+    println!(
+        "full ingest summary: legacy median {}, batch median {}, speedup {:.2}x",
+        format_duration(legacy_median),
+        format_duration(batch_median),
+        speedup
+    );
+    println!(
+        "full ingest mean: legacy mean {}, batch mean {}, speedup {:.2}x",
+        format_duration(legacy_mean),
+        format_duration(batch_mean),
+        mean_speedup
+    );
+}
+
+#[test]
+#[ignore = "benchmark"]
+fn benchmark_document_store_batch_vs_legacy() {
+    let chunks = chunk_text(FIXTURE_TEXT, &ChunkOptions::default());
+    let mime = opencrust_media::detect_mime_type(Path::new(FIXTURE_NAME));
+
+    let mut legacy_times = Vec::with_capacity(ITERATIONS);
+    let mut batch_times = Vec::with_capacity(ITERATIONS);
+
+    for run in 0..ITERATIONS {
+        let legacy_first = run % 2 == 0;
+
+        let (legacy, batch) = if legacy_first {
+            let legacy_dir = tempfile::tempdir().expect("legacy tempdir");
+            let legacy_store = doc_store_in_tempdir(&legacy_dir).expect("legacy store");
+            let legacy_started = Instant::now();
+            let legacy = legacy_store_chunks(&legacy_store, FIXTURE_NAME, None, mime, &chunks)
+                .expect("legacy store chunks");
+            let legacy_elapsed = legacy_started.elapsed();
+
+            let batch_dir = tempfile::tempdir().expect("batch tempdir");
+            let batch_store = doc_store_in_tempdir(&batch_dir).expect("batch store");
+            let batch_started = Instant::now();
+            let batch = batch_store_chunks(&batch_store, FIXTURE_NAME, None, mime, &chunks)
+                .expect("batch store chunks");
+            let batch_elapsed = batch_started.elapsed();
+
+            (
+                TimedRun {
+                    duration: legacy_elapsed,
+                    chunk_count: legacy.chunk_count,
+                },
+                TimedRun {
+                    duration: batch_elapsed,
+                    chunk_count: batch.chunk_count,
+                },
+            )
+        } else {
+            let batch_dir = tempfile::tempdir().expect("batch tempdir");
+            let batch_store = doc_store_in_tempdir(&batch_dir).expect("batch store");
+            let batch_started = Instant::now();
+            let batch = batch_store_chunks(&batch_store, FIXTURE_NAME, None, mime, &chunks)
+                .expect("batch store chunks");
+            let batch_elapsed = batch_started.elapsed();
+
+            let legacy_dir = tempfile::tempdir().expect("legacy tempdir");
+            let legacy_store = doc_store_in_tempdir(&legacy_dir).expect("legacy store");
+            let legacy_started = Instant::now();
+            let legacy = legacy_store_chunks(&legacy_store, FIXTURE_NAME, None, mime, &chunks)
+                .expect("legacy store chunks");
+            let legacy_elapsed = legacy_started.elapsed();
+
+            (
+                TimedRun {
+                    duration: legacy_elapsed,
+                    chunk_count: legacy.chunk_count,
+                },
+                TimedRun {
+                    duration: batch_elapsed,
+                    chunk_count: batch.chunk_count,
+                },
+            )
+        };
+
+        assert_eq!(legacy.chunk_count, batch.chunk_count);
+
+        println!(
+            "db write run {}: legacy {}, batch {}, chunks {}",
+            run + 1,
+            format_duration(legacy.duration),
+            format_duration(batch.duration),
+            legacy.chunk_count
+        );
+
+        legacy_times.push(legacy.duration);
+        batch_times.push(batch.duration);
+    }
+
+    let legacy_mean = mean_duration(&legacy_times);
+    let batch_mean = mean_duration(&batch_times);
+    let legacy_median = median_duration(&legacy_times);
+    let batch_median = median_duration(&batch_times);
+    let speedup = legacy_median.as_secs_f64() / batch_median.as_secs_f64();
+    let mean_speedup = legacy_mean.as_secs_f64() / batch_mean.as_secs_f64();
+
+    println!(
+        "db write summary: legacy median {}, batch median {}, speedup {:.2}x",
+        format_duration(legacy_median),
+        format_duration(batch_median),
+        speedup
+    );
+    println!(
+        "db write mean: legacy mean {}, batch mean {}, speedup {:.2}x",
+        format_duration(legacy_mean),
+        format_duration(batch_mean),
+        mean_speedup
+    );
+}


### PR DESCRIPTION
## Summary

This PR adds a focused benchmark harness for document ingestion and database writes. It measures the legacy per-chunk approach against the new batched write path and prints both median and mean timings so the performance impact is easy to inspect in CI and locally.

This PR is for benchmark reporting only. It is not intended to be merged as a standalone product change.

## Changes

- [x] Add an integration benchmark that exercises the full ingest path on a real fixture
- [x] Add a lower-level benchmark that compares legacy chunk-by-chunk writes against batch writes
- [x] Report both median and mean timings for each run
- [x] Add a CI workflow that runs only the benchmark target and prints the results

## Test Plan

- [x] `cargo test -p opencrust-gateway --test document_ingest_bench -- --ignored --nocapture --test-threads=1`
- [x] `cargo fmt --all -- --check` passes
- [x] Manual testing: Ran the benchmark locally and captured the output for review

## Related Issues
None
