### PR TITLE
fix(self-improvement): wire prune, skill-usage logging, summary candidates, and daily maintenance

### DIFF
--- a/crates/opencrust-agents/src/runtime.rs
+++ b/crates/opencrust-agents/src/runtime.rs
@@ -1764,6 +1764,9 @@ impl AgentRuntime {
 
         let dna = self.session_dna_content(session_id);
         let skills = self.session_skills_content(session_id, user_text).await;
+        if let Some(block) = &skills {
+            self.log_injected_skills(session_id, block);
+        }
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(user_text).await;
         let user_display = self.session_user_name(session_id);
@@ -2145,6 +2148,9 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let skills = self.relevant_skills_content(memory_text).await;
+        if let Some(block) = &skills {
+            self.log_injected_skills(session_id, block);
+        }
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(memory_text).await;
         let user_display = self.session_user_name(session_id);
@@ -2386,6 +2392,9 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let skills = self.relevant_skills_content(memory_text).await;
+        if let Some(block) = &skills {
+            self.log_injected_skills(session_id, block);
+        }
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(memory_text).await;
         let user_display = self.session_user_name(session_id);
@@ -2730,6 +2739,9 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let skills = self.relevant_skills_content(memory_text).await;
+        if let Some(block) = &skills {
+            self.log_injected_skills(session_id, block);
+        }
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(memory_text).await;
         let user_display = self.session_user_name(session_id);
@@ -2932,6 +2944,9 @@ impl AgentRuntime {
 
         let dna = self.dna_content();
         let skills = self.relevant_skills_content(memory_text).await;
+        if let Some(block) = &skills {
+            self.log_injected_skills(session_id, block);
+        }
         let base_prompt = self.base_prompt_with_tools();
         let rag_context = self.auto_rag_context(memory_text).await;
         let user_display = self.session_user_name(session_id);

--- a/crates/opencrust-agents/src/skill_suggester.rs
+++ b/crates/opencrust-agents/src/skill_suggester.rs
@@ -21,38 +21,68 @@ pub struct SkillSuggestion {
 
 /// Analyse trajectory data against existing skills and return suggestions for
 /// new skills that would codify frequently-repeated tool workflows.
+///
+/// Merges two sources: raw tool sequences from recent sessions and
+/// LLM-extracted skill candidates from compressed (summarised) sessions.
 pub fn suggest_from_trajectories(
     trajectory_store: &Arc<TrajectoryStore>,
     skills_dir: &Path,
     min_occurrences: usize,
 ) -> Vec<SkillSuggestion> {
-    let sequences = match trajectory_store.find_repeated_tool_sequences(min_occurrences) {
-        Ok(s) => s,
-        Err(e) => {
-            warn!("skill suggester: trajectory query failed: {e}");
-            return Vec::new();
-        }
-    };
-
-    if sequences.is_empty() {
-        return Vec::new();
-    }
-
     let existing_skills = load_existing_skills(skills_dir);
 
-    sequences
-        .into_iter()
-        .map(|seq| {
-            let (already_covered, covered_by) = check_coverage(&seq, &existing_skills);
-            SkillSuggestion {
-                fingerprint: seq.fingerprint,
-                tools: seq.tools,
-                occurrences: seq.occurrences,
-                already_covered,
-                covered_by,
+    // --- raw sequences from un-compressed trajectory events ---
+    let mut suggestions: Vec<SkillSuggestion> =
+        match trajectory_store.find_repeated_tool_sequences(min_occurrences) {
+            Ok(sequences) => sequences
+                .into_iter()
+                .map(|seq| {
+                    let (already_covered, covered_by) = check_coverage(&seq, &existing_skills);
+                    SkillSuggestion {
+                        fingerprint: seq.fingerprint,
+                        tools: seq.tools,
+                        occurrences: seq.occurrences,
+                        already_covered,
+                        covered_by,
+                    }
+                })
+                .collect(),
+            Err(e) => {
+                warn!("skill suggester: trajectory query failed: {e}");
+                Vec::new()
             }
-        })
-        .collect()
+        };
+
+    // --- candidates extracted by the LLM from compressed sessions ---
+    match trajectory_store.skill_candidates_from_summaries(min_occurrences) {
+        Ok(candidates) => {
+            for cand in candidates {
+                // Raw-sequence suggestion takes precedence (it has richer tool list).
+                if suggestions
+                    .iter()
+                    .any(|s| s.fingerprint == cand.candidate_skill)
+                {
+                    continue;
+                }
+                let covered_by = existing_skills
+                    .iter()
+                    .find(|s| s.frontmatter.name == cand.candidate_skill)
+                    .map(|s| s.frontmatter.name.clone());
+                suggestions.push(SkillSuggestion {
+                    fingerprint: cand.candidate_skill,
+                    tools: Vec::new(),
+                    occurrences: cand.session_count,
+                    already_covered: covered_by.is_some(),
+                    covered_by,
+                });
+            }
+        }
+        Err(e) => {
+            warn!("skill suggester: summary candidates query failed: {e}");
+        }
+    }
+
+    suggestions
 }
 
 fn load_existing_skills(skills_dir: &Path) -> Vec<SkillDefinition> {

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -92,27 +92,28 @@ impl GatewayServer {
         let agents = Arc::new(agents);
         handoff_handle.wire(&agents);
 
-        // Compress trajectory sessions older than 90 days on startup (best-effort).
+        // Run trajectory compression and skill pruning at startup, then daily.
         {
-            let agents_for_compression = Arc::clone(&agents);
+            let agents_maintenance = Arc::clone(&agents);
             tokio::spawn(async move {
-                let n = agents_for_compression.compress_old_trajectories(90).await;
-                if n > 0 {
-                    tracing::info!("trajectory compression: compressed {n} old session(s)");
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(86_400));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    interval.tick().await;
+                    let n = agents_maintenance.compress_old_trajectories(90).await;
+                    if n > 0 {
+                        tracing::info!("trajectory compression: compressed {n} old session(s)");
+                    }
+                    let pruned = agents_maintenance.prune_unused_skills();
+                    if !pruned.is_empty() {
+                        tracing::info!(
+                            "skill pruning: archived {} unused skill(s): {}",
+                            pruned.len(),
+                            pruned.join(", ")
+                        );
+                    }
                 }
             });
-        }
-
-        // Archive skills unused for more than 30 days (best-effort, sync).
-        {
-            let pruned = agents.prune_unused_skills();
-            if !pruned.is_empty() {
-                tracing::info!(
-                    "skill pruning: archived {} unused skill(s): {}",
-                    pruned.len(),
-                    pruned.join(", ")
-                );
-            }
         }
         // SendMessageTool: create an outbound channel and wire the tool now.
         // The dispatcher task is spawned later, after channel_senders are populated.

--- a/crates/opencrust-gateway/src/server.rs
+++ b/crates/opencrust-gateway/src/server.rs
@@ -102,6 +102,18 @@ impl GatewayServer {
                 }
             });
         }
+
+        // Archive skills unused for more than 30 days (best-effort, sync).
+        {
+            let pruned = agents.prune_unused_skills();
+            if !pruned.is_empty() {
+                tracing::info!(
+                    "skill pruning: archived {} unused skill(s): {}",
+                    pruned.len(),
+                    pruned.join(", ")
+                );
+            }
+        }
         // SendMessageTool: create an outbound channel and wire the tool now.
         // The dispatcher task is spawned later, after channel_senders are populated.
         let (send_tx, send_rx) =


### PR DESCRIPTION
## Summary

Four wiring gaps found after merging the self-improvement PRs (#367–#373). All components were implemented but not fully connected:

- **`runtime.rs`** — `log_injected_skills(session_id, block)` was called at only 1 of 6 skill-injection sites. Added it to the remaining 5 paths (`process_message_with_agent_config_at_depth`, `process_message_impl`, `process_message_streaming_impl`, `process_message_summarized_impl`, `process_message_streaming_summarized_impl`). Without this, skill pruning was effectively blind to most actual usage.

- **`skill_suggester.rs`** — `suggest_from_trajectories()` only queried raw `trajectory_events`. Added a merge with `skill_candidates_from_summaries()` so sessions that have been compressed still contribute to pattern detection. Raw-sequence results take precedence (they carry the full tool list); summary candidates fill in what was lost to compression.

- **`server.rs`** — `prune_unused_skills()` was implemented but never called. Added it to the maintenance loop.

- **`server.rs`** — `compress_old_trajectories()` and `prune_unused_skills()` were one-shot startup calls. Replaced with a 24-hour `tokio::time::interval` loop (`MissedTickBehavior::Skip`) so both run daily without requiring a server restart. First tick fires at startup (t=0), preserving existing behaviour.

## Files changed

| File | Change |
|------|--------|
| `crates/opencrust-agents/src/runtime.rs` | Add `log_injected_skills` at 5 missing injection sites |
| `crates/opencrust-agents/src/skill_suggester.rs` | Merge `skill_candidates_from_summaries()` into `suggest_from_trajectories()` |
| `crates/opencrust-gateway/src/server.rs` | Replace one-shot spawns with daily interval loop |

## Checklist

- [x] `cargo check` — clean
- [x] `cargo test` — all tests pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)