### PR TITLE
docs(readme): replace comparison table with OpenCrust-only feature table

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,28 +105,25 @@ Pre-compiled binaries for Linux (x86_64, aarch64), macOS (Intel, Apple Silicon),
 
 ## Why OpenCrust?
 
-### vs OpenClaw, ZeroClaw, Hermes, and other AI agent frameworks
-
-| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) | **Hermes** (Python) |
-|---|---|---|---|---|
-| **Binary size** | 16 MB | ~1.2 GB (with node_modules) | ~25 MB | source only |
-| **Memory at idle** | 13 MB | ~388 MB | ~20 MB | — |
-| **Cold start** | 3 ms | 13.9 s | ~50 ms | — |
-| **Credential storage** | AES-256-GCM encrypted vault | Plaintext config file | Plaintext config file | `~/.hermes/.env` (chmod 600) |
-| **Auth default** | Enabled (WebSocket pairing) | Disabled by default | Disabled by default | Pairing codes (8-char, 1h expiry) |
-| **Scheduling** | Cron, interval, one-shot | Yes | No | Yes (cron + natural language) |
-| **Multi-agent routing** | Yes (named agents) | Yes (agentId) | No | Yes (`delegate_task`, depth 2) |
-| **Session orchestration** | Yes | Yes | No | Yes |
-| **MCP support** | Stdio + HTTP | Stdio + HTTP | Stdio | Stdio + HTTP + OAuth 2.1 |
-| **Channels** | 9 | 6+ | 4 | 16 |
-| **LLM providers** | 15 | 10+ | 22+ | 18+ |
-| **Pre-compiled binaries** | Yes | N/A (Node.js) | Build from source | No (source install) |
-| **Config hot-reload** | Yes | No | No | No |
-| **Plugin system** | WASM (sandboxed) | No | No | Python plugins |
-| **Self-update** | Yes (`opencrust update`) | npm | Build from source | Yes (`hermes update`) |
-| **Execution backends** | local | local | local | local, Docker, SSH, Modal, Daytona |
-| **Security scan** | ✅ skills prompt-injection | — | — | ✅ OSV + prompt-injection + supply chain |
-| **Self-improvement** | ✅ cross-session patterns, skill lifecycle, confidence gate | — | — | ✅ RL integration + user modeling |
+| | |
+|---|---|
+| **Binary size** | 16 MB single binary |
+| **Memory at idle** | 13 MB |
+| **Cold start** | 3 ms |
+| **Credential storage** | AES-256-GCM encrypted vault |
+| **Auth default** | Enabled (WebSocket pairing) |
+| **Scheduling** | Cron, interval, one-shot |
+| **Multi-agent routing** | Yes (named agents) |
+| **Session orchestration** | Yes |
+| **MCP support** | Stdio + HTTP |
+| **Channels** | 9 |
+| **LLM providers** | 15 |
+| **Pre-compiled binaries** | Yes |
+| **Config hot-reload** | Yes |
+| **Plugin system** | WASM (sandboxed) |
+| **Self-update** | Yes (`opencrust update`) |
+| **Security scan** | ✅ skills prompt-injection scan before install |
+| **Self-improvement** | ✅ cross-session patterns, skill lifecycle, confidence gate |
 
 *Benchmarks measured on a 1 vCPU, 1 GB RAM DigitalOcean droplet.*
 

--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -105,28 +105,25 @@ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) और Windows (x86_64) �
 
 ## OpenCrust क्यों?
 
-### OpenClaw, ZeroClaw, Hermes और अन्य फ्रेमवर्क से तुलना
-
-| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) | **Hermes** (Python) |
-|---|---|---|---|---|
-| **Binary आकार** | 16 MB | ~1.2 GB (node_modules सहित) | ~25 MB | केवल source install |
-| **Idle RAM** | 13 MB | ~388 MB | ~20 MB | — |
-| **Cold start** | 3 ms | 13.9 s | ~50 ms | — |
-| **Credential स्टोरेज** | AES-256-GCM vault | plaintext config file | plaintext config file | `~/.hermes/.env` (chmod 600) |
-| **डिफ़ॉल्ट Auth** | चालू (WebSocket pairing) | बंद | बंद | Pairing code (8-char, 1h expiry) |
-| **Scheduling** | Cron, interval, one-shot | हाँ | नहीं | हाँ (cron + natural language) |
-| **Multi-agent routing** | हाँ (named agents) | हाँ (agentId) | नहीं | हाँ (`delegate_task`, depth 2) |
-| **Session orchestration** | हाँ | हाँ | नहीं | हाँ |
-| **MCP support** | Stdio + HTTP | Stdio + HTTP | Stdio | Stdio + HTTP + OAuth 2.1 |
-| **Channels** | 9 | 6+ | 4 | 16 |
-| **LLM providers** | 15 | 10+ | 22+ | 18+ |
-| **Pre-compiled binary** | हाँ | N/A (Node.js) | Source से Build | नहीं (source install) |
-| **Config hot-reload** | हाँ | नहीं | नहीं | नहीं |
-| **Plugin system** | WASM (sandboxed) | नहीं | नहीं | Python plugins |
-| **Self-update** | हाँ (`opencrust update`) | npm | Source से Build | हाँ (`hermes update`) |
-| **Execution backends** | local | local | local | local, Docker, SSH, Modal, Daytona |
-| **Security scan** | ✅ skills prompt-injection | — | — | ✅ OSV + prompt-injection + supply chain |
-| **Self-improvement** | ✅ cross-session patterns, skill lifecycle, confidence gate | — | — | ✅ RL integration + user modeling |
+| | |
+|---|---|
+| **Binary आकार** | 16 MB single binary |
+| **Idle RAM** | 13 MB |
+| **Cold start** | 3 ms |
+| **Credential स्टोरेज** | AES-256-GCM encrypted vault |
+| **डिफ़ॉल्ट Auth** | चालू (WebSocket pairing) |
+| **Scheduling** | Cron, interval, one-shot |
+| **Multi-agent routing** | हाँ (named agents) |
+| **Session orchestration** | हाँ |
+| **MCP support** | Stdio + HTTP |
+| **Channels** | 9 |
+| **LLM providers** | 15 |
+| **Pre-compiled binary** | हाँ |
+| **Config hot-reload** | हाँ |
+| **Plugin system** | WASM (sandboxed) |
+| **Self-update** | हाँ (`opencrust update`) |
+| **Security scan** | ✅ install से पहले हर skill में prompt-injection scan |
+| **Self-improvement** | ✅ cross-session patterns, skill lifecycle, confidence gate |
 
 *DigitalOcean droplet 1 vCPU, 1 GB RAM पर मापा गया — [खुद टेस्ट करें](../bench/)*
 

--- a/i18n/README.th.md
+++ b/i18n/README.th.md
@@ -105,28 +105,25 @@ binary สำหรับ Linux (x86_64, aarch64), macOS (Intel, Apple Silicon) 
 
 ## ทำไมต้อง OpenCrust?
 
-### เทียบกับ OpenClaw, ZeroClaw, Hermes และเฟรมเวิร์คอื่น
-
-| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) | **Hermes** (Python) |
-|---|---|---|---|---|
-| **ขนาด binary** | 16 MB | ~1.2 GB (รวม node_modules) | ~25 MB | source only |
-| **RAM ขณะ idle** | 13 MB | ~388 MB | ~20 MB | — |
-| **Cold start** | 3 ms | 13.9 s | ~50 ms | — |
-| **เก็บ credential** | vault เข้ารหัส AES-256-GCM | plaintext config file | plaintext config file | `~/.hermes/.env` (chmod 600) |
-| **Auth ค่าเริ่มต้น** | เปิดใช้ (WebSocket pairing) | ปิดใช้ | ปิดใช้ | pairing code (8 หลัก, หมดอายุ 1 ชม.) |
-| **Scheduling** | Cron, interval, one-shot | ใช่ | ไม่ | ใช่ (cron + ภาษาธรรมชาติ) |
-| **Multi-agent routing** | ใช่ (named agents) | ใช่ (agentId) | ไม่ | ใช่ (`delegate_task`, depth 2) |
-| **Session orchestration** | ใช่ | ใช่ | ไม่ | ใช่ |
-| **MCP support** | Stdio + HTTP | Stdio + HTTP | Stdio | Stdio + HTTP + OAuth 2.1 |
-| **ช่องทาง** | 9 | 6+ | 4 | 16 |
-| **LLM provider** | 15 | 10+ | 22+ | 18+ |
-| **Pre-compiled binary** | ใช่ | N/A (Node.js) | Build จาก source | ไม่ (ติดตั้งจาก source) |
-| **Config hot-reload** | ใช่ | ไม่ | ไม่ | ไม่ |
-| **Plugin system** | WASM (sandboxed) | ไม่ | ไม่ | Python plugins |
-| **Self-update** | ใช่ (`opencrust update`) | npm | Build จาก source | ใช่ (`hermes update`) |
-| **Execution backends** | local | local | local | local, Docker, SSH, Modal, Daytona |
-| **Security scan** | ✅ skills prompt-injection | — | — | ✅ OSV + prompt-injection + supply chain |
-| **Self-improvement** | ✅ cross-session patterns, skill lifecycle, confidence gate | — | — | ✅ RL integration + user modeling |
+| | |
+|---|---|
+| **ขนาด binary** | 16 MB single binary |
+| **RAM ขณะ idle** | 13 MB |
+| **Cold start** | 3 ms |
+| **เก็บ credential** | vault เข้ารหัส AES-256-GCM |
+| **Auth ค่าเริ่มต้น** | เปิดใช้ (WebSocket pairing) |
+| **Scheduling** | Cron, interval, one-shot |
+| **Multi-agent routing** | ใช่ (named agents) |
+| **Session orchestration** | ใช่ |
+| **MCP support** | Stdio + HTTP |
+| **ช่องทาง** | 9 |
+| **LLM provider** | 15 |
+| **Pre-compiled binary** | ใช่ |
+| **Config hot-reload** | ใช่ |
+| **Plugin system** | WASM (sandboxed) |
+| **Self-update** | ใช่ (`opencrust update`) |
+| **Security scan** | ✅ ตรวจ prompt-injection ทุก skill ก่อนติดตั้ง |
+| **Self-improvement** | ✅ cross-session patterns, skill lifecycle, confidence gate |
 
 *วัดผลบน DigitalOcean droplet 1 vCPU, 1 GB RAM [ทดสอบเองได้](../bench/)*
 

--- a/i18n/README.zh.md
+++ b/i18n/README.zh.md
@@ -105,28 +105,25 @@ opencrust chat --url http://host:3888  # 连接远程 gateway
 
 ## 为什么选择 OpenCrust?
 
-### 与 OpenClaw、ZeroClaw、Hermes 等 AI 代理框架对比
-
-| | **OpenCrust** | **OpenClaw** (Node.js) | **ZeroClaw** (Rust) | **Hermes** (Python) |
-|---|---|---|---|---|
-| **二进制文件大小** | 16 MB | ~1.2 GB (包含 node_modules) | ~25 MB | 仅源码安装 |
-| **空闲状态内存** | 13 MB | ~388 MB | ~20 MB | — |
-| **冷启动速度** | 3 ms | 13.9 s | ~50 ms | — |
-| **凭据存储方式** | AES-256-GCM 加密库 | 明文配置文件 | 明文配置文件 | `~/.hermes/.env` (chmod 600) |
-| **默认身份验证** | 已启用 (WebSocket 配对) | 默认禁用 | 默认禁用 | 配对码 (8位, 1小时有效) |
-| **任务调度** | Cron, 间隔, 单次执行 | 是 | 否 | 是 (cron + 自然语言) |
-| **多代理路由** | 是 (命名代理) | 是 (agentId) | 否 | 是 (`delegate_task`, 深度 2) |
-| **会话编排** | 是 | 是 | 否 | 是 |
-| **MCP 支持** | Stdio + HTTP | Stdio + HTTP | Stdio | Stdio + HTTP + OAuth 2.1 |
-| **渠道数量** | 9 | 6+ | 4 | 16 |
-| **LLM 供应商数量** | 15 | 10+ | 22+ | 18+ |
-| **预编译二进制文件** | 是 | 无 (Node.js) | 源码编译 | 否 (源码安装) |
-| **配置热重载** | 是 | 否 | 否 | 否 |
-| **插件系统** | WASM (沙盒隔离) | 否 | 否 | Python 插件 |
-| **自动更新** | 是 (`opencrust update`) | npm | 源码编译 | 是 (`hermes update`) |
-| **执行后端** | 本地 | 本地 | 本地 | 本地、Docker、SSH、Modal、Daytona |
-| **安全扫描** | ✅ skills 提示注入扫描 | — | — | ✅ OSV + 提示注入 + 供应链 |
-| **自我改进** | ✅ 跨 session 模式识别、skill 生命周期管理、confidence gate | — | — | ✅ RL 集成 + 用户建模 |
+| | |
+|---|---|
+| **二进制文件大小** | 16 MB 单文件 |
+| **空闲状态内存** | 13 MB |
+| **冷启动速度** | 3 ms |
+| **凭据存储方式** | AES-256-GCM 加密库 |
+| **默认身份验证** | 已启用 (WebSocket 配对) |
+| **任务调度** | Cron、间隔、单次执行 |
+| **多代理路由** | 是（命名代理） |
+| **会话编排** | 是 |
+| **MCP 支持** | Stdio + HTTP |
+| **渠道数量** | 9 |
+| **LLM 供应商数量** | 15 |
+| **预编译二进制文件** | 是 |
+| **配置热重载** | 是 |
+| **插件系统** | WASM（沙盒隔离） |
+| **自动更新** | 是（`opencrust update`） |
+| **安全扫描** | ✅ 安装前对每个 skill 进行提示注入扫描 |
+| **自我改进** | ✅ 跨 session 模式识别、skill 生命周期管理、confidence gate |
 
 *性能基准测试在 1 vCPU, 1 GB RAM 的 DigitalOcean Droplet 上进行。*
 


### PR DESCRIPTION
## Summary

The `## Why OpenCrust?` section previously compared OpenCrust against OpenClaw, ZeroClaw, and Hermes in a 4-column table. Replace it with a clean 2-column feature list showing only OpenCrust's own capabilities.

**Reason:** Competitor comparisons go stale quickly and can create friction with other projects. A feature-focused table is easier to maintain and focuses the reader on what OpenCrust offers.

Updated in all four language files: English, Thai (`README.th.md`), Chinese (`README.zh.md`), Hindi (`README.hi.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)