### PR TITLE
feat(cli,db): add re-embed command for model changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,6 +2606,7 @@ name = "opencrust"
 version = "0.2.9"
 dependencies = [
  "anyhow",
+ "async-trait",
  "cargo-husky",
  "clap",
  "colored",
@@ -2627,6 +2628,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "ring",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2636,6 +2638,7 @@ dependencies = [
  "tracing-subscriber",
  "walkdir",
  "windows-sys 0.52.0",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/opencrust-cli/Cargo.toml
+++ b/crates/opencrust-cli/Cargo.toml
@@ -39,8 +39,11 @@ colored = "3"
 walkdir = "2"
 
 [dev-dependencies]
+async-trait = { workspace = true }
 cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt"] }
+rusqlite = { workspace = true }
 tempfile = "3"
+wiremock = "0.6"
 
 [features]
 default = []

--- a/crates/opencrust-cli/src/main.rs
+++ b/crates/opencrust-cli/src/main.rs
@@ -237,6 +237,12 @@ enum DocCommands {
         /// Document name to remove
         name: String,
     },
+    /// Re-embed stored document chunks with the current embedding provider
+    ReEmbed {
+        /// Re-embed only one document by exact stored name
+        #[arg(long)]
+        name: Option<String>,
+    },
 }
 
 /// Build an embedding provider from config for document ingestion.
@@ -281,6 +287,19 @@ pub struct IngestSummary {
     pub skipped: usize,
     pub failed: usize,
 }
+
+#[derive(Debug, Default, PartialEq)]
+pub struct ReembedSummary {
+    pub succeeded: Vec<String>,
+    pub failed: Vec<String>,
+}
+
+struct PendingChunkEmbedding {
+    chunk_id: String,
+    embedding: Vec<f32>,
+}
+
+const REEMBED_BATCH_SIZE: usize = 32;
 
 /// Walk `dir` recursively and ingest every `.md / .txt / .pdf / .html / .htm`
 /// file into `store`.  Returns a summary of what happened.
@@ -429,6 +448,127 @@ pub async fn run_ingest(
 
         println!(" done");
         summary.ingested += 1;
+    }
+
+    Ok(summary)
+}
+
+async fn reembed_document(
+    store: &opencrust_db::DocumentStore,
+    doc: &opencrust_db::DocumentInfo,
+    embedding_provider: &dyn opencrust_agents::EmbeddingProvider,
+) -> anyhow::Result<()> {
+    use std::io::Write as _;
+
+    let chunks = store
+        .get_chunks_by_document_id(&doc.id)
+        .with_context(|| format!("failed to load chunks for '{}'", doc.name))?;
+
+    if chunks.is_empty() {
+        return Ok(());
+    }
+
+    let model = embedding_provider.model().to_string();
+    let mut pending = Vec::with_capacity(chunks.len());
+    let mut processed = 0usize;
+
+    for batch in chunks.chunks(REEMBED_BATCH_SIZE) {
+        let texts = batch
+            .iter()
+            .map(|chunk| chunk.text.clone())
+            .collect::<Vec<_>>();
+        let embeddings = embedding_provider
+            .embed_documents(&texts)
+            .await
+            .with_context(|| format!("embedding batch failed for '{}'", doc.name))?;
+
+        if embeddings.len() != batch.len() {
+            anyhow::bail!(
+                "embedding provider returned {} embeddings for {} chunk(s) in '{}'",
+                embeddings.len(),
+                batch.len(),
+                doc.name
+            );
+        }
+
+        for (chunk, embedding) in batch.iter().zip(embeddings) {
+            pending.push(PendingChunkEmbedding {
+                chunk_id: chunk.id.clone(),
+                embedding,
+            });
+        }
+
+        processed += batch.len();
+        print!("\r    progress {processed}/{} chunks", chunks.len());
+        std::io::stdout().flush()?;
+    }
+
+    println!();
+
+    let updates = pending
+        .iter()
+        .map(|entry| opencrust_db::ChunkEmbeddingUpdate {
+            chunk_id: &entry.chunk_id,
+            embedding: &entry.embedding,
+            model: &model,
+            dims: entry.embedding.len(),
+        })
+        .collect::<Vec<_>>();
+
+    store
+        .update_chunk_embeddings_batch(&updates)
+        .with_context(|| format!("failed to update stored embeddings for '{}'", doc.name))?;
+
+    Ok(())
+}
+
+pub async fn run_reembed_with_provider(
+    store: &opencrust_db::DocumentStore,
+    name: Option<&str>,
+    embedding_provider: Option<&dyn opencrust_agents::EmbeddingProvider>,
+) -> anyhow::Result<ReembedSummary> {
+    let embedding_provider = embedding_provider.context(
+        "No embedding provider configured. Re-embed requires an embeddings section in config.yml.",
+    )?;
+
+    let docs = match name {
+        Some(name) => {
+            let doc = store
+                .get_document_by_name(name)?
+                .with_context(|| format!("Document '{name}' not found."))?;
+            vec![doc]
+        }
+        None => store.list_documents()?,
+    };
+
+    if docs.is_empty() {
+        println!("No documents ingested. Use `opencrust doc add <file>` to ingest.");
+        return Ok(ReembedSummary::default());
+    }
+
+    println!("Re-embedding {} document(s)...", docs.len());
+
+    let mut summary = ReembedSummary::default();
+
+    for (index, doc) in docs.iter().enumerate() {
+        println!(
+            "  re-embed {}/{} {} ({} chunks)",
+            index + 1,
+            docs.len(),
+            doc.name,
+            doc.chunk_count
+        );
+
+        match reembed_document(store, doc, embedding_provider).await {
+            Ok(()) => {
+                println!("    done");
+                summary.succeeded.push(doc.name.clone());
+            }
+            Err(err) => {
+                println!("    fail ({err})");
+                summary.failed.push(doc.name.clone());
+            }
+        }
     }
 
     Ok(summary)
@@ -1307,6 +1447,36 @@ async fn async_main(
                         println!("Document '{name}' not found.");
                     }
                 }
+                DocCommands::ReEmbed { name } => {
+                    let embedding_provider = build_embedding_provider(&config);
+                    let summary = run_reembed_with_provider(
+                        &doc_store,
+                        name.as_deref(),
+                        embedding_provider.as_deref(),
+                    )
+                    .await?;
+
+                    println!();
+                    println!(
+                        "Re-embed complete: {} passed, {} failed.",
+                        summary.succeeded.len(),
+                        summary.failed.len()
+                    );
+
+                    if !summary.succeeded.is_empty() {
+                        println!("  Passed:");
+                        for name in &summary.succeeded {
+                            println!("    - {name}");
+                        }
+                    }
+
+                    if !summary.failed.is_empty() {
+                        println!("  Failed:");
+                        for name in &summary.failed {
+                            println!("    - {name}");
+                        }
+                    }
+                }
             }
         }
         Commands::Doctor => {
@@ -1599,6 +1769,62 @@ fn run_uninstall(yes: bool, keep_data: bool, config: &opencrust_config::AppConfi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use rusqlite::Connection;
+    use std::collections::HashMap;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    struct MockEmbeddingProvider {
+        model: &'static str,
+        fail_on_substring: Option<&'static str>,
+        dims: usize,
+    }
+
+    #[async_trait]
+    impl opencrust_agents::EmbeddingProvider for MockEmbeddingProvider {
+        fn provider_id(&self) -> &str {
+            "mock"
+        }
+
+        fn model(&self) -> &str {
+            self.model
+        }
+
+        async fn embed_documents(
+            &self,
+            texts: &[String],
+        ) -> opencrust_common::Result<Vec<Vec<f32>>> {
+            if let Some(needle) = self.fail_on_substring
+                && texts.iter().any(|text| text.contains(needle))
+            {
+                return Err(opencrust_common::Error::Agent(format!(
+                    "mock embedding failure for {needle}"
+                )));
+            }
+
+            Ok(texts
+                .iter()
+                .map(|text| {
+                    let mut embedding = vec![0.0; self.dims];
+                    if let Some(first) = embedding.first_mut() {
+                        *first = text.len() as f32;
+                    }
+                    embedding
+                })
+                .collect())
+        }
+
+        async fn embed_query(&self, text: &str) -> opencrust_common::Result<Vec<f32>> {
+            self.embed_documents(&[text.to_string()])
+                .await
+                .map(|mut embeddings| embeddings.remove(0))
+        }
+
+        async fn health_check(&self) -> opencrust_common::Result<bool> {
+            Ok(true)
+        }
+    }
 
     #[test]
     fn test_validate_plugin_path() {
@@ -1626,6 +1852,82 @@ mod tests {
     /// Helper: write a file with text content into a temp directory.
     fn write_file(dir: &std::path::Path, name: &str, content: &str) {
         std::fs::write(dir.join(name), content).unwrap();
+    }
+
+    fn add_document_with_chunks(
+        store: &opencrust_db::DocumentStore,
+        name: &str,
+        chunks: &[&str],
+        model: &str,
+    ) {
+        let doc_id = store.add_document(name, None, "text/plain").unwrap();
+        let new_chunks = chunks
+            .iter()
+            .enumerate()
+            .map(|(index, text)| opencrust_db::NewDocumentChunk {
+                chunk_index: index,
+                text,
+                embedding: Some(&[1.0, 0.0, 0.0]),
+                model: Some(model),
+                dims: Some(3),
+                token_count: Some(text.split_whitespace().count()),
+            })
+            .collect::<Vec<_>>();
+        store.add_chunks_batch(&doc_id, &new_chunks).unwrap();
+    }
+
+    fn document_models(db_path: &std::path::Path, name: &str) -> Vec<Option<String>> {
+        let conn = Connection::open(db_path).unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT c.embedding_model
+                 FROM document_chunks c
+                 JOIN documents d ON d.id = c.document_id
+                 WHERE d.name = ?
+                 ORDER BY c.chunk_index ASC",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map([name], |row| row.get::<_, Option<String>>(0))
+            .unwrap();
+        rows.collect::<std::result::Result<Vec<_>, _>>().unwrap()
+    }
+
+    fn document_metadata(
+        db_path: &std::path::Path,
+        name: &str,
+    ) -> Vec<(Option<String>, Option<i64>)> {
+        let conn = Connection::open(db_path).unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT c.embedding_model, c.embedding_dimensions
+                 FROM document_chunks c
+                 JOIN documents d ON d.id = c.document_id
+                 WHERE d.name = ?
+                 ORDER BY c.chunk_index ASC",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map([name], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap();
+        rows.collect::<std::result::Result<Vec<_>, _>>().unwrap()
+    }
+
+    fn ollama_config(base_url: &str, model: &str) -> opencrust_config::AppConfig {
+        let mut config = opencrust_config::AppConfig::default();
+        config.memory.embedding_provider = Some("local".to_string());
+        config.embeddings.insert(
+            "local".to_string(),
+            opencrust_config::EmbeddingProviderConfig {
+                provider: "ollama".to_string(),
+                model: Some(model.to_string()),
+                api_key: None,
+                base_url: Some(base_url.to_string()),
+                dimensions: None,
+                extra: HashMap::new(),
+            },
+        );
+        config
     }
 
     /// Test plan item 1: ingests all supported files and counts them.
@@ -1748,6 +2050,141 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("is not a directory")
+        );
+    }
+
+    #[tokio::test]
+    async fn reembed_all_documents_continues_after_failure() {
+        let (db_file, store) = tmp_store();
+        add_document_with_chunks(&store, "ok.txt", &["hello world"], "old-model");
+        add_document_with_chunks(
+            &store,
+            "fail.txt",
+            &["first chunk", "chunk that will FAIL"],
+            "old-model",
+        );
+
+        let provider = MockEmbeddingProvider {
+            model: "mock-model",
+            fail_on_substring: Some("FAIL"),
+            dims: 4,
+        };
+
+        let summary = run_reembed_with_provider(&store, None, Some(&provider))
+            .await
+            .unwrap();
+
+        assert_eq!(summary.succeeded, vec!["ok.txt".to_string()]);
+        assert_eq!(summary.failed, vec!["fail.txt".to_string()]);
+        assert_eq!(
+            document_models(db_file.path(), "ok.txt"),
+            vec![Some("mock-model".to_string())]
+        );
+        assert_eq!(
+            document_models(db_file.path(), "fail.txt"),
+            vec![Some("old-model".to_string()), Some("old-model".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn reembed_named_document_only_updates_selected_document() {
+        let (db_file, store) = tmp_store();
+        add_document_with_chunks(&store, "target.txt", &["hello world"], "old-model");
+        add_document_with_chunks(&store, "other.txt", &["leave me alone"], "old-model");
+
+        let provider = MockEmbeddingProvider {
+            model: "mock-model",
+            fail_on_substring: None,
+            dims: 4,
+        };
+
+        let summary = run_reembed_with_provider(&store, Some("target.txt"), Some(&provider))
+            .await
+            .unwrap();
+
+        assert_eq!(summary.succeeded, vec!["target.txt".to_string()]);
+        assert!(summary.failed.is_empty());
+        assert_eq!(
+            document_models(db_file.path(), "target.txt"),
+            vec![Some("mock-model".to_string())]
+        );
+        assert_eq!(
+            document_models(db_file.path(), "other.txt"),
+            vec![Some("old-model".to_string())]
+        );
+    }
+
+    #[tokio::test]
+    async fn reembed_smoke_test_with_ollama_http_provider() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let (db_file, store) = tmp_store();
+
+        write_file(tmp_dir.path(), "pass.txt", "PASS_REEMBED stays healthy");
+        write_file(tmp_dir.path(), "fail.txt", "FAIL_REEMBED should roll back");
+
+        let ingest_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "embeddings": [[1.0, 2.0, 3.0]] })),
+            )
+            .mount(&ingest_server)
+            .await;
+
+        let ingest_config = ollama_config(&ingest_server.uri(), "initial-model");
+        let ingest_provider = build_embedding_provider(&ingest_config);
+        let ingest_summary = run_ingest(&store, tmp_dir.path(), false, ingest_provider.as_deref())
+            .await
+            .unwrap();
+        assert_eq!(ingest_summary.ingested, 2);
+        assert_eq!(ingest_summary.skipped, 0);
+        assert_eq!(ingest_summary.failed, 0);
+
+        assert_eq!(
+            document_metadata(db_file.path(), "pass.txt"),
+            vec![(Some("initial-model".to_string()), Some(3))]
+        );
+        assert_eq!(
+            document_metadata(db_file.path(), "fail.txt"),
+            vec![(Some("initial-model".to_string()), Some(3))]
+        );
+
+        let reembed_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .and(body_string_contains("PASS_REEMBED"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "embeddings": [[9.0, 8.0, 7.0, 6.0]] })),
+            )
+            .mount(&reembed_server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/embed"))
+            .and(body_string_contains("FAIL_REEMBED"))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_json(serde_json::json!({ "error": "forced re-embed failure" })),
+            )
+            .mount(&reembed_server)
+            .await;
+
+        let reembed_config = ollama_config(&reembed_server.uri(), "reembed-model");
+        let reembed_provider = build_embedding_provider(&reembed_config);
+        let reembed_summary = run_reembed_with_provider(&store, None, reembed_provider.as_deref())
+            .await
+            .unwrap();
+
+        assert_eq!(reembed_summary.succeeded, vec!["pass.txt".to_string()]);
+        assert_eq!(reembed_summary.failed, vec!["fail.txt".to_string()]);
+        assert_eq!(
+            document_metadata(db_file.path(), "pass.txt"),
+            vec![(Some("reembed-model".to_string()), Some(4))]
+        );
+        assert_eq!(
+            document_metadata(db_file.path(), "fail.txt"),
+            vec![(Some("initial-model".to_string()), Some(3))]
         );
     }
 }

--- a/crates/opencrust-db/src/document_store.rs
+++ b/crates/opencrust-db/src/document_store.rs
@@ -1,5 +1,5 @@
 use opencrust_common::{Error, Result};
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OptionalExtension, params};
 use std::cmp::Ordering;
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
@@ -43,6 +43,15 @@ pub struct NewDocumentChunk<'a> {
     pub model: Option<&'a str>,
     pub dims: Option<usize>,
     pub token_count: Option<usize>,
+}
+
+/// Replacement embedding data for an existing stored chunk.
+#[derive(Debug, Clone, Copy)]
+pub struct ChunkEmbeddingUpdate<'a> {
+    pub chunk_id: &'a str,
+    pub embedding: &'a [f32],
+    pub model: &'a str,
+    pub dims: usize,
 }
 
 /// Store for RAG document ingestion and vector-based retrieval.
@@ -135,13 +144,7 @@ impl DocumentStore {
     fn ensure_doc_vec_table_on_conn(conn: &Connection, dims: usize) -> Result<()> {
         let table = format!("vec_doc_chunks_{dims}");
 
-        let exists: bool = conn
-            .query_row(
-                "SELECT count(*) > 0 FROM sqlite_master WHERE type='table' AND name=?",
-                params![table],
-                |row| row.get(0),
-            )
-            .map_err(|e| Error::Database(format!("failed to check vec table: {e}")))?;
+        let exists = Self::vec_table_exists_on_conn(conn, &table)?;
 
         if !exists {
             // Use cosine distance so similarity = 1 - distance for unit vectors.
@@ -154,6 +157,15 @@ impl DocumentStore {
             info!("created vec0 table: {table} ({dims} dims)");
         }
         Ok(())
+    }
+
+    fn vec_table_exists_on_conn(conn: &Connection, table: &str) -> Result<bool> {
+        conn.query_row(
+            "SELECT count(*) > 0 FROM sqlite_master WHERE type='table' AND name=?",
+            params![table],
+            |row| row.get(0),
+        )
+        .map_err(|e| Error::Database(format!("failed to check vec table: {e}")))
     }
 
     /// Insert a chunk embedding into the sqlite-vec index.
@@ -192,6 +204,32 @@ impl DocumentStore {
             params![rowid, blob],
         )
         .map_err(|e| Error::Database(format!("failed to insert into {table}: {e}")))?;
+
+        Ok(())
+    }
+
+    fn delete_chunk_from_vec_on_conn(conn: &Connection, chunk_id: &str, dims: usize) -> Result<()> {
+        let table = format!("vec_doc_chunks_{dims}");
+        if !Self::vec_table_exists_on_conn(conn, &table)? {
+            return Ok(());
+        }
+
+        let rowid: Option<i64> = conn
+            .query_row(
+                "SELECT rowid FROM vec_doc_id_map WHERE chunk_id = ?",
+                params![chunk_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|e| Error::Database(format!("failed to get vec rowid: {e}")))?;
+
+        if let Some(rowid) = rowid {
+            conn.execute(
+                &format!("DELETE FROM [{table}] WHERE rowid = ?"),
+                params![rowid],
+            )
+            .map_err(|e| Error::Database(format!("failed to delete from {table}: {e}")))?;
+        }
 
         Ok(())
     }
@@ -344,6 +382,88 @@ impl DocumentStore {
 
         debug!("added {} chunks for document {}", chunks.len(), doc_id);
         Ok(ids)
+    }
+
+    /// Replace stored embeddings for one or more existing chunks in a single transaction.
+    pub fn update_chunk_embeddings_batch(
+        &self,
+        updates: &[ChunkEmbeddingUpdate<'_>],
+    ) -> Result<()> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+
+        let mut conn = self.connection()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| Error::Database(format!("failed to start chunk update batch: {e}")))?;
+
+        let mut stmt = tx
+            .prepare(
+                "UPDATE document_chunks
+                 SET embedding = ?, embedding_model = ?, embedding_dimensions = ?
+                 WHERE id = ?",
+            )
+            .map_err(|e| Error::Database(format!("failed to prepare chunk update batch: {e}")))?;
+
+        for update in updates {
+            let old_dims: Option<Option<i64>> = tx
+                .query_row(
+                    "SELECT embedding_dimensions FROM document_chunks WHERE id = ?",
+                    params![update.chunk_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| {
+                    Error::Database(format!("failed to fetch existing chunk dims: {e}"))
+                })?;
+
+            let old_dims = match old_dims {
+                Some(value) => value.map(|dims| dims as usize),
+                None => {
+                    return Err(Error::Database(format!(
+                        "failed to update chunk embedding: chunk '{}' not found",
+                        update.chunk_id
+                    )));
+                }
+            };
+
+            if self.vec_enabled
+                && let Some(old_dims) = old_dims
+            {
+                Self::delete_chunk_from_vec_on_conn(&tx, update.chunk_id, old_dims)?;
+            }
+
+            let changed = stmt
+                .execute(params![
+                    embedding_to_blob(update.embedding),
+                    update.model,
+                    update.dims as i64,
+                    update.chunk_id,
+                ])
+                .map_err(|e| Error::Database(format!("failed to update document chunk: {e}")))?;
+
+            if changed == 0 {
+                return Err(Error::Database(format!(
+                    "failed to update chunk embedding: chunk '{}' not found",
+                    update.chunk_id
+                )));
+            }
+
+            if self.vec_enabled {
+                Self::insert_chunk_into_vec_on_conn(
+                    &tx,
+                    update.chunk_id,
+                    update.embedding,
+                    update.dims,
+                )?;
+            }
+        }
+
+        drop(stmt);
+        tx.commit()
+            .map_err(|e| Error::Database(format!("failed to commit chunk update batch: {e}")))?;
+        Ok(())
     }
 
     /// Vector similarity search across document chunks.
@@ -1377,5 +1497,204 @@ mod tests {
             .search_documents_by_name("nonexistent")
             .expect("search");
         assert!(none.is_empty());
+    }
+
+    #[test]
+    fn update_chunk_embedding_replaces_model_and_dimensions_without_changing_chunk_id() {
+        let store = DocumentStore::in_memory().expect("store");
+        let doc_id = store
+            .add_document("update-me.txt", None, "text/plain")
+            .expect("add_document");
+
+        store
+            .add_chunks_batch(
+                &doc_id,
+                &[NewDocumentChunk {
+                    chunk_index: 0,
+                    text: "chunk text",
+                    embedding: Some(&[1.0, 0.0, 0.0]),
+                    model: Some("old-model"),
+                    dims: Some(3),
+                    token_count: None,
+                }],
+            )
+            .expect("add_chunks_batch");
+
+        let chunk_id = store
+            .get_chunks_by_document_id(&doc_id)
+            .expect("chunks")
+            .into_iter()
+            .next()
+            .expect("chunk should exist")
+            .id;
+
+        store
+            .update_chunk_embeddings_batch(&[ChunkEmbeddingUpdate {
+                chunk_id: &chunk_id,
+                embedding: &[0.0, 1.0, 0.0],
+                model: "new-model",
+                dims: 3,
+            }])
+            .expect("update chunk embedding");
+
+        let conn = store.connection().expect("lock");
+        let (model, dims, blob): (Option<String>, Option<i64>, Vec<u8>) = conn
+            .query_row(
+                "SELECT embedding_model, embedding_dimensions, embedding
+                 FROM document_chunks
+                 WHERE id = ?",
+                params![chunk_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("updated row");
+
+        assert_eq!(model.as_deref(), Some("new-model"));
+        assert_eq!(dims, Some(3));
+        assert_eq!(
+            blob_to_embedding(&blob).expect("embedding blob"),
+            vec![0.0, 1.0, 0.0]
+        );
+    }
+
+    #[test]
+    fn update_chunk_embedding_dimension_change_moves_vec_index() {
+        let store = DocumentStore::in_memory().expect("store");
+        let doc_id = store
+            .add_document("resize-me.txt", None, "text/plain")
+            .expect("add_document");
+
+        store
+            .add_chunks_batch(
+                &doc_id,
+                &[NewDocumentChunk {
+                    chunk_index: 0,
+                    text: "chunk text",
+                    embedding: Some(&[1.0, 0.0, 0.0]),
+                    model: Some("old-model"),
+                    dims: Some(3),
+                    token_count: None,
+                }],
+            )
+            .expect("add_chunks_batch");
+
+        let chunk_id = store
+            .get_chunks_by_document_id(&doc_id)
+            .expect("chunks")
+            .into_iter()
+            .next()
+            .expect("chunk should exist")
+            .id;
+
+        store
+            .update_chunk_embeddings_batch(&[ChunkEmbeddingUpdate {
+                chunk_id: &chunk_id,
+                embedding: &[0.0, 1.0],
+                model: "new-model",
+                dims: 2,
+            }])
+            .expect("update chunk embedding");
+
+        let conn = store.connection().expect("lock");
+        let dims: Option<i64> = conn
+            .query_row(
+                "SELECT embedding_dimensions FROM document_chunks WHERE id = ?",
+                params![chunk_id],
+                |row| row.get(0),
+            )
+            .expect("chunk dims");
+        assert_eq!(dims, Some(2));
+
+        if store.vec_enabled() {
+            let rowid: i64 = conn
+                .query_row(
+                    "SELECT rowid FROM vec_doc_id_map WHERE chunk_id = ?",
+                    params![chunk_id],
+                    |row| row.get(0),
+                )
+                .expect("vec rowid");
+
+            let old_count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM [vec_doc_chunks_3] WHERE rowid = ?",
+                    params![rowid],
+                    |row| row.get(0),
+                )
+                .expect("old vec row count");
+            let new_count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM [vec_doc_chunks_2] WHERE rowid = ?",
+                    params![rowid],
+                    |row| row.get(0),
+                )
+                .expect("new vec row count");
+
+            assert_eq!(old_count, 0);
+            assert_eq!(new_count, 1);
+        }
+    }
+
+    #[test]
+    fn update_chunk_embeddings_batch_rolls_back_on_error() {
+        let store = DocumentStore::in_memory().expect("store");
+        let doc_id = store
+            .add_document("rollback-me.txt", None, "text/plain")
+            .expect("add_document");
+
+        store
+            .add_chunks_batch(
+                &doc_id,
+                &[NewDocumentChunk {
+                    chunk_index: 0,
+                    text: "chunk text",
+                    embedding: Some(&[1.0, 0.0, 0.0]),
+                    model: Some("old-model"),
+                    dims: Some(3),
+                    token_count: None,
+                }],
+            )
+            .expect("add_chunks_batch");
+
+        let chunk_id = store
+            .get_chunks_by_document_id(&doc_id)
+            .expect("chunks")
+            .into_iter()
+            .next()
+            .expect("chunk should exist")
+            .id;
+
+        let updates = [
+            ChunkEmbeddingUpdate {
+                chunk_id: &chunk_id,
+                embedding: &[0.0, 1.0, 0.0],
+                model: "new-model",
+                dims: 3,
+            },
+            ChunkEmbeddingUpdate {
+                chunk_id: "missing-chunk",
+                embedding: &[1.0, 1.0, 1.0],
+                model: "new-model",
+                dims: 3,
+            },
+        ];
+
+        let err = store
+            .update_chunk_embeddings_batch(&updates)
+            .expect_err("batch should fail on missing chunk");
+        assert!(err.to_string().contains("missing-chunk"));
+
+        let conn = store.connection().expect("lock");
+        let (model, blob): (Option<String>, Vec<u8>) = conn
+            .query_row(
+                "SELECT embedding_model, embedding FROM document_chunks WHERE id = ?",
+                params![chunk_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("row after rollback");
+
+        assert_eq!(model.as_deref(), Some("old-model"));
+        assert_eq!(
+            blob_to_embedding(&blob).expect("embedding blob"),
+            vec![1.0, 0.0, 0.0]
+        );
     }
 }

--- a/crates/opencrust-db/src/lib.rs
+++ b/crates/opencrust-db/src/lib.rs
@@ -5,7 +5,9 @@ pub mod session_store;
 pub mod trajectory_store;
 pub mod vector_store;
 
-pub use document_store::{DocumentChunk, DocumentInfo, DocumentStore, NewDocumentChunk};
+pub use document_store::{
+    ChunkEmbeddingUpdate, DocumentChunk, DocumentInfo, DocumentStore, NewDocumentChunk,
+};
 pub use memory_store::{
     CompactionReport, MemoryEntry, MemoryProvider, MemoryRole, MemoryStore, NewMemoryEntry,
     RecallQuery, SessionContext,


### PR DESCRIPTION
## Summary

Adds `opencrust doc re-embed` so stored document chunks can be refreshed with the current embedding provider. The command can target all documents or a single exact-match document via `--name`, updates existing chunk rows in place, and reports passed/failed documents at the end.

## Changes

- [x] Add `DocCommands::ReEmbed` and a shared re-embed flow in the CLI, reusing the existing provider config wiring.
- [x] Add in-place chunk embedding update APIs in `DocumentStore` so existing rows are refreshed and sqlite-vec stays in sync when dimensions change.
- [x] Add coverage for successful re-embed, partial failures, and exact-name targeting.

## Test Plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Manual testing: tested against a mock provider

## Related Issues

Closes #223

## Note 
`re-embed` does not currently mirror the ingest chunk-by-chunk behavior. If a batch fails for a document, that document stops and rolls back instead of continuing chunk-by-chunk. If this is not the desired behavior the implementation can be changed to conform.