### PR TITLE
docs(readme): update self-improvement comparison row across all languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Pre-compiled binaries for Linux (x86_64, aarch64), macOS (Intel, Apple Silicon),
 | **Self-update** | Yes (`opencrust update`) | npm | Build from source | Yes (`hermes update`) |
 | **Execution backends** | local | local | local | local, Docker, SSH, Modal, Daytona |
 | **Security scan** | ✅ skills prompt-injection | — | — | ✅ OSV + prompt-injection + supply chain |
-| **Self-improvement** | ✅ confidence gate + CHANGELOG | — | — | ✅ RL integration + user modeling |
+| **Self-improvement** | ✅ cross-session patterns, skill lifecycle, confidence gate | — | — | ✅ RL integration + user modeling |
 
 *Benchmarks measured on a 1 vCPU, 1 GB RAM DigitalOcean droplet.*
 

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -126,7 +126,7 @@ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) और Windows (x86_64) �
 | **Self-update** | हाँ (`opencrust update`) | npm | Source से Build | हाँ (`hermes update`) |
 | **Execution backends** | local | local | local | local, Docker, SSH, Modal, Daytona |
 | **Security scan** | ✅ skills prompt-injection | — | — | ✅ OSV + prompt-injection + supply chain |
-| **Self-improvement** | ✅ confidence gate + CHANGELOG | — | — | ✅ RL integration + user modeling |
+| **Self-improvement** | ✅ cross-session patterns, skill lifecycle, confidence gate | — | — | ✅ RL integration + user modeling |
 
 *DigitalOcean droplet 1 vCPU, 1 GB RAM पर मापा गया — [खुद टेस्ट करें](../bench/)*
 

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -126,7 +126,7 @@ binary สำหรับ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) 
 | **Self-update** | ใช่ (`opencrust update`) | npm | Build จาก source | ใช่ (`hermes update`) |
 | **Execution backends** | local | local | local | local, Docker, SSH, Modal, Daytona |
 | **Security scan** | ✅ skills prompt-injection | — | — | ✅ OSV + prompt-injection + supply chain |
-| **Self-improvement** | ✅ confidence gate + CHANGELOG | — | — | ✅ RL integration + user modeling |
+| **Self-improvement** | ✅ cross-session patterns, skill lifecycle, confidence gate | — | — | ✅ RL integration + user modeling |
 
 *วัดผลบน DigitalOcean droplet 1 vCPU, 1 GB RAM [ทดสอบเองได้](../bench/)*
 

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -126,7 +126,7 @@ opencrust chat --url http://host:3888  # 连接远程 gateway
 | **自动更新** | 是 (`opencrust update`) | npm | 源码编译 | 是 (`hermes update`) |
 | **执行后端** | 本地 | 本地 | 本地 | 本地、Docker、SSH、Modal、Daytona |
 | **安全扫描** | ✅ skills 提示注入扫描 | — | — | ✅ OSV + 提示注入 + 供应链 |
-| **自我改进** | ✅ confidence gate + CHANGELOG | — | — | ✅ RL 集成 + 用户建模 |
+| **自我改进** | ✅ 跨 session 模式识别、skill 生命周期管理、confidence gate | — | — | ✅ RL 集成 + 用户建模 |
 
 *性能基准测试在 1 vCPU, 1 GB RAM 的 DigitalOcean Droplet 上进行。*
 


### PR DESCRIPTION
## Summary

The self-improvement cell in the comparison table (`## Why OpenCrust?`) said `confidence gate + CHANGELOG` — which undersells what the system actually does after PRs #367–374.

**Updated OpenCrust cell from:**
> ✅ confidence gate + CHANGELOG

**To:**
> ✅ cross-session patterns, skill lifecycle, confidence gate

This reflects the three pillars of the current implementation:
- **Cross-session trajectory patterns** — same tool sequence repeated 5+ times across sessions triggers auto-save (not just a single turn)
- **Skill lifecycle** — automatic archiving after 30 days unused, daily LLM compression of trajectories older than 90 days
- **Confidence gate** — 2-round LLM review with 0.7 threshold before any skill patch is applied

Hermes, OpenClaw, and ZeroClaw cells are unchanged.

Updated in all four language files: English, Thai (`README.th.md`), Chinese (`README.zh.md`), Hindi (`README.hi.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)